### PR TITLE
WaitForLKEClusterPoolStatus feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 
 * add `CreateLKECluster`, `GetLKECluster`, `ListLKEClusters`, `UpdateLKECluster`, `DeleteLKECluster`
-* add `CreateLKEClusterPool`, `GetLKEClusterPool`, `ListLKEClusterPools`, `UpdateLKEClusterPool`, `DeleteLKEClusterPool`, `WaitForLKEClusterStatus`
+* add `CreateLKEClusterPool`, `GetLKEClusterPool`, `ListLKEClusterPools`, `UpdateLKEClusterPool`, `DeleteLKEClusterPool`, `WaitForLKEClusterStatus`, `WaitForLKEClusterPoolStatus`
 * add `ListLKEVersions`, `GetLKEVersion`, `GetLKEClusterAPIEndpoint`, `GetLKEClusterKubeconfig`
 
 ## [v0.12.2] (2019-12-03)

--- a/lke_cluster_pools.go
+++ b/lke_cluster_pools.go
@@ -18,7 +18,7 @@ const (
 
 // LKEClusterPoolLinode represents a LKEClusterPoolLinode object
 type LKEClusterPoolLinode struct {
-	ID     *int            `json:"id"`
+	ID     string          `json:"id"`
 	Status LKELinodeStatus `json:"status"`
 }
 
@@ -27,7 +27,7 @@ type LKEClusterPool struct {
 	ID      int                    `json:"id"`
 	Count   int                    `json:"count"`
 	Type    string                 `json:"type"`
-	Linodes []LKEClusterPoolLinode `json:"linodes"`
+	Linodes []LKEClusterPoolLinode `json:"nodes"`
 }
 
 // LKEClusterPoolCreateOptions fields are those accepted by CreateLKEClusterPool

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -35,6 +35,21 @@ func TestGetLKECluster_missing(t *testing.T) {
 	}
 }
 
+func TestLKEClusterWaitForClusterPool(t *testing.T) {
+	client, lkeCluster, teardown, err := setupLKECluster(t, []clusterModifier{func(createOpts *linodego.LKEClusterCreateOptions) {
+		createOpts.Label = randString(12, lowerBytes, digits) + "-linodego-testing"
+	}}, "fixtures/TestGetLKECluster_found")
+	defer teardown()
+	cluster, err := client.GetLKECluster(context.Background(), lkeCluster.ID)
+	if err != nil {
+		t.Errorf("Error getting LKE Cluster, got %v and error %v", cluster, err)
+	}
+	err = client.WaitForLKEClusterPoolStatus(context.Background(), cluster.ID, 300)
+	if err != nil {
+		t.Errorf("Error waiting for the LKE cluster pools to be ready %s", err)
+	}
+}
+
 func TestGetLKECluster_found(t *testing.T) {
 	client, lkeCluster, teardown, err := setupLKECluster(t, []clusterModifier{func(createOpts *linodego.LKEClusterCreateOptions) {
 		createOpts.Label = randString(12, lowerBytes, digits) + "-linodego-testing"

--- a/waitfor.go
+++ b/waitfor.go
@@ -207,10 +207,10 @@ func (client Client) WaitForLKEClusterPoolStatus(ctx context.Context, clusterID 
 			allNodesReady := func(p []LKEClusterPool) bool {
 				var tNodes int
 				for _, pool := range p {
-					tNodes = tNodes + pool.Count
+					tNodes += pool.Count
 					for _, node := range pool.Linodes {
 						if node.Status == LKELinodeReady {
-							tNodes = tNodes - 1
+							tNodes--
 						}
 					}
 				}


### PR DESCRIPTION
While working in adding the LKE feature to the `terraform-provider-linode` I noticed that `WaitForLKEClusterStatus` returns immediately. However, this does not guarantee the LKE cluster is in ready status. The LKE Cluster is operational when all the instances in each cluster pool defined, are in ready status. 

I added a test just using this new function, it may be overkilling as it's just like `TestGetLKECluster_found`.

By adding this function, now the create LKE cluster on Terraform is more realistic:

```shell
linode_lke_cluster.beta: Still creating... [1m10s elapsed]
linode_lke_cluster.beta: Still creating... [1m20s elapsed]
linode_lke_cluster.beta: Still creating... [1m30s elapsed]
linode_lke_cluster.beta: Still creating... [1m40s elapsed]
linode_lke_cluster.beta: Creation complete after 1m48s [id=1559]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

This PR includes  #124 , I need those changes to test this functionality.