### PR TITLE
use runtime/debug to source linodego Version

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,8 +32,6 @@ const (
 	APISecondsPerPoll = 3
 	// Maximum wait time for retries
 	APIRetryMaxWaitTime = time.Duration(30) * time.Second
-	// DefaultUserAgent is the default User-Agent sent in HTTP request headers
-	DefaultUserAgent = "linodego https://github.com/linode/linodego"
 )
 
 var envDebug = false

--- a/version.go
+++ b/version.go
@@ -1,0 +1,34 @@
+package linodego
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+const packagePath = "github.com/linode/linodego"
+
+var (
+	Version = "dev"
+
+	// DefaultUserAgent is the default User-Agent sent in HTTP request headers
+	DefaultUserAgent string
+)
+
+// init attempts to source the version from the build info injected
+// at runtime and sets the DefaultUserAgent.
+func init() {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if ok {
+		for _, dep := range buildInfo.Deps {
+			if dep.Path == packagePath {
+				if dep.Replace != nil {
+					Version = dep.Replace.Version
+				}
+				Version = dep.Version
+				break
+			}
+		}
+	}
+
+	DefaultUserAgent = fmt.Sprintf("linodego/%s https://github.com/linode/linodego", Version)
+}


### PR DESCRIPTION
This change exposes the package version dynamically via `linodego.Version` and in the user agent.