### PR TITLE
429 and 408 handling

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -48,6 +48,11 @@ func coupleAPIErrors(r *resty.Response, err error) (*resty.Response, error) {
 		return nil, NewError(err)
 	}
 
+	// Special case for undocumented rate limit response
+	if r.StatusCode() == 429 && r.Size() == 0 {
+		return nil, NewError(r)
+	}
+
 	if r.Error() != nil {
 		apiError, ok := r.Error().(*APIError)
 		if !ok || (ok && len(apiError.Errors) == 0) {

--- a/errors.go
+++ b/errors.go
@@ -49,7 +49,7 @@ func coupleAPIErrors(r *resty.Response, err error) (*resty.Response, error) {
 	}
 
 	// Special case for undocumented rate limit response
-	if r.StatusCode() == 429 && r.Size() == 0 {
+	if r.StatusCode() == http.StatusTooManyRequests && r.Size() == 0 {
 		return nil, NewError(r)
 	}
 

--- a/fixtures/TestListTypes_429.yaml
+++ b/fixtures/TestListTypes_429.yaml
@@ -29,3 +29,87 @@ interactions:
     status: 429 429
     code: 429
     duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.0.1 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/linode/types
+    method: GET
+  response:
+    body: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "0"
+      Date:
+      - Tue, 03 Jul 2018 01:38:52 GMT
+      Server:
+      - nginx
+    status: 408 408
+    code: 408
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.0.1 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/linode/types
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Rate Limited"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "0"
+      Date:
+      - Tue, 03 Jul 2018 01:38:52 GMT
+      Server:
+      - nginx
+    status: 429 429
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.0.1 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/linode/types
+    method: GET
+  response:
+    body: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "0"
+      Date:
+      - Tue, 03 Jul 2018 01:38:52 GMT
+      Server:
+      - nginx
+    status: 429 429
+    code: 429
+    duration: ""

--- a/fixtures/TestListTypes_429recovered.yaml
+++ b/fixtures/TestListTypes_429recovered.yaml
@@ -1,0 +1,153 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.0.1 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/linode/types
+    method: GET
+  response:
+    body: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "0"
+      Date:
+      - Tue, 03 Jul 2018 01:38:52 GMT
+      Server:
+      - nginx
+    status: 429 429
+    code: 429
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Authorization:
+      - Bearer awesometokenawesometokenawesometoken
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego 0.0.1 https://github.com/linode/linodego
+    url: https://api.linode.com/v4/linode/types
+    method: GET
+  response:
+    body: '{"pages": 1, "page": 1, "data": [{"memory": 1024, "label": "Nanode 1GB",
+      "addons": {"backups": {"price": {"hourly": 0.003, "monthly": 2.0}}}, "vcpus":
+      1, "price": {"hourly": 0.0075, "monthly": 5.0}, "disk": 25600, "transfer": 1000,
+      "network_out": 1000, "class": "nanode", "id": "g6-nanode-1"}, {"memory": 2048,
+      "label": "Linode 2GB", "addons": {"backups": {"price": {"hourly": 0.004, "monthly":
+      2.5}}}, "vcpus": 1, "price": {"hourly": 0.015, "monthly": 10.0}, "disk": 51200,
+      "transfer": 2000, "network_out": 2000, "class": "standard", "id": "g6-standard-1"},
+      {"memory": 4096, "label": "Linode 4GB", "addons": {"backups": {"price": {"hourly":
+      0.008, "monthly": 5.0}}}, "vcpus": 2, "price": {"hourly": 0.03, "monthly": 20.0},
+      "disk": 81920, "transfer": 4000, "network_out": 4000, "class": "standard", "id":
+      "g6-standard-2"}, {"memory": 8192, "label": "Linode 8GB", "addons": {"backups":
+      {"price": {"hourly": 0.015, "monthly": 10.0}}}, "vcpus": 4, "price": {"hourly":
+      0.06, "monthly": 40.0}, "disk": 163840, "transfer": 5000, "network_out": 5000,
+      "class": "standard", "id": "g6-standard-4"}, {"memory": 16384, "label": "Linode
+      16GB", "addons": {"backups": {"price": {"hourly": 0.03, "monthly": 20.0}}},
+      "vcpus": 6, "price": {"hourly": 0.12, "monthly": 80.0}, "disk": 327680, "transfer":
+      8000, "network_out": 6000, "class": "standard", "id": "g6-standard-6"}, {"memory":
+      32768, "label": "Linode 32GB", "addons": {"backups": {"price": {"hourly": 0.06,
+      "monthly": 40.0}}}, "vcpus": 8, "price": {"hourly": 0.24, "monthly": 160.0},
+      "disk": 655360, "transfer": 16000, "network_out": 7000, "class": "standard",
+      "id": "g6-standard-8"}, {"memory": 65536, "label": "Linode 64GB", "addons":
+      {"backups": {"price": {"hourly": 0.12, "monthly": 80.0}}}, "vcpus": 16, "price":
+      {"hourly": 0.48, "monthly": 320.0}, "disk": 1310720, "transfer": 20000, "network_out":
+      9000, "class": "standard", "id": "g6-standard-16"}, {"memory": 98304, "label":
+      "Linode 96GB", "addons": {"backups": {"price": {"hourly": 0.18, "monthly": 120.0}}},
+      "vcpus": 20, "price": {"hourly": 0.72, "monthly": 480.0}, "disk": 1966080, "transfer":
+      20000, "network_out": 10000, "class": "standard", "id": "g6-standard-20"}, {"memory":
+      131072, "label": "Linode 128GB", "addons": {"backups": {"price": {"hourly":
+      0.24, "monthly": 160.0}}}, "vcpus": 24, "price": {"hourly": 0.96, "monthly":
+      640.0}, "disk": 2621440, "transfer": 20000, "network_out": 11000, "class": "standard",
+      "id": "g6-standard-24"}, {"memory": 196608, "label": "Linode 192GB", "addons":
+      {"backups": {"price": {"hourly": 0.36, "monthly": 240.0}}}, "vcpus": 32, "price":
+      {"hourly": 1.44, "monthly": 960.0}, "disk": 3932160, "transfer": 20000, "network_out":
+      12000, "class": "standard", "id": "g6-standard-32"}, {"memory": 24576, "label":
+      "Linode 24GB", "addons": {"backups": {"price": {"hourly": 0.0075, "monthly":
+      5.0}}}, "vcpus": 1, "price": {"hourly": 0.09, "monthly": 60.0}, "disk": 20480,
+      "transfer": 5000, "network_out": 5000, "class": "highmem", "id": "g6-highmem-1"},
+      {"memory": 49152, "label": "Linode 48GB", "addons": {"backups": {"price": {"hourly":
+      0.015, "monthly": 10.0}}}, "vcpus": 2, "price": {"hourly": 0.18, "monthly":
+      120.0}, "disk": 40960, "transfer": 6000, "network_out": 6000, "class": "highmem",
+      "id": "g6-highmem-2"}, {"memory": 92160, "label": "Linode 90GB", "addons": {"backups":
+      {"price": {"hourly": 0.03, "monthly": 20.0}}}, "vcpus": 4, "price": {"hourly":
+      0.36, "monthly": 240.0}, "disk": 92160, "transfer": 7000, "network_out": 7000,
+      "class": "highmem", "id": "g6-highmem-4"}, {"memory": 153600, "label": "Linode
+      150GB", "addons": {"backups": {"price": {"hourly": 0.06, "monthly": 40.0}}},
+      "vcpus": 8, "price": {"hourly": 0.72, "monthly": 480.0}, "disk": 204800, "transfer":
+      8000, "network_out": 8000, "class": "highmem", "id": "g6-highmem-8"}, {"memory":
+      307200, "label": "Linode 300GB", "addons": {"backups": {"price": {"hourly":
+      0.12, "monthly": 80.0}}}, "vcpus": 16, "price": {"hourly": 1.44, "monthly":
+      960.0}, "disk": 348160, "transfer": 9000, "network_out": 9000, "class": "highmem",
+      "id": "g6-highmem-16"}], "results": 15}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=900
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "4072"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 03 Jul 2018 01:38:52 GMT
+      Retry-After:
+      - "25"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - unknown
+      X-Ratelimit-Limit:
+      - "400"
+      X-Ratelimit-Remaining:
+      - "397"
+      X-Ratelimit-Reset:
+      - "1530581958"
+      X-Spec-Version:
+      - 4.0.2
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/http403_test.go
+++ b/http403_test.go
@@ -1,0 +1,26 @@
+package linodego_test
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListTypes_429(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestListTypes_429")
+	defer teardown()
+
+	_, err := client.ListTypes(context.Background(), nil)
+	if err == nil {
+		t.Errorf("Error listing images, expected error")
+	}
+}
+
+func TestListTypes_429recovered(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestListTypes_429recovered")
+	defer teardown()
+
+	_, err := client.ListTypes(context.Background(), nil)
+	if err != nil {
+		t.Errorf("Error listing images, expected 429 to recover")
+	}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -50,13 +50,3 @@ func TestListTypes(t *testing.T) {
 		t.Errorf("Expected a list of images, but got none %v", i)
 	}
 }
-
-func TestListTypes_429(t *testing.T) {
-	client, teardown := createTestClient(t, "fixtures/TestListTypes_429")
-	defer teardown()
-
-	_, err := client.ListTypes(context.Background(), nil)
-	if err == nil {
-		t.Errorf("Error listing images, expected error")
-	}
-}


### PR DESCRIPTION
This is a work in progress branch to sort out 429 handling. (Replaces #19 whose source branch is gone)

* [x] Needs tests
      - complicated because the current test runner does not handle repeated requests
      - a `[ GET /something [429], GET /something [200] ]` list of fixtures would be keyed on the METHOD+URL and so the `[429]` response will loop

Some responses do not return the full 429 response, so special attention must be made to those more severe 429 responses.

Headers like this may be returned on normal requests,
```
Retry-After: 106
X-Ratelimit-Limit: 400
X-Ratelimit-Remaining: 388
X-Ratelimit-Reset: 1531247494
```

And headers and body values like this, may be return on a 429 response:
```
TODO provide detail snippet here
```

And headers and body values like this, may be return on a 429 response that does not include all headers:
```
TODO provide detail snippet here
```

And 408 headers and body messages may be returned:
```
TODO provide detail snippet here
```