### PR TITLE
improve generic html error propagation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -63,12 +63,13 @@ func coupleAPIErrors(r *resty.Response, err error) (*resty.Response, error) {
 
 		if responseContentType != expectedContentType {
 			msg := fmt.Sprintf(
-				"Unexpected Content-Type: Expected: %v, Received: %v",
+				"Unexpected Content-Type: Expected: %v, Received: %v\nResponse body: %s",
 				expectedContentType,
 				responseContentType,
+				string(r.Body()),
 			)
 
-			return nil, NewError(msg)
+			return nil, Error{Code: r.StatusCode(), Message: msg}
 		}
 
 		apiError, ok := r.Error().(*APIError)

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,14 +2,57 @@ package linodego
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-cmp/cmp"
 )
+
+func createTestServer(method, route, contentType, body string, statusCode int) (*httptest.Server, *Client) {
+	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method == method && r.URL.Path == route {
+			rw.Header().Add("Content-Type", contentType)
+			rw.WriteHeader(statusCode)
+			rw.Write([]byte(body))
+			return
+		}
+		rw.WriteHeader(http.StatusNotImplemented)
+	})
+	ts := httptest.NewServer(h)
+
+	client := NewClient(nil)
+	client.SetBaseURL(ts.URL)
+	return ts, &client
+}
+
+func TestCoupleAPIErrors_genericHtmlError(t *testing.T) {
+	rawResponse := `<html>
+<head><title>500 Internal Server Error</title></head>
+<body bgcolor="white">
+<center><h1>500 Internal Server Error</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>`
+	route := "/v4/linode/instances/123"
+	ts, client := createTestServer(http.MethodGet, route, "text/html", rawResponse, http.StatusInternalServerError)
+	client.SetDebug(true)
+	defer ts.Close()
+
+	expectedError := Error{
+		Code:    http.StatusInternalServerError,
+		Message: "Unexpected Content-Type: Expected: application/json, Received: text/html\nResponse body: " + rawResponse,
+	}
+
+	_, err := coupleAPIErrors(client.R(context.Background()).SetResult(&Instance{}).Get(ts.URL + route))
+	if diff := cmp.Diff(expectedError, err); diff != "" {
+		t.Errorf("expected error to match but got diff:\n%s", diff)
+	}
+}
 
 func TestCoupleAPIErrors_badGatewayError(t *testing.T) {
 	rawResponse := []byte(`<html>


### PR DESCRIPTION
When our API LBs fail to reach a server upstream they sometimes return generic HTML error responses. This change improves error propagation in logs for this case by outputting the entire body of the response as well as the status code.

In the event that an API NB throws a 500:

```
[001] Unexpected Content-Type: Expected: application/json, Received: text/html
```

now looks like:

```
[500] Unexpected Content-Type: Expected: application/json, Received: text/html
Response body: <html>
<head><title>500 Internal Server Error</title></head>
<body bgcolor="white">
<center><h1>500 Internal Server Error</h1></center>
```