### PR TITLE
Make account_access field nullable

### DIFF
--- a/account_user_grants.go
+++ b/account_user_grants.go
@@ -13,21 +13,21 @@ const (
 )
 
 type GlobalUserGrants struct {
-	AccountAccess        GrantPermissionLevel `json:"account_access"`
-	AddDomains           bool                 `json:"add_domains"`
-	AddImages            bool                 `json:"add_images"`
-	AddLinodes           bool                 `json:"add_linodes"`
-	AddLongview          bool                 `json:"add_longview"`
-	AddNodeBalancers     bool                 `json:"add_nodebalancers"`
-	AddStackScripts      bool                 `json:"add_stackscripts"`
-	AddVolumes           bool                 `json:"add_volumes"`
-	CancelAccount        bool                 `json:"cancel_account"`
-	LongviewSubscription bool                 `json:"longview_subscription"`
+	AccountAccess        *GrantPermissionLevel `json:"account_access"`
+	AddDomains           bool                  `json:"add_domains"`
+	AddImages            bool                  `json:"add_images"`
+	AddLinodes           bool                  `json:"add_linodes"`
+	AddLongview          bool                  `json:"add_longview"`
+	AddNodeBalancers     bool                  `json:"add_nodebalancers"`
+	AddStackScripts      bool                  `json:"add_stackscripts"`
+	AddVolumes           bool                  `json:"add_volumes"`
+	CancelAccount        bool                  `json:"cancel_account"`
+	LongviewSubscription bool                  `json:"longview_subscription"`
 }
 
 type EntityUserGrant struct {
-	ID          int                  `json:"id"`
-	Permissions GrantPermissionLevel `json:"permissions"`
+	ID          int                   `json:"id"`
+	Permissions *GrantPermissionLevel `json:"permissions"`
 }
 
 type GrantedEntity struct {

--- a/test/integration/account_user_grants_test.go
+++ b/test/integration/account_user_grants_test.go
@@ -20,8 +20,10 @@ func TestUpdateUserGrants(t *testing.T) {
 	}, "fixtures/TestUpdateUserGrants")
 	defer teardown()
 
+	accessLevel := linodego.AccessLevelReadOnly
+
 	globalGrants := linodego.GlobalUserGrants{
-		AccountAccess:    linodego.AccessLevelReadOnly,
+		AccountAccess:    &accessLevel,
 		AddDomains:       false,
 		AddImages:        true,
 		AddLinodes:       false,
@@ -30,6 +32,44 @@ func TestUpdateUserGrants(t *testing.T) {
 		AddStackScripts:  true,
 		AddVolumes:       true,
 		CancelAccount:    false,
+	}
+
+	expectedUserGrants := linodego.UserGrants{
+		Global:       globalGrants,
+		Domain:       []linodego.GrantedEntity{},
+		Image:        []linodego.GrantedEntity{},
+		Linode:       []linodego.GrantedEntity{},
+		Longview:     []linodego.GrantedEntity{},
+		NodeBalancer: []linodego.GrantedEntity{},
+		StackScript:  []linodego.GrantedEntity{},
+		Volume:       []linodego.GrantedEntity{},
+	}
+	grants, err := client.UpdateUserGrants(context.TODO(), username, linodego.UserGrantsUpdateOptions{
+		Global: globalGrants,
+	})
+	if err != nil {
+		t.Fatalf("failed to get user grants: %s", err)
+	}
+
+	if !cmp.Equal(grants, &expectedUserGrants) {
+		t.Errorf("expected rules to match test rules, but got diff: %s", cmp.Diff(grants, &expectedUserGrants))
+	}
+}
+
+func TestUpdateUserGrants_noAccess(t *testing.T) {
+	username := usernamePrefix + "updateusergrantsna"
+
+	client, _, teardown := setupUser(t, []userModifier{
+		func(createOpts *linodego.UserCreateOptions) {
+			createOpts.Username = username
+			createOpts.Email = usernamePrefix + "updateusergrants@example.com"
+			createOpts.Restricted = true
+		},
+	}, "fixtures/TestUpdateUserGrants_noAccess")
+	defer teardown()
+
+	globalGrants := linodego.GlobalUserGrants{
+		AccountAccess: nil,
 	}
 
 	expectedUserGrants := linodego.UserGrants{

--- a/test/integration/fixtures/TestUpdateUserGrants_noAccess.yaml
+++ b/test/integration/fixtures/TestUpdateUserGrants_noAccess.yaml
@@ -1,0 +1,166 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"username":"linodegotest-updateusergrantsna","email":"linodegotest-updateusergrants@example.com","restricted":true}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/users
+    method: POST
+  response:
+    body: '{"username": "linodegotest-updateusergrantsna", "email": "linodegotest-updateusergrants@example.com", "restricted": true, "ssh_keys": [], "tfa_enabled": false}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "159"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - account:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"global":{"account_access":null,"add_domains":false,"add_images":false,"add_linodes":false,"add_longview":false,"add_nodebalancers":false,"add_stackscripts":false,"add_volumes":false,"cancel_account":false,"longview_subscription":false}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/users/linodegotest-updateusergrantsna/grants
+    method: PUT
+  response:
+    body: '{"linode": [], "nodebalancer": [], "domain": [], "stackscript": [], "longview": [], "image": [], "volume": [], "global": {"add_domains": false, "add_linodes": false, "add_longview": false, "longview_subscription": false, "add_stackscripts": false, "add_nodebalancers": false, "add_images": false, "add_volumes": false, "account_access": null, "cancel_account": false}}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - account:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/users/linodegotest-updateusergrantsna
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - account:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
This change is necessary because the API accepts `null` values as "no access".
- Makes the `account_access` field nullable for user grants.