### PR TITLE
add new PersistAcrossBoots flag for volume attachments

### DIFF
--- a/volumes.go
+++ b/volumes.go
@@ -50,7 +50,8 @@ type VolumeCreateOptions struct {
 	// The Volume's size, in GiB. Minimum size is 10GiB, maximum size is 10240GiB. A "0" value will result in the default size.
 	Size int `json:"size,omitempty"`
 	// An array of tags applied to this object. Tags are for organizational purposes only.
-	Tags []string `json:"tags"`
+	Tags               []string `json:"tags"`
+	PersistAcrossBoots *bool    `json:"persist_across_boots,omitempty"`
 }
 
 // VolumeUpdateOptions fields are those accepted by UpdateVolume
@@ -61,8 +62,9 @@ type VolumeUpdateOptions struct {
 
 // VolumeAttachOptions fields are those accepted by AttachVolume
 type VolumeAttachOptions struct {
-	LinodeID int `json:"linode_id"`
-	ConfigID int `json:"config_id,omitempty"`
+	LinodeID           int   `json:"linode_id"`
+	ConfigID           int   `json:"config_id,omitempty"`
+	PersistAcrossBoots *bool `json:"persist_across_boots,omitempty"`
 }
 
 // VolumesPagedResponse represents a linode API response for listing of volumes


### PR DESCRIPTION
Adds support for `persist_across_boots`:

https://developers.linode.com/api/docs/v4#operation/attachVolume

This is needed for CSI driver support beyond 8 devices, for example.

https://www.linode.com/community/questions/17538/linode-block-storage-csi-driver#answer-69053
