### PR TITLE
add support for the top-level profile/ endpoint

### DIFF
--- a/API_SUPPORT.md
+++ b/API_SUPPORT.md
@@ -305,8 +305,8 @@
 ### Personalized User Settings
 
 - `/profile`
-  - [ ] `GET`
-  - [ ] `PUT`
+  - [X] `GET`
+  - [X] `PUT`
 
 ### Granted OAuth Apps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+### Fixes
+
+### Features
+
+* Adds support for fetching and updating basic Profile information
+
 <a name-"v0.6.0"></a>
 ## [v0.6.0](https://github.com/linode/linodego/compare/v0.5.1..v0.6.0) (2018-10-25)
 

--- a/fixtures/TestGetProfile.yaml
+++ b/fixtures/TestGetProfile.yaml
@@ -1,0 +1,80 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.6.0 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/profile
+    method: GET
+  response:
+    body: '{"ip_whitelist_enabled": false, "email_notifications": true, "email": "restricted_tester@example.com",
+      "timezone": "GMT", "restricted": true, "two_factor_auth": false, "uid": 123456,
+      "lish_auth_method": "password_keys", "authorized_keys": null, "referrals": {"total":
+      0, "credit": 0, "completed": 0, "code": "919117eb5f8eb87eff289a49d30c76bf0c3f7de1",
+      "url": "https://www.linode.com/?r=919117eb5f8eb87eff289a49d30c76bf0c3f7de1",
+      "pending": 0}, "username": "restricted_tester"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "478"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 26 Oct 2018 03:20:06 GMT
+      Retry-After:
+      - "95"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "398"
+      X-Ratelimit-Reset:
+      - "1540524102"
+      X-Spec-Version:
+      - 4.0.7
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/fixtures/TestUpdateProfile.yaml
+++ b/fixtures/TestUpdateProfile.yaml
@@ -1,0 +1,155 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.6.0 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/profile
+    method: GET
+  response:
+    body: '{"username": "restricted_tester", "ip_whitelist_enabled": false, "timezone":
+      "GMT", "uid": 123456, "restricted": true, "lish_auth_method": "password_keys",
+      "two_factor_auth": false, "email": "restricted_tester@example.com", "referrals":
+      {"pending": 0, "credit": 0, "total": 0, "completed": 0, "code": "919117eb5f8eb87eff289a49d30c76bf0c3f7de1",
+      "url": "https://www.linode.com/?r=919117eb5f8eb87eff289a49d30c76bf0c3f7de1"},
+      "email_notifications": true, "authorized_keys": null}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "478"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 26 Oct 2018 03:20:21 GMT
+      Retry-After:
+      - "80"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "398"
+      X-Ratelimit-Reset:
+      - "1540524102"
+      X-Spec-Version:
+      - 4.0.7
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"email":"restricted_tester@example.com","timezone":"GMT","email_notifications":true,"ip_whitelist_enabled":false,"lish_auth_method":"password_keys","authorized_keys":[],"two_factor_auth":false,"restricted":true}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.6.0 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/profile
+    method: PUT
+  response:
+    body: '{"restricted": true, "email": "restricted_tester@example.com", "two_factor_auth":
+      false, "username": "restricted_tester", "lish_auth_method": "password_keys",
+      "timezone": "GMT", "authorized_keys": null, "referrals": {"credit": 0, "completed":
+      0, "code": "919117eb5f8eb87eff289a49d30c76bf0c3f7de1", "pending": 0, "url":
+      "https://www.linode.com/?r=919117eb5f8eb87eff289a49d30c76bf0c3f7de1", "total":
+      0}, "uid": 123456, "ip_whitelist_enabled": false, "email_notifications": true}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "478"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 26 Oct 2018 03:20:22 GMT
+      Retry-After:
+      - "119"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - account:read_write
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "399"
+      X-Ratelimit-Reset:
+      - "1540524142"
+      X-Spec-Version:
+      - 4.0.7
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/profile.go
+++ b/profile.go
@@ -1,1 +1,119 @@
 package linodego
