### PR TITLE
Fix bad JSON tags

### DIFF
--- a/lke_cluster_pools.go
+++ b/lke_cluster_pools.go
@@ -18,7 +18,7 @@ const (
 
 // LKEClusterPoolLinode represents a LKEClusterPoolLinode object
 type LKEClusterPoolLinode struct {
-	ID     *int            `json:"id"`
+	ID     string          `json:"id"`
 	Status LKELinodeStatus `json:"status"`
 }
 
@@ -27,7 +27,7 @@ type LKEClusterPool struct {
 	ID      int                    `json:"id"`
 	Count   int                    `json:"count"`
 	Type    string                 `json:"type"`
-	Linodes []LKEClusterPoolLinode `json:"linodes"`
+	Linodes []LKEClusterPoolLinode `json:"nodes"`
 }
 
 // LKEClusterPoolCreateOptions fields are those accepted by CreateLKEClusterPool


### PR DESCRIPTION
Unmarshalling did not work properly due to bad JSON tags, here is the response. Also the `id` for the nodes is a `string`. 

```json
{
  "data": [
    {
      "id": 1831,
      "type": "g6-standard-2",
      "count": 3,
      "nodes": [
        {
          "id": "1831-5e47cf804ba4",
          "instance_id": 19430031,
          "status": "ready"
        },
        {
          "id": "1831-5e47cf805247",
          "instance_id": 19430032,
          "status": "ready"
        },
        {
          "id": "1831-5e47cf80578b",
          "instance_id": 19430034,
          "status": "ready"
        }
      ]
    }
  ],
  "page": 1,
  "pages": 1,
  "results": 1
}
```

