### PR TITLE
all timestamps should be pointers

### DIFF
--- a/instance_disks.go
+++ b/instance_disks.go
@@ -16,8 +16,8 @@ type InstanceDisk struct {
 	Status     DiskStatus     `json:"status"`
 	Size       int            `json:"size"`
 	Filesystem DiskFilesystem `json:"filesystem"`
-	Created    time.Time      `json:"-"`
-	Updated    time.Time      `json:"-"`
+	Created    *time.Time     `json:"-"`
+	Updated    *time.Time     `json:"-"`
 }
 
 // DiskFilesystem constants start with Filesystem and include Linode API Filesystems
@@ -112,12 +112,8 @@ func (i *InstanceDisk) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	if p.Created != nil {
-		i.Created = time.Time(*p.Created)
-	}
-	if p.Updated != nil {
-		i.Updated = time.Time(*p.Updated)
-	}
+	i.Created = (*time.Time)(p.Created)
+	i.Updated = (*time.Time)(p.Updated)
 
 	return nil
 }

--- a/test/integration/example_integration_test.go
+++ b/test/integration/example_integration_test.go
@@ -104,7 +104,7 @@ func Example() {
 		if errSwap != nil {
 			log.Fatalln("* While creating swap disk:", errSwap)
 		}
-		eventSwap, errSwapEvent := linodeClient.WaitForEventFinished(context.Background(), linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, diskSwap.Created, 240)
+		eventSwap, errSwapEvent := linodeClient.WaitForEventFinished(context.Background(), linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, *diskSwap.Created, 240)
 		// @TODO it is not sufficient that a disk was created. Which disk was it?
 		// Sounds like we'll need a WaitForEntityStatus function.
 		if errSwapEvent != nil {
@@ -118,7 +118,7 @@ func Example() {
 		if errRaw != nil {
 			log.Fatalln("* While creating raw disk:", errRaw)
 		}
-		eventRaw, errRawEvent := linodeClient.WaitForEventFinished(context.Background(), linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, diskRaw.Created, 240)
+		eventRaw, errRawEvent := linodeClient.WaitForEventFinished(context.Background(), linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, *diskRaw.Created, 240)
 		// @TODO it is not sufficient that a disk was created. Which disk was it?
 		// Sounds like we'll need a WaitForEntityStatus function.
 		if errRawEvent != nil {
@@ -142,7 +142,7 @@ func Example() {
 		if errDebian != nil {
 			log.Fatalln("* While creating Debian disk:", errDebian)
 		}
-		eventDebian, errDebianEvent := linodeClient.WaitForEventFinished(context.Background(), linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, diskDebian.Created, 240)
+		eventDebian, errDebianEvent := linodeClient.WaitForEventFinished(context.Background(), linode.ID, linodego.EntityLinode, linodego.ActionDiskCreate, *diskDebian.Created, 240)
 		// @TODO it is not sufficient that a disk was created. Which disk was it?
 		// Sounds like we'll need a WaitForEntityStatus function.
 		if errDebianEvent != nil {

--- a/test/integration/instance_snapshots_test.go
+++ b/test/integration/instance_snapshots_test.go
@@ -81,7 +81,7 @@ func setupInstanceBackup(t *testing.T, fixturesYaml string) (*linodego.Client, *
 	}
 
 	// wait for disk to finish provisioning
-	event, err := client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionDiskCreate, disk.Created, 240)
+	event, err := client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionDiskCreate, *disk.Created, 240)
 	if err != nil {
 		t.Errorf("Error waiting for instance snapshot: %v", err)
 	}

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -145,7 +145,7 @@ func TestMultiplePrivateInstanceDisk(t *testing.T) {
 		t.Errorf("Error waiting for instance readiness: %s", err)
 	}
 
-	_, err = client.WaitForEventFinished(context.Background(), instance1.ID, linodego.EntityLinode, linodego.ActionDiskImagize, disk.Created, 300)
+	_, err = client.WaitForEventFinished(context.Background(), instance1.ID, linodego.EntityLinode, linodego.ActionDiskImagize, *disk.Created, 300)
 	if err != nil {
 		t.Errorf("Error waiting for imagize event: %s", err)
 	}

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -23,8 +23,8 @@ func TestCreateVolume(t *testing.T) {
 		t.Errorf("Expected a volumes id, but got 0")
 	}
 
-	assertDateSet(t, &volume.Created)
-	assertDateSet(t, &volume.Updated)
+	assertDateSet(t, volume.Created)
+	assertDateSet(t, volume.Updated)
 
 	if err := client.DeleteVolume(context.Background(), volume.ID); err != nil {
 		t.Errorf("Expected to delete a volume, but got %v", err)
@@ -81,8 +81,8 @@ func TestGetVolume(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting volume %d, expected *LinodeVolume, got error %v", volume.ID, err)
 	}
-	assertDateSet(t, &volume.Created)
-	assertDateSet(t, &volume.Updated)
+	assertDateSet(t, volume.Created)
+	assertDateSet(t, volume.Updated)
 }
 
 func TestWaitForVolumeLinodeID_nil(t *testing.T) {

--- a/volumes.go
+++ b/volumes.go
@@ -36,8 +36,8 @@ type Volume struct {
 	LinodeID       *int         `json:"linode_id"`
 	FilesystemPath string       `json:"filesystem_path"`
 	Tags           []string     `json:"tags"`
-	Created        time.Time    `json:"-"`
-	Updated        time.Time    `json:"-"`
+	Created        *time.Time   `json:"-"`
+	Updated        *time.Time   `json:"-"`
 }
 
 // VolumeCreateOptions fields are those accepted by CreateVolume
@@ -88,8 +88,8 @@ func (v *Volume) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	v.Created = time.Time(*p.Created)
-	v.Updated = time.Time(*p.Updated)
+	v.Created = (*time.Time)(p.Created)
+	v.Updated = (*time.Time)(p.Updated)
 
 	return nil
 }


### PR DESCRIPTION
~~This change removes all dereferences of timestamps on resources that don't use pointers.~~

~~Sometimes, mysteriously, the API can omit timestamps. With these implementations of `UnmarshalJSON`, a panic will occur because of a 'nil dereference' (like with terraform-providers/terraform-provider-linode#152).~~

This change changes all `time.Time` fields on resources to `*time.Time`.