### PR TITLE
Responds to api changes for Firewalls

### DIFF
--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -17,21 +17,26 @@ const (
 
 // NetworkAddresses are arrays of ipv4 and v6 addresses
 type NetworkAddresses struct {
-	IPv4 []string `json:"ipv4,omitempty"`
-	IPv6 []string `json:"ipv6,omitempty"`
+	IPv4 *[]string `json:"ipv4,omitempty"`
+	IPv6 *[]string `json:"ipv6,omitempty"`
 }
 
 // A FirewallRule is a whitelist of ports, protocols, and addresses for which traffic should be allowed.
 type FirewallRule struct {
-	Ports     string           `json:"ports,omitempty"`
-	Protocol  NetworkProtocol  `json:"protocol"`
-	Addresses NetworkAddresses `json:"addresses"`
+	Action      string           `json:"action"`
+	Label       string           `json:"label"`
+	Description string           `json:"description,omitempty"`
+	Ports       string           `json:"ports,omitempty"`
+	Protocol    NetworkProtocol  `json:"protocol"`
+	Addresses   NetworkAddresses `json:"addresses"`
 }
 
 // FirewallRuleSet is a pair of inbound and outbound rules that specify what network traffic should be allowed.
 type FirewallRuleSet struct {
-	Inbound  []FirewallRule `json:"inbound,omitempty"`
-	Outbound []FirewallRule `json:"outbound,omitempty"`
+	Inbound        []FirewallRule `json:"inbound"`
+	InboundPolicy  string         `json:"inbound_policy"`
+	Outbound       []FirewallRule `json:"outbound"`
+	OutboundPolicy string         `json:"outbound_policy"`
 }
 
 // GetFirewallRules gets the FirewallRuleSet for the given Firewall.

--- a/test/integration/firewalls_test.go
+++ b/test/integration/firewalls_test.go
@@ -53,13 +53,17 @@ func TestGetFirewall(t *testing.T) {
 	rules := linodego.FirewallRuleSet{
 		Inbound: []linodego.FirewallRule{
 			{
+				Label: "test-label",
+				Action: "DROP",
 				Protocol: linodego.ICMP,
 				Addresses: linodego.NetworkAddresses{
-					IPv4: []string{"10.20.30.40/0"},
-					IPv6: []string{"1234::5678/0"},
+					IPv4: &[]string{"0.0.0.0/0"},
+					IPv6: &[]string{"::/0"},
 				},
 			},
 		},
+		InboundPolicy: "ACCEPT",
+		OutboundPolicy: "ACCEPT",
 	}
 	client, created, teardown, err := setupFirewall(t, []firewallModifier{
 		func(createOpts *linodego.FirewallCreateOptions) {
@@ -85,14 +89,18 @@ func TestGetFirewall(t *testing.T) {
 func TestUpdateFirewall(t *testing.T) {
 	label := randString(12, lowerBytes, upperBytes) + "-linodego-testing"
 	rules := linodego.FirewallRuleSet{
+		InboundPolicy: "ACCEPT",
 		Inbound: []linodego.FirewallRule{
 			{
+				Label: "test-label",
+				Action: "DROP",
 				Protocol: linodego.ICMP,
 				Addresses: linodego.NetworkAddresses{
-					IPv4: []string{"0.0.0.0/0"},
+					IPv4: &[]string{"0.0.0.0/0"},
 				},
 			},
 		},
+		OutboundPolicy: "ACCEPT",
 	}
 
 	client, firewall, teardown, err := setupFirewall(t, []firewallModifier{

--- a/test/integration/fixtures/TestDeleteFirewallDevice.yaml
+++ b/test/integration/fixtures/TestDeleteFirewallDevice.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"region":"us-west","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
+    body: '{"region":"ca-central","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -10,18 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 20346485, "label": "linodego-test-instance", "group": "", "status":
-      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["10.20.30.40"], "ipv6": "1234::5678/64",
-      "image": "linode/debian9", "region": "us-west", "specs": {"disk": 25600, "memory":
-      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
-      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
-      false, "schedule": {"day": null, "window": null}, "last_successful": null},
-      "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 25176408, "label": "linodego-test-instance", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["172.105.106.103"], "ipv6": "2600:3c04::f03c:92ff:fe52:748e/64", "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -36,15 +29,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "636"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:55:32 GMT
-      Retry-After:
-      - "117"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -61,20 +50,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1599"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"label","rules":{"inbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}],"outbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}]},"tags":["testing"],"devices":{}}'
+    body: '{"label":"label","rules":{"inbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"inbound_policy":"ACCEPT","outbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"outbound_policy":"ACCEPT"},"tags":["testing"],"devices":{}}'
     form: {}
     headers:
       Accept:
@@ -82,15 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 191, "label": "label", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"ports":
-      "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}],
-      "outbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"],
-      "ipv6": ["1234::5678/0"]}}]}, "tags": ["testing"]}'
+    body: '{"id": 3414, "label": "label", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -105,15 +84,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "363"
+      - "505"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:55:33 GMT
-      Retry-After:
-      - "117"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -130,20 +105,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1598"
-      X-Ratelimit-Reset:
-      - "1588633051"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"id":20346485,"type":"linode"}'
+    body: '{"id":25176408,"type":"linode"}'
     form: {}
     headers:
       Accept:
