### PR TITLE
Change ListOptions `Filter` field to map[string]interface{}

### DIFF
--- a/domain_records_test.go
+++ b/domain_records_test.go
@@ -2,7 +2,6 @@ package linodego_test
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/linode/linodego"
@@ -68,14 +67,11 @@ func TestListDomainRecords(t *testing.T) {
 		t.Error(err)
 	}
 
-	filter, err := json.Marshal(map[string]interface{}{
+	filter := map[string]interface{}{
 		"name": record.Name,
-	})
-	if err != nil {
-		t.Error(err)
 	}
 
-	listOpts := linodego.NewListOptions(0, string(filter))
+	listOpts := linodego.NewListOptions(0, filter)
 	records, err := client.ListDomainRecords(context.Background(), domain.ID, listOpts)
 	if err != nil {
 		t.Errorf("Error listing domains records, expected array, got error %v", err)
@@ -95,13 +91,10 @@ func TestListDomainRecordsMultiplePages(t *testing.T) {
 		t.Error(err)
 	}
 
-	filter, err := json.Marshal(map[string]interface{}{
+	filter := map[string]interface{}{
 		"name": record.Name,
-	})
-	if err != nil {
-		t.Error(err)
 	}
-	listOpts := linodego.NewListOptions(0, string(filter))
+	listOpts := linodego.NewListOptions(0, filter)
 	records, err := client.ListDomainRecords(context.Background(), domain.ID, listOpts)
 	if err != nil {
 		t.Errorf("Error listing domains records, expected array, got error %v", err)

--- a/example_integration_test.go
+++ b/example_integration_test.go
@@ -282,7 +282,7 @@ func Example() {
 			fmt.Println("### No Volumes")
 		}
 
-		stackscripts, err := linodeClient.ListStackscripts(context.Background(), &linodego.ListOptions{Filter: "{\"mine\":true}"})
+		stackscripts, err := linodeClient.ListStackscripts(context.Background(), &linodego.ListOptions{Filter: map[string]interface{}{"mine": true}})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/example_test.go
+++ b/example_test.go
@@ -81,7 +81,7 @@ func ExampleClient_ListKernels_allWithOpts() {
 	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListKernels_allWithOpts")
 	defer teardown()
 
-	filterOpt := linodego.NewListOptions(0, "")
+	filterOpt := linodego.NewListOptions(0, nil)
 	kernels, err := linodeClient.ListKernels(context.Background(), filterOpt)
 	if err != nil {
 		log.Fatal(err)
@@ -104,7 +104,7 @@ func ExampleClient_ListKernels_filtered() {
 	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListKernels_filtered")
 	defer teardown()
 
-	filterOpt := linodego.ListOptions{Filter: "{\"label\":\"Recovery - Finnix (kernel)\"}"}
+	filterOpt := linodego.ListOptions{Filter: map[string]interface{}{"label": "Recovery - Finnix (kernel)"}}
 	kernels, err := linodeClient.ListKernels(context.Background(), &filterOpt)
 	if err != nil {
 		log.Fatal(err)
@@ -123,7 +123,7 @@ func ExampleClient_ListKernels_page1() {
 	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListKernels_page1")
 	defer teardown()
 
-	filterOpt := linodego.NewListOptions(1, "")
+	filterOpt := linodego.NewListOptions(1, nil)
 	kernels, err := linodeClient.ListKernels(context.Background(), filterOpt)
 	if err != nil {
 		log.Fatal(err)
@@ -193,7 +193,7 @@ func ExampleClient_ListImages_all() {
 	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListImages_all")
 	defer teardown()
 
-	filterOpt := linodego.NewListOptions(0, "")
+	filterOpt := linodego.NewListOptions(0, nil)
 	images, err := linodeClient.ListImages(context.Background(), filterOpt)
 	if err != nil {
 		log.Fatal(err)
@@ -214,7 +214,7 @@ func ExampleClient_ListImages_notfound() {
 	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListImages_notfound")
 	defer teardown()
 
-	filterOpt := linodego.ListOptions{Filter: "{\"label\":\"not-found\"}"}
+	filterOpt := linodego.ListOptions{Filter: map[string]interface{}{"label": "not-found"}}
 	images, err := linodeClient.ListImages(context.Background(), &filterOpt)
 	if err != nil {
 		log.Fatal(err)
@@ -232,7 +232,7 @@ func ExampleClient_ListImages_badfilter() {
 	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListImages_badfilter")
 	defer teardown()
 
-	filterOpt := linodego.ListOptions{Filter: "{\"foo\":\"bar\"}"}
+	filterOpt := linodego.ListOptions{Filter: map[string]interface{}{"foo": "bar"}}
 	images, err := linodeClient.ListImages(context.Background(), &filterOpt)
 	if err == nil {
 		log.Fatal(err)
@@ -266,7 +266,7 @@ func ExampleClient_ListStackscripts_page1() {
 	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListStackscripts_page1")
 	defer teardown()
 
-	filterOpt := linodego.NewListOptions(1, "")
+	filterOpt := linodego.NewListOptions(1, nil)
 	scripts, err := linodeClient.ListStackscripts(context.Background(), filterOpt)
 	if err != nil {
 		log.Fatal(err)

--- a/nodebalancer_config_nodes_test.go
+++ b/nodebalancer_config_nodes_test.go
@@ -83,7 +83,7 @@ func TestListNodeBalancerNodes(t *testing.T) {
 		t.Error(err)
 	}
 
-	listOpts := linodego.NewListOptions(0, "")
+	listOpts := linodego.NewListOptions(0, nil)
 	nodes, err := client.ListNodeBalancerNodes(context.Background(), nodebalancer.ID, config.ID, listOpts)
 	if err != nil {
 		t.Errorf("Error listing nodebalancers nodes, expected array, got error %v", err)
@@ -106,7 +106,7 @@ func TestListNodeBalancerNodesMultiplePages(t *testing.T) {
 		t.Error(err)
 	}
 
-	listOpts := linodego.NewListOptions(0, "")
+	listOpts := linodego.NewListOptions(0, nil)
 	nodes, err := client.ListNodeBalancerNodes(context.Background(), nodebalancer.ID, config.ID, listOpts)
 	if err != nil {
 		t.Errorf("Error listing nodebalancers configs, expected array, got error %v", err)

--- a/nodebalancer_configs_test.go
+++ b/nodebalancer_configs_test.go
@@ -71,7 +71,7 @@ func TestListNodeBalancerConfigs(t *testing.T) {
 		t.Error(err)
 	}
 
-	listOpts := linodego.NewListOptions(0, "")
+	listOpts := linodego.NewListOptions(0, nil)
 	configs, err := client.ListNodeBalancerConfigs(context.Background(), nodebalancer.ID, listOpts)
 	if err != nil {
 		t.Errorf("Error listing nodebalancers configs, expected array, got error %v", err)
@@ -94,7 +94,7 @@ func TestListNodeBalancerConfigsMultiplePages(t *testing.T) {
 		t.Error(err)
 	}
 
-	listOpts := linodego.NewListOptions(0, "")
+	listOpts := linodego.NewListOptions(0, nil)
 	configs, err := client.ListNodeBalancerConfigs(context.Background(), nodebalancer.ID, listOpts)
 	if err != nil {
 		t.Errorf("Error listing nodebalancers configs, expected array, got error %v", err)

--- a/pagination.go
+++ b/pagination.go
@@ -6,6 +6,7 @@ package linodego
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -23,12 +24,12 @@ type PageOptions struct {
 // ListOptions are the pagination and filtering (TODO) parameters for endpoints
 type ListOptions struct {
 	*PageOptions
-	Filter string
+	Filter map[string]interface{}
 }
 
 // NewListOptions simplified construction of ListOptions using only
 // the two writable properties, Page and Filter
-func NewListOptions(Page int, Filter string) *ListOptions {
+func NewListOptions(Page int, Filter map[string]interface{}) *ListOptions {
 	return &ListOptions{PageOptions: &PageOptions{Page: Page}, Filter: Filter}
 
 }
@@ -52,7 +53,11 @@ func (c *Client) listHelper(ctx context.Context, i interface{}, opts *ListOption
 	)
 
 	if opts != nil && len(opts.Filter) > 0 {
-		req.SetHeader("X-Filter", opts.Filter)
+		b, err := json.Marshal(&opts.Filter)
+		if err != nil {
+			return err
+		}
+		req.SetHeader("X-Filter", string(b))
 	}
 
 	switch v := i.(type) {
@@ -312,7 +317,11 @@ func (c *Client) listHelperWithID(ctx context.Context, i interface{}, id int, op
 	)
 
 	if opts != nil && len(opts.Filter) > 0 {
-		req.SetHeader("X-Filter", opts.Filter)
+		b, err := json.Marshal(&opts.Filter)
+		if err != nil {
+			return err
+		}
+		req.SetHeader("X-Filter", string(b))
 	}
 
 	switch v := i.(type) {
@@ -426,7 +435,11 @@ func (c *Client) listHelperWithTwoIDs(ctx context.Context, i interface{}, firstI
 	)
 
 	if opts != nil && len(opts.Filter) > 0 {
-		req.SetHeader("X-Filter", opts.Filter)
+		b, err := json.Marshal(&opts.Filter)
+		if err != nil {
+			return err
+		}
+		req.SetHeader("X-Filter", string(b))
 	}
 
 	switch v := i.(type) {

--- a/stackscripts_test.go
+++ b/stackscripts_test.go
@@ -11,7 +11,7 @@ func TestListStackscripts(t *testing.T) {
 	client, teardown := createTestClient(t, "fixtures/TestListStackscripts")
 	defer teardown()
 
-	filterOpt := linodego.NewListOptions(1, "")
+	filterOpt := linodego.NewListOptions(1, nil)
 	stackscripts, err := client.ListStackscripts(context.Background(), filterOpt)
 	if err != nil {
 		t.Errorf("Error listing stackscripts, expected struct - error %v", err)

--- a/waitfor.go
+++ b/waitfor.go
@@ -2,7 +2,6 @@ package linodego
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -125,7 +124,7 @@ func (client Client) WaitForVolumeLinodeID(ctx context.Context, volumeID int, li
 // If the event indicates a failure both the failed event and the error will be returned.
 func (client Client) WaitForEventFinished(ctx context.Context, id interface{}, entityType EntityType, action EventAction, minStart time.Time, timeoutSeconds int) (*Event, error) {
 	titledEntityType := strings.Title(string(entityType))
-	filter, _ := json.Marshal(map[string]interface{}{
+	filter := map[string]interface{}{
 		// Entity is not filtered by the API
 		// Perhaps one day they will permit Entity ID/Type filtering.
 		// We'll have to verify these values manually, for now.
@@ -149,11 +148,11 @@ func (client Client) WaitForEventFinished(ctx context.Context, id interface{}, e
 		// Float the latest events to page 1
 		"+order_by": "created",
 		"+order":    "desc",
-	})
+	}
 
 	// Optimistically restrict results to page 1.  We should remove this when more
 	// precise filtering options exist.
-	listOptions := NewListOptions(1, string(filter))
+	listOptions := NewListOptions(1, filter)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()


### PR DESCRIPTION
This should make the filter much easier to use than plain `string` type. In the old API library I've written in a private project, I've used this same approach and it works quite well for me.

I think we can use Filters this way until Linode's v4 API becomes stable and/or we found a better way to handle Filters.