### PR TITLE
Remove omitempty from Interfaces JSON tag

### DIFF
--- a/instance_configs.go
+++ b/instance_configs.go
@@ -81,7 +81,7 @@ type InstanceConfigCreateOptions struct {
 	Comments    string                    `json:"comments,omitempty"`
 	Devices     InstanceConfigDeviceMap   `json:"devices"`
 	Helpers     *InstanceConfigHelpers    `json:"helpers,omitempty"`
-	Interfaces  []InstanceConfigInterface `json:"interfaces,omitempty"`
+	Interfaces  []InstanceConfigInterface `json:"interfaces"`
 	MemoryLimit int                       `json:"memory_limit,omitempty"`
 	Kernel      string                    `json:"kernel,omitempty"`
 	InitRD      int                       `json:"init_rd,omitempty"`
@@ -96,7 +96,7 @@ type InstanceConfigUpdateOptions struct {
 	Comments   string                    `json:"comments"`
 	Devices    *InstanceConfigDeviceMap  `json:"devices,omitempty"`
 	Helpers    *InstanceConfigHelpers    `json:"helpers,omitempty"`
-	Interfaces []InstanceConfigInterface `json:"interfaces,omitempty"`
+	Interfaces []InstanceConfigInterface `json:"interfaces"`
 	// MemoryLimit 0 means unlimitted, this is not omitted
 	MemoryLimit int    `json:"memory_limit"`
 	Kernel      string `json:"kernel,omitempty"`

--- a/test/integration/fixtures/TestListVLAN.yaml
+++ b/test/integration/fixtures/TestListVLAN.yaml
@@ -14,7 +14,7 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 26154279, "label": "linodego-testing-aSTefFgoEhTM-0", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["139.177.206.223"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 26462802, "label": "linodego-testing-aSTefFgoEhTM-0", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["194.195.210.240"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -69,7 +69,7 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 26154280, "label": "linodego-testing-aSTefFgoEhTM-1", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["139.177.203.109"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 26462803, "label": "linodego-testing-aSTefFgoEhTM-1", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["194.195.211.241"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -121,10 +121,67 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26154279
+    url: https://api.linode.com/v4beta/linode/instances/26462802
     method: GET
   response:
-    body: '{"id": 26154279, "label": "linodego-testing-aSTefFgoEhTM-0", "group": "", "status": "booting", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["139.177.206.223"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 26462802, "label": "linodego-testing-aSTefFgoEhTM-0", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["194.195.210.240"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "654"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/26462802
+    method: GET
+  response:
+    body: '{"id": 26462802, "label": "linodego-testing-aSTefFgoEhTM-0", "group": "", "status": "booting", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["194.195.210.240"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -178,10 +235,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26154279
+    url: https://api.linode.com/v4beta/linode/instances/26462802
     method: GET
   response:
-    body: '{"id": 26154279, "label": "linodego-testing-aSTefFgoEhTM-0", "group": "", "status": "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["139.177.206.223"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 26462802, "label": "linodego-testing-aSTefFgoEhTM-0", "group": "", "status": "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["194.195.210.240"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -235,10 +292,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26154280
+    url: https://api.linode.com/v4beta/linode/instances/26462803
     method: GET
   response:
-    body: '{"id": 26154280, "label": "linodego-testing-aSTefFgoEhTM-1", "group": "", "status": "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["139.177.203.109"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 26462803, "label": "linodego-testing-aSTefFgoEhTM-1", "group": "", "status": "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["194.195.211.241"], "ipv6": "1234::5678/128", "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -297,7 +354,7 @@ interactions:
     url: https://api.linode.com/v4beta/networking/vlans
     method: GET
   response:
-    body: '{"data": [{"region": "us-southeast", "label": "linodego-really-cool-vlan-KBFddmZeCExb", "linodes": [26154279, 26154280], "created": "2018-01-02T03:04:05"}], "page": 1, "pages": 1, "results": 1}'
+    body: '{"data": [{"region": "us-southeast", "label": "linodego-really-cool-vlan-KBFddmZeCExb", "linodes": [26462802, 26462803], "created": "2018-01-02T03:04:05"}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -351,7 +408,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26154280
+    url: https://api.linode.com/v4beta/linode/instances/26462803
     method: DELETE
   response:
     body: '{}'
@@ -406,7 +463,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26154279
+    url: https://api.linode.com/v4beta/linode/instances/26462802
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestUpdateInstanceConfigInterfaces.yaml
+++ b/test/integration/fixtures/TestUpdateInstanceConfigInterfaces.yaml
@@ -14,7 +14,7 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 26152771, "label": "linodego-test-instance-wo-disk", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["139.177.206.223"], "ipv6": "1234::5678/128", "image": null, "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    body: '{"id": 26463220, "label": "linodego-test-instance-wo-disk", "group": "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type": "g6-nanode-1", "ipv4": ["194.195.210.242"], "ipv6": "1234::5678/128", "image": null, "region": "us-southeast", "specs": {"disk": 25600, "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -57,7 +57,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-config","devices":{}}'
+    body: '{"label":"linodego-test-config","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -66,10 +66,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26152771/configs
+    url: https://api.linode.com/v4beta/linode/instances/26463220/configs
     method: POST
   response:
-    body: '{"id": 28117003, "label": "linodego-test-config", "helpers": {"updatedb_disabled": true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount": true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda", "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null, "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default", "virt_mode": "paravirt", "interfaces": []}'
+    body: '{"id": 28452095, "label": "linodego-test-config", "helpers": {"updatedb_disabled": true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount": true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda", "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null, "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default", "virt_mode": "paravirt", "interfaces": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -121,10 +121,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26152771/configs/28117003
+    url: https://api.linode.com/v4beta/linode/instances/26463220/configs/28452095
     method: PUT
   response:
-    body: '{"id": 28117003, "label": "linodego-test-config", "helpers": {"updatedb_disabled": true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount": true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda", "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null, "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default", "virt_mode": "paravirt", "interfaces": [{"purpose": "public", "ipam_address": null, "label": null}, {"purpose": "vlan", "ipam_address": "", "label": "linodego-cool-vlan"}]}'
+    body: '{"id": 28452095, "label": "linodego-test-config", "helpers": {"updatedb_disabled": true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount": true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda", "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null, "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default", "virt_mode": "paravirt", "interfaces": [{"purpose": "public", "ipam_address": null, "label": null}, {"purpose": "vlan", "ipam_address": "", "label": "linodego-cool-vlan"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -176,10 +176,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26152771/configs/28117003
+    url: https://api.linode.com/v4beta/linode/instances/26463220/configs/28452095
     method: GET
   response:
-    body: '{"id": 28117003, "label": "linodego-test-config", "helpers": {"updatedb_disabled": true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount": true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda", "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null, "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default", "virt_mode": "paravirt", "interfaces": [{"purpose": "public", "ipam_address": null, "label": null}, {"purpose": "vlan", "ipam_address": "", "label": "linodego-cool-vlan"}]}'
+    body: '{"id": 28452095, "label": "linodego-test-config", "helpers": {"updatedb_disabled": true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount": true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda", "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null, "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default", "virt_mode": "paravirt", "interfaces": [{"purpose": "public", "ipam_address": null, "label": null}, {"purpose": "vlan", "ipam_address": "", "label": "linodego-cool-vlan"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -224,6 +224,61 @@ interactions:
     code: 200
     duration: ""
 - request:
+    body: '{"comments":"","interfaces":null,"memory_limit":0,"init_rd":null}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/26463220/configs/28452095
+    method: PUT
+  response:
+    body: '{"id": 28452095, "label": "linodego-test-config", "helpers": {"updatedb_disabled": true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount": true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda", "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null, "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default", "virt_mode": "paravirt", "interfaces": [{"purpose": "public", "ipam_address": null, "label": null}, {"purpose": "vlan", "ipam_address": "", "label": "linodego-cool-vlan"}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "664"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: ""
     form: {}
     headers:
@@ -233,7 +288,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/26152771
+    url: https://api.linode.com/v4beta/linode/instances/26463220
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -292,6 +292,16 @@ func TestUpdateInstanceConfigInterfaces(t *testing.T) {
 	if !reflect.DeepEqual(result.Interfaces, updateConfigOpts.Interfaces) {
 		t.Error("failed to update linode interfaces: configs do not match")
 	}
+
+	// Ensure that a nil value will not update interfaces
+	_, err = client.UpdateInstanceConfig(context.Background(), instance.ID, config.ID, linodego.InstanceConfigUpdateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(result.Interfaces, updateConfigOpts.Interfaces) {
+		t.Error("failed to update linode interfaces: configs do not match")
+	}
 }
 
 func TestListInstanceVolumes(t *testing.T) {


### PR DESCRIPTION
This is necessary because an empty slice counts as input for `Interfaces`.

- Remove `omitempty` from all `Interfaces` json tags