@@ -151,13 +120,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/191/devices
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3414/devices
     method: POST
   response:
-    body: '{"id": 2685, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "entity": {"id": 20346485, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/20346485"}}'
+    body: '{"id": 16563, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "entity": {"id": 25176408, "type": "linode", "label": "linodego-test-instance", "url": "/v4/linode/instances/25176408"}}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -172,15 +139,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "201"
+      - "202"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:55:33 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -197,13 +160,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1597"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -218,8 +175,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/191/devices/2685
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3414/devices/16563
     method: DELETE
   response:
     body: '{}'
@@ -242,10 +199,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:55:33 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -262,13 +215,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1596"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -283,8 +230,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/191/devices/2685
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3414/devices/16563
     method: GET
   response:
     body: '{"errors": [{"reason": "Not found"}]}'
@@ -301,10 +248,6 @@ interactions:
       - "37"
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:55:33 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Vary:
@@ -316,13 +259,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1595"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
     status: 404 Not Found
     code: 404
     duration: ""
@@ -335,8 +272,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/191
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3414
     method: DELETE
   response:
     body: '{}'
@@ -359,10 +296,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:55:33 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -379,13 +312,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1594"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -400,8 +327,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/20346485
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25176408
     method: DELETE
   response:
     body: '{}'
@@ -424,10 +351,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:55:34 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -444,13 +367,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1593"
-      X-Ratelimit-Reset:
-      - "1588633051"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestGetFirewall.yaml
+++ b/test/integration/fixtures/TestGetFirewall.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"label":"KBFddmZeCExb-linodego-testing","rules":{"inbound":[{"protocol":"ICMP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}]},"tags":["testing"],"devices":{}}'
+    body: '{"label":"KBFddmZeCExb-linodego-testing","rules":{"inbound":[{"action":"DROP","label":"test-label","protocol":"ICMP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::/0"]}}],"inbound_policy":"ACCEPT","outbound":null,"outbound_policy":"ACCEPT"},"tags":["testing"],"devices":{}}'
     form: {}
     headers:
       Accept:
@@ -10,14 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 137, "label": "KBFddmZeCExb-linodego-testing", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
-      [{"protocol": "ICMP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}]},
-      "tags": ["testing"]}'
+    body: '{"id": 3416, "label": "KBFddmZeCExb-linodego-testing", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "DROP", "label": "test-label", "protocol": "ICMP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": null, "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -32,15 +29,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "266"
+      - "382"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Sat, 11 Apr 2020 23:26:36 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -55,15 +48,9 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write,domains:read_write,events:read_write,images:read_write,ips:read_write,linodes:read_write,lke:read_write,longview:read_write,nodebalancers:read_write,stackscripts:read_write,volumes:read_write,firewall:read_write
+      - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1599"
-      X-Ratelimit-Reset:
-      - "1586647716"
-      X-Spec-Version:
-      - 4.62.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -78,14 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/137
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3416
     method: GET
   response:
-    body: '{"id": 137, "label": "KBFddmZeCExb-linodego-testing", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
-      [{"protocol": "ICMP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}]},
-      "tags": ["testing"]}'
+    body: '{"id": 3416, "label": "KBFddmZeCExb-linodego-testing", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "DROP", "label": "test-label", "protocol": "ICMP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": null, "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -101,15 +85,11 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "266"
+      - "382"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Sat, 11 Apr 2020 23:26:37 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -125,15 +105,9 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write,domains:read_write,events:read_write,images:read_write,ips:read_write,linodes:read_write,lke:read_write,longview:read_write,nodebalancers:read_write,stackscripts:read_write,volumes:read_write,firewall:read_write
+      - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1598"
-      X-Ratelimit-Reset:
-      - "1586647717"
-      X-Spec-Version:
-      - 4.62.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -148,8 +122,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/137
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3416
     method: DELETE
   response:
     body: '{}'
@@ -172,10 +146,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Sat, 11 Apr 2020 23:26:37 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -190,15 +160,9 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write,domains:read_write,events:read_write,images:read_write,ips:read_write,linodes:read_write,lke:read_write,longview:read_write,nodebalancers:read_write,stackscripts:read_write,volumes:read_write,firewall:read_write
+      - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1597"
-      X-Ratelimit-Reset:
-      - "1586647717"
-      X-Spec-Version:
-      - 4.62.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestGetFirewallDevice.yaml
+++ b/test/integration/fixtures/TestGetFirewallDevice.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"region":"us-west","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
+    body: '{"region":"ca-central","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -10,18 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 20346491, "label": "linodego-test-instance", "group": "", "status":
-      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["10.20.30.40"], "ipv6": "1234::5678/64",
-      "image": "linode/debian9", "region": "us-west", "specs": {"disk": 25600, "memory":
-      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
-      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
-      false, "schedule": {"day": null, "window": null}, "last_successful": null},
-      "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 25176406, "label": "linodego-test-instance", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["172.105.13.182"], "ipv6": "2600:3c04::f03c:92ff:fe52:747b/64", "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -36,15 +29,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "635"
+      - "641"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:25 GMT
-      Retry-After:
-      - "64"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -61,20 +50,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1587"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"label","rules":{"inbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}],"outbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}]},"tags":["testing"],"devices":{}}'
+    body: '{"label":"label","rules":{"inbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"inbound_policy":"ACCEPT","outbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"outbound_policy":"ACCEPT"},"tags":["testing"],"devices":{}}'
     form: {}
     headers:
       Accept:
@@ -82,15 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 193, "label": "label", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"ports":
-      "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}],
-      "outbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"],
-      "ipv6": ["1234::5678/0"]}}]}, "tags": ["testing"]}'
+    body: '{"id": 3413, "label": "label", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -105,15 +84,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "363"
+      - "505"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:25 GMT
-      Retry-After:
-      - "64"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -130,20 +105,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1586"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"id":20346491,"type":"linode"}'
+    body: '{"id":25176406,"type":"linode"}'
     form: {}
     headers:
       Accept:
