### PR TITLE
Replace bad JSON tag

### DIFF
--- a/lke_cluster_pools.go
+++ b/lke_cluster_pools.go
@@ -26,7 +26,7 @@ type LKEClusterPoolLinode struct {
 type LKEClusterPool struct {
 	ID      int                    `json:"id"`
 	Count   int                    `json:"count"`
-	Type    string                 `json:"string"`
+	Type    string                 `json:"type"`
 	Linodes []LKEClusterPoolLinode `json:"linodes"`
 }
 


### PR DESCRIPTION
I'm currently working on the `terraform-provider-linode` when I noticed that `type` for the `LKEClusterPool` was missing. I first ran the tests and it passed, it would be worth to take a look into that as well.

```
BODY         :
{
   "id": 1531,
   "type": "g6-standard-2",
   "count": 3,
   "linodes": [
      {
         "id": 19266821,
         "status": "ready"
      },
      {
         "id": 19266825,
         "status": "ready"
      },
      {
         "id": 19266823,
         "status": "ready"
      }
   ]
}
==============================================================================
type=&linodego.LKEClusterPool{ID:1531, Count:3, Type:"", Linodes:[]linodego.LKEClusterPoolLinode{linodego.LKEClusterPoolLinode{ID:(*int)(0xc0000aa620), Status:"ready"}, linodego.LKEClusterPoolLinode{ID:(*int)(0xc0000aa638), Status:"ready"}, linodego.LKEClusterPoolLinode{ID:(*int)(0xc0000aa650), Status:"ready"}}}
```