### PR TITLE
Add SetRetryAfterRateLimit to Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * add `CreateLKECluster`, `GetLKECluster`, `ListLKEClusters`, `UpdateLKECluster`, `DeleteLKECluster`
 * add `CreateLKEClusterPool`, `GetLKEClusterPool`, `ListLKEClusterPools`, `UpdateLKEClusterPool`, `DeleteLKEClusterPool`, `WaitForLKEClusterStatus`
 * add `ListLKEVersions`, `GetLKEVersion`, `GetLKEClusterAPIEndpoint`, `GetLKEClusterKubeconfig`
+* add `SetRetryAfterRateLimit`
 
 ## [v0.12.2] (2019-12-03)
 


### PR DESCRIPTION
`SetRetryAfterRateLimit` sets the client to retry on 429 responses so linodego is able to more gracefully handle API rate limits.