@@ -151,13 +120,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/193/devices
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3413/devices
     method: POST
   response:
-    body: '{"id": 2687, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "entity": {"id": 20346491, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/20346491"}}'
+    body: '{"id": 16562, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "entity": {"id": 25176406, "type": "linode", "label": "linodego-test-instance", "url": "/v4/linode/instances/25176406"}}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -172,15 +139,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "201"
+      - "202"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:26 GMT
-      Retry-After:
-      - "64"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -197,13 +160,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1585"
-      X-Ratelimit-Reset:
-      - "1588633051"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -218,13 +175,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/193/devices/2687
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3413/devices/16562
     method: GET
   response:
-    body: '{"id": 2687, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "entity": {"id": 20346491, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/20346491"}}'
+    body: '{"id": 16562, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "entity": {"id": 25176406, "type": "linode", "label": "linodego-test-instance", "url": "/v4/linode/instances/25176406"}}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -240,15 +195,11 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "201"
+      - "202"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:26 GMT
-      Retry-After:
-      - "64"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -266,13 +217,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1584"
-      X-Ratelimit-Reset:
-      - "1588633051"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -287,8 +232,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/193
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3413
     method: DELETE
   response:
     body: '{}'
@@ -311,10 +256,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:26 GMT
-      Retry-After:
-      - "63"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -331,13 +272,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1583"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -352,8 +287,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/20346491
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25176406
     method: DELETE
   response:
     body: '{}'
