### PR TITLE
[wip] 429 handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -48,6 +48,11 @@ func coupleAPIErrors(r *resty.Response, err error) (*resty.Response, error) {
 		return nil, NewError(err)
 	}
 
+	// Special case for undocumented rate limit response
+	if r.StatusCode() == 429 && r.Size() == 0 {
+		return nil, NewError(r)
+	}
+
 	if r.Error() != nil {
 		apiError, ok := r.Error().(*APIError)
 		if !ok || (ok && len(apiError.Errors) == 0) {


### PR DESCRIPTION
This is a work in progress branch to sort out 429 handling.

Some responses do not return the full 429 response, so special attention must be made to those more severe 429 responses.

Values like this may be returned on normal requests,
```
Retry-After: 106
X-Ratelimit-Limit: 400
X-Ratelimit-Remaining: 388
X-Ratelimit-Reset: 1531247494
```

And values like this, may be return on a 429 response:
```
TODO
```

And values like this, may be return on a 429 response that does not include all headers:
```
TODO
```