### PR TITLE
Add support for CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ jobs:
     docker:
       - image: circleci/golang:1.10
     working_directory: /go/src/github.com/linode/linodego
-    environment:
-      #LINODE_INSTANCE_ID: something
-      #LINODE_VOLUME_ID: something
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.10
+    working_directory: /go/src/github.com/linode/linodego
+    environment:
+      #LINODE_INSTANCE_ID: something
+      #LINODE_VOLUME_ID: something
+    steps:
+      - checkout
+      - run:
+          name: "Install Dependencies"
+          command: |
+            go get -u gopkg.in/alecthomas/gometalinter.v2
+            gometalinter.v2 --install
+            touch .env
+      - run:
+          name: "Run Tests"
+          command: |
+            make test ARGS='-v -race -count=2 -coverprofile=coverage.txt -covermode=atomic ./...'
+      - run:
+          name: "Run Linter"
+          command: |
+            gometalinter.v2 --enable-all --disable=vetshadow --disable=gocyclo --disable=unparam --disable=nakedret --disable=lll --disable=dupl --disable=gosec --disable=gochecknoinits --disable=gochecknoglobals --disable=test --deadline=120s
+            gometalinter.v2 --disable-all --enable=vetshadow --enable=gocyclo --enable=unparam --enable=nakedret --enable=lll --enable=dupl --enable=gosec --enable=gochecknoinits --enable=gochecknoglobals --deadline=120s || true
+      - run:
+          name: "Upload Coverage"
+          command: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Hey Friends,

I wanted to show how CircleCI could work for this repo since I'm both a Linode and Go fan.

I ran three sample builds taking 1m23s, 1m28s, and 1m21s for an **average of 1m24s**. Last three Travis builds were 3m16s, 2m35s, and 2m32s for an **average of 2m48s**.

This is also without any caching and parallel jobs configured for Go meaning we might be able to reduce the time a little more.

The beauty is that this can be run alongside Travis if you want as well, no need to choose one or the other.

---

Notes:

There's two environment variables that seem to have been set privately in the Travis build. For understandable reasons I can't replicate those secrets in the CircleCI build myself so I commented out placeholders for them in the config.

I'm here as a resource if anyone has any questions.