@@ -376,10 +311,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:26 GMT
-      Retry-After:
-      - "63"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -396,13 +327,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1582"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestGetFirewallRules.yaml
+++ b/test/integration/fixtures/TestGetFirewallRules.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"label":"label","rules":{"inbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}],"outbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}]},"tags":["testing"],"devices":{}}'
+    body: '{"label":"label","rules":{"inbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"inbound_policy":"ACCEPT","outbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"outbound_policy":"ACCEPT"},"tags":["testing"],"devices":{}}'
     form: {}
     headers:
       Accept:
@@ -10,15 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 217, "label": "label", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"ports":
-      "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}],
-      "outbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"],
-      "ipv6": ["1234::5678/0"]}}]}, "tags": ["testing"]}'
+    body: '{"id": 3410, "label": "label", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -33,15 +29,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "363"
+      - "505"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Tue, 19 May 2020 16:26:33 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -58,13 +50,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1599"
-      X-Ratelimit-Reset:
-      - "1589905713"
-      X-Spec-Version:
-      - 4.65.1
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -79,13 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/217/rules
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3410/rules
     method: GET
   response:
-    body: '{"inbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"],
-      "ipv6": ["1234::5678/0"]}}], "outbound": [{"ports": "22", "protocol": "TCP", "addresses":
-      {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}]}'
+    body: '{"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -101,15 +85,11 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "213"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Tue, 19 May 2020 16:26:33 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -127,13 +107,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1598"
-      X-Ratelimit-Reset:
-      - "1589905713"
-      X-Spec-Version:
-      - 4.65.1
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -148,8 +122,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/217
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3410
     method: DELETE
   response:
     body: '{}'
@@ -172,10 +146,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Tue, 19 May 2020 16:26:33 GMT
-      Retry-After:
-      - "118"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -192,13 +162,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1597"
-      X-Ratelimit-Reset:
-      - "1589905712"
-      X-Spec-Version:
-      - 4.65.1
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestListFirewallDevices.yaml
+++ b/test/integration/fixtures/TestListFirewallDevices.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"region":"us-west","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
+    body: '{"region":"ca-central","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -10,18 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 20346486, "label": "linodego-test-instance", "group": "", "status":
-      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["10.20.30.40"], "ipv6": "1234::5678/64",
-      "image": "linode/debian9", "region": "us-west", "specs": {"disk": 25600, "memory":
-      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
-      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
-      false, "schedule": {"day": null, "window": null}, "last_successful": null},
-      "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 25176403, "label": "linodego-test-instance", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["172.105.23.19"], "ipv6": "2600:3c04::f03c:92ff:fe52:74c3/64", "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -36,15 +29,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "636"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:06 GMT
-      Retry-After:
-      - "83"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -61,20 +50,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1592"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"label","rules":{"inbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}],"outbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}]},"tags":["testing"],"devices":{"linodes":[20346486]}}'
+    body: '{"label":"label","rules":{"inbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"inbound_policy":"ACCEPT","outbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"outbound_policy":"ACCEPT"},"tags":["testing"],"devices":{"linodes":[25176403]}}'
     form: {}
     headers:
       Accept:
