### PR TITLE
Add support for configuring alternate API base URL through env vars

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,6 +15,8 @@ import (
 const (
 	// APIHost Linode API hostname
 	APIHost = "api.linode.com"
+	// APIHostVar environment var to check for alternate API URL
+	APIHostVar = "LINODE_URL"
 	// APIVersion Linode API version
 	APIVersion = "v4"
 	// APIProto connect to API with http(s)
@@ -148,7 +150,12 @@ func NewClient(hc *http.Client) (client Client) {
 	restyClient := resty.NewWithClient(hc)
 	client.resty = restyClient
 	client.SetUserAgent(DefaultUserAgent)
-	client.SetBaseURL(fmt.Sprintf("%s://%s/%s", APIProto, APIHost, APIVersion))
+	baseURL, baseURLExists := os.LookupEnv(APIHostVar)
+	if baseURLExists {
+		client.SetBaseURL(baseURL)
+	} else {
+		client.SetBaseURL(fmt.Sprintf("%s://%s/%s", APIProto, APIHost, APIVersion))
+	}
 	client.SetPollDelay(1000 * APISecondsPerPoll)
 
 	resources := map[string]*Resource{


### PR DESCRIPTION
We need the ability to set alternate base URLs (for e.g. mock API
endpoints, internal environments, etc). I think looking for an
environment variable in linodego itself makes sense here; it'd let us
override the URL for other environments without changing all
downstream applications that use this library.