### PR TITLE
feature: add support for user account operations

### DIFF
--- a/API_SUPPORT.md
+++ b/API_SUPPORT.md
@@ -288,12 +288,12 @@
 ### Users
 
 - `/account/users`
-  - [ ] `GET`
-  - [ ] `POST`
+  - [X] `GET`
+  - [X] `POST`
 - `/account/users/$username`
-  - [ ] `GET`
-  - [ ] `PUT`
-  - [ ] `DELETE`
+  - [X] `GET`
+  - [X] `PUT`
+  - [X] `DELETE`
 - `/account/users/$username/grants`
   - [ ] `GET`
   - [ ] `PUT`

--- a/account_users.go
+++ b/account_users.go
@@ -1,0 +1,164 @@
+package linodego
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// User represents a User object
+type User struct {
+	Username   string   `json:"username"`
+	Email      string   `json:"email"`
+	Restricted bool     `json:"restricted"`
+	SSHKeys    []string `json:"ssh_keys"`
+}
+
+// UserCreateOptions fields are those accepted by CreateUser
+type UserCreateOptions struct {
+	Username   string `json:"username"`
+	Email      string `json:"email"`
+	Restricted bool   `json:"restricted,omitempty"`
+}
+
+// UserUpdateOptions fields are those accepted by UpdateUser
+type UserUpdateOptions struct {
+	Username   string    `json:"username,omitempty"`
+	Email      string    `json:"email,omitempty"`
+	Restricted *bool     `json:"restricted,omitempty"`
+	SSHKeys    *[]string `json:"ssh_keys,omitempty"`
+}
+
+// GetCreateOptions converts a User to UserCreateOptions for use in CreateUser
+func (i User) GetCreateOptions() (o UserCreateOptions) {
+	o.Username = i.Username
+	o.Email = i.Email
+	o.Restricted = i.Restricted
+	return
+}
+
+// GetUpdateOptions converts a User to UserUpdateOptions for use in UpdateUser
+func (i User) GetUpdateOptions() (o UserUpdateOptions) {
+	o.Username = i.Username
+	o.Email = i.Email
+	o.Restricted = copyBool(&i.Restricted)
+	return
+}
+
+// UsersPagedResponse represents a paginated User API response
+type UsersPagedResponse struct {
+	*PageOptions
+	Data []User `json:"data"`
+}
+
+// endpoint gets the endpoint URL for User
+func (UsersPagedResponse) endpoint(c *Client) string {
+	endpoint, err := c.Users.Endpoint()
+	if err != nil {
+		panic(err)
+	}
+	return endpoint
+}
+
+// appendData appends Users when processing paginated User responses
+func (resp *UsersPagedResponse) appendData(r *UsersPagedResponse) {
+	resp.Data = append(resp.Data, r.Data...)
+}
+
+// ListUsers lists Users on the account
+func (c *Client) ListUsers(ctx context.Context, opts *ListOptions) ([]User, error) {
+	response := UsersPagedResponse{}
+	err := c.listHelper(ctx, &response, opts)
+	for i := range response.Data {
+		response.Data[i].fixDates()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return response.Data, nil
+}
+
+// fixDates converts JSON timestamps to Go time.Time values
+func (i *User) fixDates() *User {
+	return i
+}
+
+// GetUser gets the user with the provided ID
+func (c *Client) GetUser(ctx context.Context, id string) (*User, error) {
+	e, err := c.Users.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s/%s", e, id)
+	r, err := coupleAPIErrors(c.R(ctx).SetResult(&User{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*User).fixDates(), nil
+}
+
+// CreateUser creates a User.  The email address must be confirmed before the
+// User account can be accessed.
+func (c *Client) CreateUser(ctx context.Context, createOpts UserCreateOptions) (*User, error) {
+	var body string
+	e, err := c.Users.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	req := c.R(ctx).SetResult(&User{})
+
+	if bodyData, err := json.Marshal(createOpts); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Post(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*User).fixDates(), nil
+}
+
+// UpdateUser updates the User with the specified id
+func (c *Client) UpdateUser(ctx context.Context, id string, updateOpts UserUpdateOptions) (*User, error) {
+	var body string
+	e, err := c.Users.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s/%s", e, id)
+
+	req := c.R(ctx).SetResult(&User{})
+
+	if bodyData, err := json.Marshal(updateOpts); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Put(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*User).fixDates(), nil
+}
+
+// DeleteUser deletes the User with the specified id
+func (c *Client) DeleteUser(ctx context.Context, id string) error {
+	e, err := c.Users.Endpoint()
+	if err != nil {
+		return err
+	}
+	e = fmt.Sprintf("%s/%s", e, id)
+
+	_, err = coupleAPIErrors(c.R(ctx).Delete(e))
+	return err
+}

--- a/account_users_test.go
+++ b/account_users_test.go
@@ -1,0 +1,123 @@
+package linodego_test
+
+import (
+	"context"
+
+	. "github.com/linode/linodego"
+
+	"testing"
+)
+
+func TestGetUser_missing(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestGetUser_missing")
+	defer teardown()
+
+	i, err := client.GetUser(context.Background(), "does-not-exist")
+	if err == nil {
+		t.Errorf("should have received an error requesting a missing user, got %v", i)
+	}
+	e, ok := err.(*Error)
+	if !ok {
+		t.Errorf("should have received an Error requesting a missing user, got %v", e)
+	}
+
+	if e.Code != 404 {
+		t.Errorf("should have received a 404 Code requesting a missing user, got %v", e.Code)
+	}
+}
+
+/**
+// -----------------------------------------------------------
+// TODO(displague)
+// User creation/list/updates require User email confirmation.
+// Testing will be revisited.
+// -----------------------------------------------------------
+func TestGetUser_found(t *testing.T) {
+	client, _, teardown, err := setupUser(t, "fixtures/TestGetUser_found")
+	defer teardown()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i, err := client.GetUser(context.Background(), "linodego-testuser")
+	if err != nil {
+		t.Errorf("Error getting user, expected struct, got %v and error %v", i, err)
+	}
+	if i.Username != "linodego-testuser" {
+		t.Errorf("Expected a specific user, but got a different one %v", i)
+	}
+}
+
+func TestUpdateUser(t *testing.T) {
+	client, user, teardown, err := setupUser(t, "fixtures/TestUpdateUser")
+	defer teardown()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createOpts := user.GetCreateOptions()
+	if createOpts.Restricted != user.Restricted {
+		t.Errorf("Expected Restricted to match GetCreateOptions, got: %v", createOpts)
+	}
+
+	updateOpts := user.GetUpdateOptions()
+	if updateOpts.Email != user.Email {
+		t.Errorf("Expected matching Email from GetUpdateOptions, got: %v", updateOpts)
+	}
+
+	updateOpts.Email = "r_" + user.Email
+	user, err = client.UpdateUser(context.Background(), user.Username, updateOpts)
+	if err != nil {
+		t.Errorf("Error listing users, expected struct, got error %v", err)
+	}
+
+	if user.Email != updateOpts.Email {
+		t.Errorf("Expected a change in user Email, but got none %v", user)
+	}
+}
+
+func TestListUsers(t *testing.T) {
+	client, user, teardown, err := setupUser(t, "fixtures/TestListUsers")
+	defer teardown()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listOpts := NewListOptions(1, "{\"username\":\""+user.Username+"\"}")
+	i, err := client.ListUsers(context.Background(), listOpts)
+	if err != nil {
+		t.Errorf("Error listing users, expected struct, got error %v", err)
+	}
+	if len(i) == 0 {
+		t.Errorf("Expected a list of users, but got none %v", i)
+	}
+}
+
+func setupUser(t *testing.T, fixturesYaml string) (*Client, *User, func(), error) {
+	t.Helper()
+	client, fixtureTeardown := createTestClient(t, fixturesYaml)
+
+	// This scope must be <= the scope used for testing
+	username := "linodego-testuser"
+
+	createOpts := UserCreateOptions{
+		Username:   username,
+		Email:      username + "@example.com",
+		Restricted: true,
+	}
+	user, err := client.CreateUser(context.Background(), createOpts)
+	if err != nil {
+		t.Fatalf("Error creating test User: %s", err)
+	}
+
+	teardown := func() {
+		if user != nil {
+			if err := client.DeleteUser(context.Background(), user.Username); err != nil {
+				t.Errorf("Error deleting test User: %s", err)
+			}
+		}
+		fixtureTeardown()
+	}
+	return client, user, teardown, err
+}
+**/

--- a/client.go
+++ b/client.go
@@ -77,6 +77,7 @@ type Client struct {
 	Profile               *Resource
 	Managed               *Resource
 	Tags                  *Resource
+	Users                 *Resource
 }
 
 func init() {
@@ -180,6 +181,7 @@ func NewClient(hc *http.Client) (client Client) {
 		profileName:               NewResource(&client, profileName, profileEndpoint, false, nil, nil), // really?
 		managedName:               NewResource(&client, managedName, managedEndpoint, false, nil, nil), // really?
 		tagsName:                  NewResource(&client, tagsName, tagsEndpoint, false, Tag{}, TagsPagedResponse{}),
+		usersName:                 NewResource(&client, usersName, usersEndpoint, false, User{}, UsersPagedResponse{}),
 	}
 
 	client.resources = resources
@@ -216,5 +218,38 @@ func NewClient(hc *http.Client) (client Client) {
 	client.Profile = resources[profileName]
 	client.Managed = resources[managedName]
 	client.Tags = resources[tagsName]
+	client.Users = resources[usersName]
 	return
+}
+
+func copyBool(bPtr *bool) *bool {
+	if bPtr == nil {
+		return nil
+	}
+	var t = *bPtr
+	return &t
+}
+
+func copyInt(iPtr *int) *int {
+	if iPtr == nil {
+		return nil
+	}
+	var t = *iPtr
+	return &t
+}
+
+func copyString(sPtr *string) *string {
+	if sPtr == nil {
+		return nil
+	}
+	var t = *sPtr
+	return &t
+}
+
+func copyTime(tPtr *time.Time) *time.Time {
+	if tPtr == nil {
+		return nil
+	}
+	var t = *tPtr
+	return &t
 }

--- a/domain_records.go
+++ b/domain_records.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
 // DomainRecord represents a DomainRecord object
@@ -79,30 +78,6 @@ func (d DomainRecord) GetUpdateOptions() (du DomainRecordUpdateOptions) {
 	du.TTLSec = d.TTLSec
 	du.Tag = copyString(d.Tag)
 	return
-}
-
-func copyInt(iPtr *int) *int {
-	if iPtr == nil {
-		return nil
-	}
-	var t = *iPtr
-	return &t
-}
-
-func copyString(sPtr *string) *string {
-	if sPtr == nil {
-		return nil
-	}
-	var t = *sPtr
-	return &t
-}
-
-func copyTime(tPtr *time.Time) *time.Time {
-	if tPtr == nil {
-		return nil
-	}
-	var t = *tPtr
-	return &t
 }
 
 // DomainRecordsPagedResponse represents a paginated DomainRecord API response

--- a/example_integration_test.go
+++ b/example_integration_test.go
@@ -54,6 +54,22 @@ func ExampleClient_GetAccount() {
 	// Account email has @: true
 }
 
+func ExampleClient_ListUsers() {
+	// Example readers, Ignore this bit of setup code needed to record test fixtures
+	linodeClient, teardown := createTestClient(nil, "fixtures/ExampleListUsers")
+	defer teardown()
+
+	users, err := linodeClient.ListUsers(context.Background(), nil)
+	if err != nil {
+		log.Fatalln("* While getting users: ", err)
+	}
+	user := users[0]
+	fmt.Println("Account email has @:", strings.Contains(user.Email, "@"))
+
+	// Output:
+	// Account email has @: true
+}
+
 func Example() {
 	// Example readers, Ignore this bit of setup code needed to record test fixtures
 	linodeClient, teardown := createTestClient(nil, "fixtures/Example")

--- a/fixtures/ExampleListUsers.yaml
+++ b/fixtures/ExampleListUsers.yaml
@@ -1,0 +1,76 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.5.1 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/account/users
+    method: GET
+  response:
+    body: '{"page": 1, "results": 1, "data": [{"restricted": false, "email": "linodego-testuser@example.com",
+      "username": "linodego-testuser", "ssh_keys": []}], "pages": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "1037"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 25 Oct 2018 13:00:37 GMT
+      Retry-After:
+      - "119"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - account:read_only
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - linodes:delete,domains:delete,nodebalancers:delete,images:delete,stackscripts:delete,longview:delete,events:delete,tokens:delete,clients:delete,account:delete,users:delete,tickets:delete
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "399"
+      X-Ratelimit-Reset:
+      - "1540472557"
+      X-Spec-Version:
+      - 4.0.7
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fixtures/TestGetToken_noexpiry.yaml
+++ b/fixtures/TestGetToken_noexpiry.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Authorization:
-      - Bearer 6b882c8c7c8034830b284bc75073c41cc1eb6c4c27b8e982ab433a112ccda7e0
+      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
@@ -18,7 +18,7 @@ interactions:
   response:
     body: '{"label": "linodego-test-token", "expiry": "2999-12-12T05:00:00", "token":
       "431485bee492baf2c2577342a87b4d5919f1f3360594c6a91acdb4d7826deb79", "id": 319584,
-      "created": "2018-10-19T19:13:57", "scopes": "linodes:read_only"}'
+      "created": "2018-01-02T03:04:05", "scopes": "linodes:read_only"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -80,7 +80,7 @@ interactions:
       Accept:
       - application/json
       Authorization:
-      - Bearer 6b882c8c7c8034830b284bc75073c41cc1eb6c4c27b8e982ab433a112ccda7e0
+      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
@@ -89,7 +89,7 @@ interactions:
     method: GET
   response:
     body: '{"id": 319584, "label": "linodego-test-token", "token": "431485bee492baf2",
-      "created": "2018-10-19T19:13:57", "expiry": "2999-12-12T05:00:00", "scopes":
+      "created": "2018-01-02T03:04:05", "expiry": "2999-12-12T05:00:00", "scopes":
       "linodes:read_only"}'
     headers:
       Access-Control-Allow-Credentials:
@@ -154,7 +154,7 @@ interactions:
       Accept:
       - application/json
       Authorization:
-      - Bearer 6b882c8c7c8034830b284bc75073c41cc1eb6c4c27b8e982ab433a112ccda7e0
+      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:

--- a/fixtures/TestGetUser_missing.yaml
+++ b/fixtures/TestGetUser_missing.yaml
@@ -1,0 +1,59 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.5.1 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/account/users/does-not-exist
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Not found"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "37"
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 23 Oct 2018 01:54:32 GMT
+      Retry-After:
+      - "119"
+      Server:
+      - nginx
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - account:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - linodes:delete,domains:delete,nodebalancers:delete,images:delete,stackscripts:delete,longview:delete,events:delete,tokens:delete,clients:delete,account:delete,users:delete,tickets:delete
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "399"
+      X-Ratelimit-Reset:
+      - "1540259792"
+      X-Spec-Version:
+      - 4.0.6
+    status: 404 NOT FOUND
+    code: 404
+    duration: ""

--- a/pagination.go
+++ b/pagination.go
@@ -191,11 +191,15 @@ func (c *Client) listHelper(ctx context.Context, i interface{}, opts *ListOption
 			results = r.Result().(*TokensPagedResponse).Results
 			v.appendData(r.Result().(*TokensPagedResponse))
 		}
-
+	case *UsersPagedResponse:
+		if r, err = coupleAPIErrors(req.SetResult(UsersPagedResponse{}).Get(v.endpoint(c))); err == nil {
+			pages = r.Result().(*UsersPagedResponse).Pages
+			results = r.Result().(*UsersPagedResponse).Results
+			v.appendData(r.Result().(*UsersPagedResponse))
+		}
 	/**
 	case AccountOauthClientsPagedResponse:
 	case AccountPaymentsPagedResponse:
-	case AccountUsersPagedResponse:
 	case ProfileAppsPagedResponse:
 	case ProfileWhitelistPagedResponse:
 	case ManagedContactsPagedResponse:

--- a/resources.go
+++ b/resources.go
@@ -43,6 +43,7 @@ const (
 	profileName               = "profile"
 	managedName               = "managed"
 	tagsName                  = "tags"
+	usersName                 = "users"
 	// notificationsName = "notifications"
 
 	stackscriptsEndpoint          = "linode/stackscripts"
@@ -82,6 +83,7 @@ const (
 	profileEndpoint             = "profile"
 	managedEndpoint             = "managed"
 	tagsEndpoint                = "tags"
+	usersEndpoint               = "account/users"
 	// notificationsEndpoint       = "account/notifications"
 )
 


### PR DESCRIPTION

- `/account/users`
  - [X] `GET`
  - [X] `POST`
- `/account/users/$username`
  - [X] `GET`
  - [X] `PUT`
  - [X] `DELETE`


I didn't include tests for most of the User operations because the test user account that is created is not accessible through the API until the email address is confirmed.