@@ -82,15 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 192, "label": "label", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"ports":
-      "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}],
-      "outbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"],
-      "ipv6": ["1234::5678/0"]}}]}, "tags": ["testing"]}'
+    body: '{"id": 3412, "label": "label", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -105,15 +84,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "363"
+      - "505"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:07 GMT
-      Retry-After:
-      - "83"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -130,13 +105,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1591"
-      X-Ratelimit-Reset:
-      - "1588633051"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -151,14 +120,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/192/devices
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3412/devices
     method: GET
   response:
-    body: '{"data": [{"id": 2686, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "entity": {"id": 20346486, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/20346486"}}], "page": 1, "pages": 1, "results":
-      1}'
+    body: '{"data": [{"id": 16561, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "entity": {"id": 25176403, "type": "linode", "label": "linodego-test-instance", "url": "/v4/linode/instances/25176403"}}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -174,15 +140,11 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "250"
+      - "251"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:07 GMT
-      Retry-After:
-      - "83"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -200,13 +162,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1590"
-      X-Ratelimit-Reset:
-      - "1588633051"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -221,8 +177,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/192
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3412
     method: DELETE
   response:
     body: '{}'
@@ -245,10 +201,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:07 GMT
-      Retry-After:
-      - "82"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -265,13 +217,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1589"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -286,8 +232,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/20346486
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25176403
     method: DELETE
   response:
     body: '{}'
@@ -310,10 +256,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 04 May 2020 22:56:07 GMT
-      Retry-After:
-      - "82"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -330,13 +272,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1588"
-      X-Ratelimit-Reset:
-      - "1588633050"
-      X-Spec-Version:
-      - 4.64.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestListFirewalls.yaml
+++ b/test/integration/fixtures/TestListFirewalls.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"label":"a83ef3go2h76-linodego-testing","rules":{"inbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}],"outbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":["1234::5678/0"]}}]},"tags":["testing"],"devices":{}}'
+    body: '{"label":"aSTefFgoEhTM-linodego-testing","rules":{"inbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"inbound_policy":"ACCEPT","outbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"outbound_policy":"ACCEPT"},"tags":["testing"],"devices":{}}'
     form: {}
     headers:
       Accept:
@@ -10,15 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 37, "label": "a83ef3go2h76-linodego-testing", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
-      [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6":
-      ["1234::5678/0"]}}], "outbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4":
-      ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}]}, "tags": ["testing"]}'
+    body: '{"id": 3415, "label": "aSTefFgoEhTM-linodego-testing", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -32,18 +28,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "386"
+      - "529"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Wed, 19 Feb 2020 19:38:16 GMT
-      Retry-After:
-      - "41"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -60,13 +50,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1593"
-      X-Ratelimit-Reset:
-      - "1582141138"
-      X-Spec-Version:
-      - 4.14.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -81,44 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: GET
   response:
