### PR TITLE
Add ACL and CorsEnabled options to Object Storage

### DIFF
--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -42,7 +42,21 @@ func (i *ObjectStorageBucket) UnmarshalJSON(b []byte) error {
 type ObjectStorageBucketCreateOptions struct {
 	Cluster string `json:"cluster"`
 	Label   string `json:"label"`
+
+	ACL         ObjectStorageACL `json:"acl,omitempty"`
+	CorsEnabled *bool            `json:"cors_enabled,omitempty"`
 }
+
+// ObjectStorageACL options start with ACL and include all known ACL types
+type ObjectStorageACL string
+
+// ObjectStorageACL options represent the access control level of a bucket.
+const (
+	ACLPrivate           ObjectStorageACL = "private"
+	ACLPublicRead        ObjectStorageACL = "public-read"
+	ACLAuthenticatedRead ObjectStorageACL = "authenticated-read"
+	ACLPublicReadWrite   ObjectStorageACL = "public-read-write"
+)
 
 // ObjectStorageBucketsPagedResponse represents a paginated ObjectStorageBucket API response
 type ObjectStorageBucketsPagedResponse struct {

--- a/test/integration/fixtures/TestCreateObjectStorageBucket.yaml
+++ b/test/integration/fixtures/TestCreateObjectStorageBucket.yaml
@@ -1,113 +1,113 @@
 ---
 version: 1
 interactions:
-- request:
-    body: '{"cluster":"us-east-1","label":"linodego-test-bucket-1603371589949339000"}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/object-storage/buckets
-    method: POST
-  response:
-    body: '{"hostname": "linodego-test-bucket-1603371589949339000.us-east-1.linodeobjects.com", "label": "linodego-test-bucket-1603371589949339000", "created": "2018-01-02T03:04:05", "cluster": "us-east-1", "size": 0}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "206"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - object_storage:read_write
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/object-storage/buckets/us-east-1/linodego-test-bucket-1603371589949339000
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "2"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - object_storage:read_write
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
+  - request:
+      body: '{"cluster":"us-east-1","label":"linodego-test-bucket-1615917124470992000"}'
+      form: {}
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - linodego https://github.com/linode/linodego
+      url: https://api.linode.com/v4beta/object-storage/buckets
+      method: POST
+    response:
+      body: '{"hostname": "linodego-test-bucket-1615917124470992000.us-east-1.linodeobjects.com", "label": "linodego-test-bucket-1615917124470992000", "created": "2018-01-02T03:04:05", "cluster": "us-east-1", "size": 0, "objects": 0}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+        Access-Control-Allow-Methods:
+          - HEAD, GET, OPTIONS, POST, PUT, DELETE
+        Access-Control-Allow-Origin:
+          - '*'
+        Access-Control-Expose-Headers:
+          - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+        Cache-Control:
+          - private, max-age=60, s-maxage=60
+        Content-Length:
+          - "220"
+        Content-Security-Policy:
+          - default-src 'none'
+        Content-Type:
+          - application/json
+        Server:
+          - nginx
+        Strict-Transport-Security:
+          - max-age=31536000
+        Vary:
+          - Authorization, X-Filter
+        X-Accepted-Oauth-Scopes:
+          - object_storage:read_write
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+          - DENY
+        X-Oauth-Scopes:
+          - '*'
+        X-Ratelimit-Limit:
+          - "800"
+        X-Xss-Protection:
+          - 1; mode=block
+      status: 200 OK
+      code: 200
+      duration: ""
+  - request:
+      body: ""
+      form: {}
+      headers:
+        Accept:
+          - application/json
+        Content-Type:
+          - application/json
+        User-Agent:
+          - linodego https://github.com/linode/linodego
+      url: https://api.linode.com/v4beta/object-storage/buckets/us-east-1/linodego-test-bucket-1615917124470992000
+      method: DELETE
+    response:
+      body: '{}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+        Access-Control-Allow-Methods:
+          - HEAD, GET, OPTIONS, POST, PUT, DELETE
+        Access-Control-Allow-Origin:
+          - '*'
+        Access-Control-Expose-Headers:
+          - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+        Cache-Control:
+          - private, max-age=60, s-maxage=60
+        Content-Length:
+          - "2"
+        Content-Security-Policy:
+          - default-src 'none'
+        Content-Type:
+          - application/json
+        Server:
+          - nginx
+        Strict-Transport-Security:
+          - max-age=31536000
+        Vary:
+          - Authorization, X-Filter
+        X-Accepted-Oauth-Scopes:
+          - object_storage:read_write
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+          - DENY
+        X-Oauth-Scopes:
+          - '*'
+        X-Ratelimit-Limit:
+          - "800"
+        X-Xss-Protection:
+          - 1; mode=block
+      status: 200 OK
+      code: 200
+      duration: ""

--- a/test/integration/object_storage_buckets_test.go
+++ b/test/integration/object_storage_buckets_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 var testObjectStorageBucketCreateOpts = ObjectStorageBucketCreateOptions{
-	Cluster: "us-east-1",
-	Label:   fmt.Sprintf("linodego-test-bucket-%d", time.Now().UnixNano()),
+	Cluster:     "us-east-1",
+	Label:       fmt.Sprintf("linodego-test-bucket-%d", time.Now().UnixNano()),
 }
 
 func TestCreateObjectStorageBucket(t *testing.T) {


### PR DESCRIPTION
- Add `ACL` and `ObjectStorageACL` enums for configuring the access control of a new Object Storage bucket.
- Add `CorsEnabled` option for bucket creation.