### PR TITLE
Replace bad JSON tag

### DIFF
--- a/lke_cluster_pools.go
+++ b/lke_cluster_pools.go
@@ -26,7 +26,7 @@ type LKEClusterPoolLinode struct {
 type LKEClusterPool struct {
 	ID      int                    `json:"id"`
 	Count   int                    `json:"count"`
-	Type    string                 `json:"string"`
+	Type    string                 `json:"type"`
 	Linodes []LKEClusterPoolLinode `json:"linodes"`
 }
 


### PR DESCRIPTION
I'm currently working on adding the LKE feature to the `terraform-provider-linode` when I noticed that `LKEClusterPools` where missing the `type`.  A simple example saw me

```HEADERS      :
        Access-Control-Allow-Credentials: true
        Access-Control-Allow-Headers: Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
        Access-Control-Allow-Methods: HEAD, GET, OPTIONS, POST, PUT, DELETE
        Access-Control-Allow-Origin: *
        Access-Control-Expose-Headers: X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
        Cache-Control: private, max-age=0, s-maxage=0, no-cache, no-store, private, max-age=60, s-maxage=60
        Connection: keep-alive
        Content-Length: 173
        Content-Security-Policy: default-src 'none'
        Content-Type: application/json
        Date: Sat, 01 Feb 2020 16:31:50 GMT
        Retry-After: 119
        Server: nginx
        Strict-Transport-Security: max-age=31536000
        Vary: Authorization, X-Filter, Authorization, X-Filter
        X-Accepted-Oauth-Scopes: lke:read_only
        X-Content-Type-Options: nosniff
        X-Frame-Options: DENY, DENY
        X-Oauth-Scopes: *
        X-Ratelimit-Limit: 800
        X-Ratelimit-Remaining: 799
        X-Ratelimit-Reset: 1580574830
        X-Spec-Version: 4.13.0
        X-Xss-Protection: 1; mode=block
BODY         :
{
   "id": 1531,
   "type": "g6-standard-2",
   "count": 3,
   "linodes": [
      {
         "id": 19266821,
         "status": "ready"
      },
      {
         "id": 19266825,
         "status": "ready"
      },
      {
         "id": 19266823,
         "status": "ready"
      }
   ]
}
type=&linodego.LKEClusterPool{ID:1531, Count:3, Type:"", Linodes:[]linodego.LKEClusterPoolLinode{linodego.LKEClusterPoolLinode{ID:(*int)(0xc0000aa620), Status:"ready"}, linodego.LKEClusterPoolLinode{ID:(*int)(0xc0000aa638), Status:"ready"}, linodego.LKEClusterPoolLinode{ID:(*int)(0xc0000aa650), Status:"ready"}}}
```
I first ran the tests and they passed, but I guess somehow escaped to this.
