### PR TITLE
Improve documentation comments

### DIFF
--- a/account_events.go
+++ b/account_events.go
@@ -179,6 +179,7 @@ func (EventsPagedResponse) endpoint(c *Client) string {
 	return endpoint
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Event) UnmarshalJSON(b []byte) error {
 	type Mask Event
 

--- a/account_invoices.go
+++ b/account_invoices.go
@@ -61,6 +61,7 @@ func (c *Client) ListInvoices(ctx context.Context, opts *ListOptions) ([]Invoice
 	return response.Data, nil
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Invoice) UnmarshalJSON(b []byte) error {
 	type Mask Invoice
 
@@ -80,6 +81,7 @@ func (i *Invoice) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *InvoiceItem) UnmarshalJSON(b []byte) error {
 	type Mask InvoiceItem
 

--- a/account_notifications.go
+++ b/account_notifications.go
@@ -93,6 +93,7 @@ func (c *Client) ListNotifications(ctx context.Context, opts *ListOptions) ([]No
 	return response.Data, nil
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Notification) UnmarshalJSON(b []byte) error {
 	type Mask Notification
 

--- a/account_payments.go
+++ b/account_payments.go
@@ -30,6 +30,7 @@ type PaymentCreateOptions struct {
 	USD json.Number `json:"usd,Number"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Payment) UnmarshalJSON(b []byte) error {
 	type Mask Payment
 

--- a/client.go
+++ b/client.go
@@ -141,11 +141,13 @@ func (c *Client) SetBaseURL(url string) *Client {
 	return c
 }
 
+// SetAPIVersion sets the version of the API to interface with
 func (c *Client) SetAPIVersion(apiVersion string) *Client {
 	c.SetBaseURL(fmt.Sprintf("%s://%s/%s", APIProto, APIHost, apiVersion))
 	return c
 }
 
+// SetRootCertificate adds a root certificate to the underlying TLS client config
 func (c *Client) SetRootCertificate(path string) *Client {
 	c.resty.SetRootCertificate(path)
 	return c

--- a/images.go
+++ b/images.go
@@ -37,6 +37,7 @@ type ImageUpdateOptions struct {
 	Description *string `json:"description,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Image) UnmarshalJSON(b []byte) error {
 	type Mask Image
 

--- a/instance_configs.go
+++ b/instance_configs.go
@@ -89,6 +89,7 @@ type InstanceConfigUpdateOptions struct {
 	VirtMode   string `json:"virt_mode,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *InstanceConfig) UnmarshalJSON(b []byte) error {
 	type Mask InstanceConfig
 

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -96,6 +96,7 @@ func (c *Client) ListInstanceDisks(ctx context.Context, linodeID int, opts *List
 	return response.Data, nil
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *InstanceDisk) UnmarshalJSON(b []byte) error {
 	type Mask InstanceDisk
 

--- a/instance_snapshots.go
+++ b/instance_snapshots.go
@@ -61,6 +61,7 @@ var (
 	SnapshotUserAborted         InstanceSnapshotStatus = "userAborted"
 )
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *InstanceSnapshot) UnmarshalJSON(b []byte) error {
 	type Mask InstanceSnapshot
 

--- a/instances.go
+++ b/instances.go
@@ -172,7 +172,7 @@ type InstanceCloneOptions struct {
 	Configs        []int  `json:"configs,omitempty"`
 }
 
-// InstanceResizeOptions
+// InstanceResizeOptions is an options struct used when resizing an instance
 type InstanceResizeOptions struct {
 	Type string `json:"type"`
 
@@ -227,7 +227,7 @@ func (c *Client) GetInstance(ctx context.Context, linodeID int) (*Instance, erro
 	return r.Result().(*Instance), nil
 }
 
-// GetInstance gets the instance with the provided ID
+// GetInstanceTransfer gets the instance with the provided ID
 func (c *Client) GetInstanceTransfer(ctx context.Context, linodeID int) (*InstanceTransfer, error) {
 	e, err := c.Instances.Endpoint()
 	if err != nil {

--- a/instances.go
+++ b/instances.go
@@ -124,6 +124,7 @@ type InstanceUpdateOptions struct {
 	Tags            *[]string       `json:"tags,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Instance) UnmarshalJSON(b []byte) error {
 	type Mask Instance
 

--- a/lke_clusters.go
+++ b/lke_clusters.go
@@ -9,6 +9,7 @@ import (
 	"github.com/linode/linodego/internal/parseabletime"
 )
 
+// LKEClusterStatus represents the status of an LKECluster
 type LKEClusterStatus string
 
 // LKEClusterStatus enums start with LKECluster

--- a/lke_clusters.go
+++ b/lke_clusters.go
@@ -58,6 +58,7 @@ type LKEVersion struct {
 	ID string `json:"id"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *LKECluster) UnmarshalJSON(b []byte) error {
 	type Mask LKECluster
 

--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -61,6 +61,7 @@ type NodeBalancerUpdateOptions struct {
 	Tags               *[]string `json:"tags,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *NodeBalancer) UnmarshalJSON(b []byte) error {
 	type Mask NodeBalancer
 

--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -18,6 +18,7 @@ type ObjectStorageBucket struct {
 	Hostname string     `json:"hostname"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *ObjectStorageBucket) UnmarshalJSON(b []byte) error {
 	type Mask ObjectStorageBucket
 

--- a/object_storage_keys.go
+++ b/object_storage_keys.go
@@ -94,7 +94,7 @@ func (c *Client) GetObjectStorageKey(ctx context.Context, id int) (*ObjectStorag
 	return r.Result().(*ObjectStorageKey), nil
 }
 
-// UpdateObjKey updates the object storage key with the specified id
+// UpdateObjectStorageKey updates the object storage key with the specified id
 func (c *Client) UpdateObjectStorageKey(ctx context.Context, id int, updateOpts ObjectStorageKeyUpdateOptions) (*ObjectStorageKey, error) {
 	var body string
 	e, err := c.ObjectStorageKeys.Endpoint()

--- a/profile_sshkeys.go
+++ b/profile_sshkeys.go
@@ -28,6 +28,7 @@ type SSHKeyUpdateOptions struct {
 	Label string `json:"label"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *SSHKey) UnmarshalJSON(b []byte) error {
 	type Mask SSHKey
 

--- a/profile_tokens.go
+++ b/profile_tokens.go
@@ -49,6 +49,7 @@ type TokenUpdateOptions struct {
 	Label string `json:"label"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Token) UnmarshalJSON(b []byte) error {
 	type Mask Token
 

--- a/stackscripts.go
+++ b/stackscripts.go
@@ -63,6 +63,7 @@ type StackscriptCreateOptions struct {
 // StackscriptUpdateOptions fields are those accepted by UpdateStackscript
 type StackscriptUpdateOptions StackscriptCreateOptions
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Stackscript) UnmarshalJSON(b []byte) error {
 	type Mask Stackscript
 

--- a/volumes.go
+++ b/volumes.go
@@ -72,6 +72,7 @@ type VolumesPagedResponse struct {
 	Data []Volume `json:"data"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface
 func (v *Volume) UnmarshalJSON(b []byte) error {
 	type Mask Volume
 


### PR DESCRIPTION
`golint` has brought to attention several missing and incorrectly formatted doc comments. This PR resolves all of them.