-    body: '{"data": [{"id": 19, "label": "firewall19", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "disabled", "rules": {"inbound":
-      [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40"]}}]},
-      "tags": []}, {"id": 20, "label": "firewall20", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "disabled", "rules": {"inbound":
-      [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40"]}}]},
-      "tags": []}, {"id": 31, "label": "firewall31", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "disabled", "rules": {"inbound":
-      [{"ports": "3306", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6":
-      ["1234::5678/0"]}}], "outbound": [{"ports": "3306", "protocol": "TCP", "addresses":
-      {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}]}, "tags": []}, {"id": 32, "label":
-      "blah", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "status": "enabled", "rules": {"inbound": [{"ports": "80", "protocol": "TCP",
-      "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}, {"ports": "443", "protocol":
-      "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}], "outbound":
-      [{"ports": "80", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6":
-      ["1234::5678/0"]}}, {"ports": "443", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"],
-      "ipv6": ["1234::5678/0"]}}]}, "tags": []}, {"id": 33, "label": "test-firewall", "created":
-      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled",
-      "rules": {"inbound": [{"ports": "80", "protocol": "TCP", "addresses": {"ipv4":
-      ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}, {"ports": "443", "protocol": "TCP", "addresses":
-      {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}], "outbound": [{"ports": "80", "protocol":
-      "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}, {"ports": "443",
-      "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}]},
-      "tags": []}, {"id": 34, "label": "asdf", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "status": "disabled", "rules": {"inbound": [{"ports":
-      "443", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}],
-      "outbound": [{"ports": "443", "protocol": "TCP", "addresses": {"ipv4": ["10.20.30.40/0"],
-      "ipv6": ["1234::5678/0"]}}]}, "tags": []}, {"id": 37, "label": "a83ef3go2h76-linodego-testing",
-      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status":
-      "enabled", "rules": {"inbound": [{"ports": "22", "protocol": "TCP", "addresses":
-      {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}], "outbound": [{"ports": "22", "protocol":
-      "TCP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": ["1234::5678/0"]}}]}, "tags": ["testing"]}],
-      "page": 1, "pages": 1, "results": 7}'
+    body: '{"data": [{"id": 3196, "label": "asdfasdf", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound_policy": "DROP", "outbound_policy": "ACCEPT", "inbound": [{"label": "accept-inbound-SSH", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}, "action": "ACCEPT"}, {"label": "accept-inbound-DNS", "ports": "53", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}, "action": "ACCEPT"}], "outbound": []}, "tags": []}, {"id": 3415, "label": "aSTefFgoEhTM-linodego-testing", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}, "tags": ["testing"]}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -133,16 +84,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Wed, 19 Feb 2020 19:38:16 GMT
-      Retry-After:
-      - "41"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -160,13 +105,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1592"
-      X-Ratelimit-Reset:
-      - "1582141138"
-      X-Spec-Version:
-      - 4.14.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -181,8 +120,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/37
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3415
     method: DELETE
   response:
     body: '{}'
@@ -199,18 +138,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Wed, 19 Feb 2020 19:38:17 GMT
-      Retry-After:
-      - "40"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -227,13 +160,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1591"
-      X-Ratelimit-Reset:
-      - "1582141138"
-      X-Spec-Version:
-      - 4.14.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestUpdateFirewall.yaml
+++ b/test/integration/fixtures/TestUpdateFirewall.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"label":"aSTefFgoEhTM-linodego-testing","rules":{"inbound":[{"protocol":"ICMP","addresses":{"ipv4":["10.20.30.40/0"],"ipv6":null}}]},"tags":["test"],"devices":{}}'
+    body: '{"label":"NaAiTackNOYy-linodego-testing","rules":{"inbound":[{"action":"DROP","label":"test-label","protocol":"ICMP","addresses":{"ipv4":["0.0.0.0/0"]}}],"inbound_policy":"ACCEPT","outbound":null,"outbound_policy":"ACCEPT"},"tags":["test"],"devices":{}}'
     form: {}
     headers:
       Accept:
@@ -10,14 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 250, "label": "aSTefFgoEhTM-linodego-testing", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
-      [{"protocol": "ICMP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": null}}]},
-      "tags": ["test"]}'
+    body: '{"id": 3417, "label": "NaAiTackNOYy-linodego-testing", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "DROP", "label": "test-label", "protocol": "ICMP", "addresses": {"ipv4": ["0.0.0.0/0"]}}], "inbound_policy": "ACCEPT", "outbound": null, "outbound_policy": "ACCEPT"}, "tags": ["test"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -32,15 +29,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "258"
+      - "361"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Fri, 22 May 2020 13:35:21 GMT
-      Retry-After:
-      - "118"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -57,13 +50,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1595"
-      X-Ratelimit-Reset:
-      - "1590154640"
-      X-Spec-Version:
-      - 4.65.1
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -78,14 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/250
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3417
     method: PUT
   response:
-    body: '{"id": 250, "label": "updatedFirewallLabel", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "status": "disabled", "rules": {"inbound":
-      [{"protocol": "ICMP", "addresses": {"ipv4": ["10.20.30.40/0"], "ipv6": null}}]},
-      "tags": []}'
+    body: '{"id": 3417, "label": "updatedFirewallLabel", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "disabled", "rules": {"inbound": [{"action": "DROP", "label": "test-label", "protocol": "ICMP", "addresses": {"ipv4": ["0.0.0.0/0"]}}], "inbound_policy": "ACCEPT", "outbound": null, "outbound_policy": "ACCEPT"}, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -100,15 +84,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "244"
+      - "347"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Fri, 22 May 2020 13:35:22 GMT
-      Retry-After:
-      - "118"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -125,13 +105,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1594"
-      X-Ratelimit-Reset:
-      - "1590154641"
-      X-Spec-Version:
-      - 4.65.1
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -146,8 +120,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/250
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/3417
     method: DELETE
   response:
     body: '{}'