+
+/*
+ - copy profile_test.go and do the same
+ - When updating Profile structs,
+   - use pointers where ever null'able would have a different meaning if the wrapper
+	 supplied "" or 0 instead
+ - Add "NameOfResource" to client.go, resources.go, pagination.go
+*/
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// LishAuthMethod constants start with AuthMethod and include Linode API Lish Authentication Methods
+type LishAuthMethod string
+
+// LishAuthMethod constants are the methods of authentication allowed when connecting via Lish
+const (
+	AuthMethodPasswordKeys LishAuthMethod = "password_keys"
+	AuthMethodKeysOnly     LishAuthMethod = "keys_only"
+	AuthMethodDisabled     LishAuthMethod = "disabled"
+)
+
+// ProfileReferrals represent a User's status in the Referral Program
+type ProfileReferrals struct {
+	Code      string  `json:"code"`
+	URL       string  `json:"url"`
+	Total     int     `json:"total"`
+	Completed int     `json:"completed"`
+	Pending   int     `json:"pending"`
+	Credit    float64 `json:"credit"`
+}
+
+// Profile represents a Profile object
+type Profile struct {
+	UID                int              `json:"uid"`
+	Username           string           `json:"username"`
+	Email              string           `json:"email"`
+	Timezone           string           `json:"timezone"`
+	EmailNotifications bool             `json:"email_notifications"`
+	Referrals          ProfileReferrals `json:"referrals"`
+	IPWhitelistEnabled bool             `json:"ip_whitelist_enabled"`
+	LishAuthMethod     LishAuthMethod   `json:"lish_auth_method"`
+	AuthorizedKeys     []string         `json:"authorized_keys"`
+	TwoFactorAuth      bool             `json:"two_factor_auth"`
+	Restricted         bool             `json:"restricted"`
+}
+
+// ProfileUpdateOptions fields are those accepted by UpdateProfile
+type ProfileUpdateOptions struct {
+	Email              string         `json:"email,omitempty"`
+	Timezone           string         `json:"timezone,omitempty"`
+	EmailNotifications *bool          `json:"email_notifications,omitempty"`
+	IPWhitelistEnabled *bool          `json:"ip_whitelist_enabled,omitempty"`
+	LishAuthMethod     LishAuthMethod `json:"lish_auth_method,omitempty"`
+	AuthorizedKeys     *[]string      `json:"authorized_keys,omitempty"`
+	TwoFactorAuth      *bool          `json:"two_factor_auth,omitempty"`
+	Restricted         *bool          `json:"restricted,omitempty"`
+}
+
+// GetUpdateOptions converts a Profile to ProfileUpdateOptions for use in UpdateProfile
+func (i Profile) GetUpdateOptions() (o ProfileUpdateOptions) {
+	o.Email = i.Email
+	o.Timezone = i.Timezone
+	o.EmailNotifications = copyBool(&i.EmailNotifications)
+	o.IPWhitelistEnabled = copyBool(&i.IPWhitelistEnabled)
+	o.LishAuthMethod = i.LishAuthMethod
+	authorizedKeys := make([]string, len(i.AuthorizedKeys))
+	copy(authorizedKeys, i.AuthorizedKeys)
+	o.AuthorizedKeys = &authorizedKeys
+	o.TwoFactorAuth = copyBool(&i.TwoFactorAuth)
+	o.Restricted = copyBool(&i.Restricted)
+
+	return
+}
+
+// GetProfile gets the profile with the provided ID
+func (c *Client) GetProfile(ctx context.Context) (*Profile, error) {
+	e, err := c.Profile.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s", e)
+	r, err := coupleAPIErrors(c.R(ctx).SetResult(&Profile{}).Get(e))
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Profile), nil
+}
+
+// UpdateProfile updates the Profile with the specified id
+func (c *Client) UpdateProfile(ctx context.Context, updateOpts ProfileUpdateOptions) (*Profile, error) {
+	var body string
+	e, err := c.Profile.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s", e)
+
+	req := c.R(ctx).SetResult(&Profile{})
+
+	if bodyData, err := json.Marshal(updateOpts); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
+		SetBody(body).
+		Put(e))
+
+	if err != nil {
+		return nil, err
+	}
+	return r.Result().(*Profile), nil
+}

--- a/profile_test.go
+++ b/profile_test.go
@@ -1,0 +1,44 @@
+package linodego_test
+
+import (
+	"context"
+	"strings"
+
+	"testing"
+)
+
+func TestGetProfile(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestGetProfile")
+	defer teardown()
+
+	i, err := client.GetProfile(context.Background())
+	if err != nil {
+		t.Errorf("Error getting profile: %s", err)
+	}
+	if !strings.Contains(i.Email, "@") {
+		t.Errorf("Expected profile email to contain @: %v", i)
+	}
+}
+
+func TestUpdateProfile(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestUpdateProfile")
+	defer teardown()
+
+	profile, err := client.GetProfile(context.Background())
+	if err != nil {
+		t.Errorf("Error getting profile: %s", err)
+	}
+
+	updateOpts := profile.GetUpdateOptions()
+	if updateOpts.Email != profile.Email {
+		t.Errorf("Expected matching Username from GetUpdateOptions, got: %v", updateOpts)
+	}
+
+	i, err := client.UpdateProfile(context.Background(), updateOpts)
+	if err != nil {
+		t.Errorf("Error updating profile: %s", err)
+	}
+	if i.Email != updateOpts.Email {
+		t.Errorf("Expected profile email to be changed, but found %v", i)
+	}
+}


### PR DESCRIPTION
Implements the /profile endpoint:

- `/profile`
  - [X] `GET`
  - [X] `PUT`