### PR TITLE
add support for domain, nodebalancer, and volume tags

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -39,6 +39,9 @@ type Domain struct {
 	// The list of IPs that may perform a zone transfer for this Domain. This is potentially dangerous, and should be set to an empty list unless you intend to use it.
 	AXfrIPs []string `json:"axfr_ips"`
 
+	// An array of tags applied to this object. Tags are for organizational purposes only.
+	Tags []string `json:"tags"`
+
 	// The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 	ExpireSec int `json:"expire_sec"`
 
@@ -80,6 +83,9 @@ type DomainCreateOptions struct {
 
 	// The list of IPs that may perform a zone transfer for this Domain. This is potentially dangerous, and should be set to an empty list unless you intend to use it.
 	AXfrIPs []string `json:"axfr_ips,omitempty"`
+
+	// An array of tags applied to this object. Tags are for organizational purposes only.
+	Tags []string `json:"tags"`
 
 	// The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 	ExpireSec int `json:"expire_sec,omitempty"`
@@ -123,6 +129,9 @@ type DomainUpdateOptions struct {
 	// The list of IPs that may perform a zone transfer for this Domain. This is potentially dangerous, and should be set to an empty list unless you intend to use it.
 	AXfrIPs []string `json:"axfr_ips,omitempty"`
 
+	// An array of tags applied to this object. Tags are for organizational purposes only.
+	Tags []string `json:"tags"`
+
 	// The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
 	ExpireSec int `json:"expire_sec,omitempty"`
 
@@ -164,6 +173,7 @@ func (d Domain) GetUpdateOptions() (du DomainUpdateOptions) {
 	du.RetrySec = d.RetrySec
 	du.MasterIPs = d.MasterIPs
 	du.AXfrIPs = d.AXfrIPs
+	du.Tags = d.Tags
 	du.ExpireSec = d.ExpireSec
 	du.RefreshSec = d.RefreshSec
 	du.TTLSec = d.TTLSec

--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -28,6 +28,9 @@ type NodeBalancer struct {
 	// Information about the amount of transfer this NodeBalancer has had so far this month.
 	Transfer NodeBalancerTransfer `json:"transfer"`
 
+	// An array of tags applied to this object. Tags are for organizational purposes only.
+	Tags []string `json:"tags"`
+
 	Created *time.Time `json:"-"`
 	Updated *time.Time `json:"-"`
 }
@@ -48,12 +51,14 @@ type NodeBalancerCreateOptions struct {
 	Region             string                             `json:"region,omitempty"`
 	ClientConnThrottle *int                               `json:"client_conn_throttle,omitempty"`
 	Configs            []*NodeBalancerConfigCreateOptions `json:"configs,omitempty"`
+	Tags               []string                           `json:"tags"`
 }
 
 // NodeBalancerUpdateOptions are the options permitted for UpdateNodeBalancer
 type NodeBalancerUpdateOptions struct {
-	Label              *string `json:"label,omitempty"`
-	ClientConnThrottle *int    `json:"client_conn_throttle,omitempty"`
+	Label              *string   `json:"label,omitempty"`
+	ClientConnThrottle *int      `json:"client_conn_throttle,omitempty"`
+	Tags               *[]string `json:"tags,omitempty"`
 }
 
 // GetCreateOptions converts a NodeBalancer to NodeBalancerCreateOptions for use in CreateNodeBalancer
@@ -62,6 +67,7 @@ func (i NodeBalancer) GetCreateOptions() NodeBalancerCreateOptions {
 		Label:              i.Label,
 		Region:             i.Region,
 		ClientConnThrottle: &i.ClientConnThrottle,
+		Tags:               i.Tags,
 	}
 }
 
@@ -70,6 +76,7 @@ func (i NodeBalancer) GetUpdateOptions() NodeBalancerUpdateOptions {
 	return NodeBalancerUpdateOptions{
 		Label:              i.Label,
 		ClientConnThrottle: &i.ClientConnThrottle,
+		Tags:               &i.Tags,
 	}
 }
 

--- a/tags.go
+++ b/tags.go
@@ -22,9 +22,10 @@ type TaggedObject struct {
 // SortedObjects currently only includes Instances
 type SortedObjects struct {
 	Instances []Instance
+	Domains   []Domain
+	Volumes   []Volume
 	/*
 		NodeBalancers []NodeBalancer
-		Domains       []Domain
 		StackScripts  []Stackscript
 	*/
 }
@@ -36,6 +37,8 @@ type TaggedObjectList []TaggedObject
 type TagCreateOptions struct {
 	Label   string `json:"label"`
 	Linodes []int  `json:"linodes,omitempty"`
+	Domains []int  `json:"domains,omitempty"`
+	Volumes []int  `json:"volumes,omitempty"`
 }
 
 // GetCreateOptions converts a Tag to TagCreateOptions for use in CreateTag
@@ -133,6 +136,18 @@ func (t TaggedObjectList) SortedObjects() (SortedObjects, error) {
 				so.Instances = append(so.Instances, instance)
 			} else {
 				return so, errors.New("Expected an Instance when Type was \"linode\"")
+			}
+		case "domain":
+			if domain, ok := o.Data.(Domain); ok {
+				so.Domains = append(so.Domains, domain)
+			} else {
+				return so, errors.New("Expected a Domain when Type was \"domain\"")
+			}
+		case "volume":
+			if volume, ok := o.Data.(Volume); ok {
+				so.Volumes = append(so.Volumes, volume)
+			} else {
+				return so, errors.New("Expected an Volume when Type was \"volume\"")
 			}
 		}
 	}

--- a/tags.go
+++ b/tags.go
@@ -21,11 +21,11 @@ type TaggedObject struct {
 
 // SortedObjects currently only includes Instances
 type SortedObjects struct {
-	Instances []Instance
-	Domains   []Domain
-	Volumes   []Volume
+	Instances     []Instance
+	Domains       []Domain
+	Volumes       []Volume
+	NodeBalancers []NodeBalancer
 	/*
-		NodeBalancers []NodeBalancer
 		StackScripts  []Stackscript
 	*/
 }
@@ -35,10 +35,11 @@ type TaggedObjectList []TaggedObject
 
 // TagCreateOptions fields are those accepted by CreateTag
 type TagCreateOptions struct {
-	Label   string `json:"label"`
-	Linodes []int  `json:"linodes,omitempty"`
-	Domains []int  `json:"domains,omitempty"`
-	Volumes []int  `json:"volumes,omitempty"`
+	Label         string `json:"label"`
+	Linodes       []int  `json:"linodes,omitempty"`
+	Domains       []int  `json:"domains,omitempty"`
+	Volumes       []int  `json:"volumes,omitempty"`
+	NodeBalancers []int  `json:"nodebalancers,omitempty"`
 }
 
 // GetCreateOptions converts a Tag to TagCreateOptions for use in CreateTag
@@ -102,12 +103,31 @@ func (c *Client) ListTags(ctx context.Context, opts *ListOptions) ([]Tag, error)
 func (i *TaggedObject) fixData() (*TaggedObject, error) {
 	switch i.Type {
 	case "linode":
-		instance := Instance{}
-		if err := json.Unmarshal(i.RawData, &instance); err != nil {
+		obj := Instance{}
+		if err := json.Unmarshal(i.RawData, &obj); err != nil {
 			return nil, err
 		}
-		i.Data = instance
+		i.Data = obj
+	case "nodebalancer":
+		obj := NodeBalancer{}
+		if err := json.Unmarshal(i.RawData, &obj); err != nil {
+			return nil, err
+		}
+		i.Data = obj
+	case "domain":
+		obj := Domain{}
+		if err := json.Unmarshal(i.RawData, &obj); err != nil {
+			return nil, err
+		}
+		i.Data = obj
+	case "volume":
+		obj := Volume{}
+		if err := json.Unmarshal(i.RawData, &obj); err != nil {
+			return nil, err
+		}
+		i.Data = obj
 	}
+
 	return i, nil
 }
 
@@ -148,6 +168,12 @@ func (t TaggedObjectList) SortedObjects() (SortedObjects, error) {
 				so.Volumes = append(so.Volumes, volume)
 			} else {
 				return so, errors.New("Expected an Volume when Type was \"volume\"")
+			}
+		case "nodebalancer":
+			if nodebalancer, ok := o.Data.(NodeBalancer); ok {
+				so.NodeBalancers = append(so.NodeBalancers, nodebalancer)
+			} else {
+				return so, errors.New("Expected an NodeBalancer when Type was \"nodebalancer\"")
 			}
 		}
 	}

--- a/volumes.go
+++ b/volumes.go
@@ -36,6 +36,7 @@ type Volume struct {
 	Size           int          `json:"size"`
 	LinodeID       *int         `json:"linode_id"`
 	FilesystemPath string       `json:"filesystem_path"`
+	Tags           []string     `json:"tags"`
 	Created        time.Time    `json:"-"`
 	Updated        time.Time    `json:"-"`
 }
@@ -48,6 +49,14 @@ type VolumeCreateOptions struct {
 	ConfigID int    `json:"config_id,omitempty"`
 	// The Volume's size, in GiB. Minimum size is 10GiB, maximum size is 10240GiB. A "0" value will result in the default size.
 	Size int `json:"size,omitempty"`
+	// An array of tags applied to this object. Tags are for organizational purposes only.
+	Tags []string `json:"tags"`
+}
+
+// VolumeUpdateOptions fields are those accepted by UpdateVolume
+type VolumeUpdateOptions struct {
+	Label string    `json:"label,omitempty"`
+	Tags  *[]string `json:"tags,omitempty"`
 }
 
 // VolumeAttachOptions fields are those accepted by AttachVolume
@@ -60,6 +69,25 @@ type VolumeAttachOptions struct {
 type VolumesPagedResponse struct {
 	*PageOptions
 	Data []Volume `json:"data"`
+}
+
+// GetUpdateOptions converts a Volume to VolumeUpdateOptions for use in UpdateVolume
+func (v Volume) GetUpdateOptions() (updateOpts VolumeUpdateOptions) {
+	updateOpts.Label = v.Label
+	updateOpts.Tags = &v.Tags
+	return
+}
+
+// GetCreateOptions converts a Volume to VolumeCreateOptions for use in CreateVolume
+func (v Volume) GetCreateOptions() (createOpts VolumeCreateOptions) {
+	createOpts.Label = v.Label
+	createOpts.Tags = v.Tags
+	createOpts.Region = v.Region
+	createOpts.Size = v.Size
+	if v.LinodeID != nil && *v.LinodeID > 0 {
+		createOpts.LinodeID = *v.LinodeID
+	}
+	return
 }
 
 // endpoint gets the endpoint URL for Volume
@@ -168,26 +196,37 @@ func (c *Client) CreateVolume(ctx context.Context, createOpts VolumeCreateOption
 }
 
 // RenameVolume renames the label of a Linode volume
-// There is no UpdateVolume because the label is the only alterable field.
+// DEPRECATED: use UpdateVolume
 func (c *Client) RenameVolume(ctx context.Context, id int, label string) (*Volume, error) {
-	body, _ := json.Marshal(map[string]string{"label": label})
+	updateOpts := VolumeUpdateOptions{Label: label}
+	return c.UpdateVolume(ctx, id, updateOpts)
+}
 
+// UpdateVolume updates the Volume with the specified id
+func (c *Client) UpdateVolume(ctx context.Context, id int, volume VolumeUpdateOptions) (*Volume, error) {
+	var body string
 	e, err := c.Volumes.Endpoint()
 	if err != nil {
-		return nil, NewError(err)
+		return nil, err
 	}
 	e = fmt.Sprintf("%s/%d", e, id)
 
-	resp, err := coupleAPIErrors(c.R(ctx).
-		SetResult(&Volume{}).
+	req := c.R(ctx).SetResult(&Volume{})
+
+	if bodyData, err := json.Marshal(volume); err == nil {
+		body = string(bodyData)
+	} else {
+		return nil, NewError(err)
+	}
+
+	r, err := coupleAPIErrors(req.
 		SetBody(body).
 		Put(e))
 
 	if err != nil {
 		return nil, err
 	}
-
-	return resp.Result().(*Volume).fixDates(), nil
+	return r.Result().(*Volume).fixDates(), nil
 }
 
 // CloneVolume clones a Linode volume


### PR DESCRIPTION
Adds `GetUpdateOptions` `GetCreateOptions` for `Volume` 
Adds `Tags` for `NodeBalancer`, `Volume`, and `Domain` (and their respective `GetUpdateOptions` and `GetCreateOptions`)
Adds `UpdateVolume` (deprecates `RenameVolume`, since both `Label` and `Tags` can now be updated)
Adds `Domains`, `NodeBalancer`, and `Volumes` to `TaggedObjects`, `SortedObjects` and `TagCreateOptions` (used by `ListTaggedObjects` and `SortedObjects`)

Closes #64 