@@ -170,10 +144,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Fri, 22 May 2020 13:35:22 GMT
-      Retry-After:
-      - "118"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -190,13 +160,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1593"
-      X-Ratelimit-Reset:
-      - "1590154641"
-      X-Spec-Version:
-      - 4.65.1
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestUpdateFirewallRules.yaml
+++ b/test/integration/fixtures/TestUpdateFirewallRules.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"label":"label","rules":{"inbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["1234::5678/0"]}}],"outbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["1234::5678/0"]}}]},"tags":["testing"],"devices":{}}'
+    body: '{"label":"label","rules":{"inbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"inbound_policy":"ACCEPT","outbound":[{"action":"ACCEPT","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"outbound_policy":"ACCEPT"},"tags":["testing"],"devices":{}}'
     form: {}
     headers:
       Accept:
@@ -14,7 +14,7 @@ interactions:
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 2403, "label": "label", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["1234::5678/0"]}}], "outbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["1234::5678/0"]}}]}, "tags": ["testing"]}'
+    body: '{"id": 3411, "label": "label", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -29,7 +29,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "362"
+      - "505"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -57,7 +57,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"inbound":[{"ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"]}}]}'
+    body: '{"inbound":[{"action":"DROP","label":"test-label","ports":"22","protocol":"TCP","addresses":{"ipv4":["0.0.0.0/0"],"ipv6":["::0/0"]}}],"inbound_policy":"ACCEPT","outbound":null,"outbound_policy":"ACCEPT"}'
     form: {}
     headers:
       Accept:
@@ -66,10 +66,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/2403/rules
+    url: https://api.linode.com/v4beta/networking/firewalls/3411/rules
     method: PUT
   response:
-    body: '{"inbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"]}}], "outbound": []}'
+    body: '{"inbound": [{"action": "DROP", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": null, "outbound_policy": "ACCEPT"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -84,7 +84,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "103"
+      - "221"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -121,10 +121,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/2403/rules
+    url: https://api.linode.com/v4beta/networking/firewalls/3411/rules
     method: GET
   response:
-    body: '{"inbound": [{"ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"]}}], "outbound": []}'
+    body: '{"inbound": [{"action": "DROP", "label": "test-label", "ports": "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["::/0"]}}], "inbound_policy": "ACCEPT", "outbound": null, "outbound_policy": "ACCEPT"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -140,7 +140,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "103"
+      - "221"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -178,7 +178,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/2403
+    url: https://api.linode.com/v4beta/networking/firewalls/3411
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -325,7 +325,7 @@ func createInstance(t *testing.T, client *linodego.Client, modifiers ...instance
 	createOpts := linodego.InstanceCreateOptions{
 		Label:    "linodego-test-instance",
 		RootPass: "R34lBAdP455",
-		Region:   "us-west",
+		Region:   "ca-central",
 		Type:     "g6-nanode-1",
 		Image:    "linode/debian9",
 		Booted:   &booted,


### PR DESCRIPTION
- Changes instance region to one that supports firewalls.
- inbound_policy and outbound_policy are required.
- Firewall rule's IPv4 and IPv6 must not be set if empty.
- A firewall rule's action must be set, and Label and Description are added.
