### PR TITLE
make ClusterConditionFunc's adhere to k8s waiter convention

### DIFF
--- a/k8s/pkg/condition/lke.go
+++ b/k8s/pkg/condition/lke.go
@@ -2,7 +2,6 @@ package condition
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/linode/linodego"
@@ -31,8 +30,7 @@ func ClusterHasReadyNode(ctx context.Context, options linodego.ClusterConditionO
 			}
 		}
 	}
-
-	return false, errors.New("no nodes in cluster are ready")
+	return false, nil
 }
 
 // WaitForLKEClusterReady polls with a given timeout for the LKE Cluster's api-server

--- a/waitfor.go
+++ b/waitfor.go
@@ -221,7 +221,6 @@ func (client Client) WaitForLKEClusterConditions(
 	}
 	defer cancel()
 
-	var prevLog string
 	lkeKubeConfig, err := client.GetLKEClusterKubeconfig(ctx, clusterID)
 	if err != nil {
 		return fmt.Errorf("failed to get Kubeconfig for LKE cluster %d: %s", clusterID, err)
@@ -239,10 +238,7 @@ func (client Client) WaitForLKEClusterConditions(
 			case <-ticker.C:
 				result, err := condition(ctx, conditionOptions)
 				if err != nil {
-					if err.Error() != prevLog {
-						prevLog = err.Error()
-						log.Printf("[ERROR] %s\n", err)
-					}
+					return err
 				}
 
 				if result {


### PR DESCRIPTION
See: https://godoc.org/gopkg.in/kubernetes/client-go.v1/1.5/pkg/util/wait#ConditionFunc
> ConditionFunc returns true if the condition is satisfied, or an error if the loop should be aborted.
