### PR TITLE
add support for tagging nodepools

### DIFF
--- a/lke_cluster_pools.go
+++ b/lke_cluster_pools.go
@@ -36,6 +36,7 @@ type LKEClusterPool struct {
 	Type    string                 `json:"type"`
 	Disks   []LKEClusterPoolDisk   `json:"disks"`
 	Linodes []LKEClusterPoolLinode `json:"nodes"`
+	Tags    []string               `json:"tags"`
 }
 
 // LKEClusterPoolCreateOptions fields are those accepted by CreateLKEClusterPool
@@ -43,11 +44,13 @@ type LKEClusterPoolCreateOptions struct {
 	Count int                  `json:"count"`
 	Type  string               `json:"type"`
 	Disks []LKEClusterPoolDisk `json:"disks"`
+	Tags  []string             `json:"tags"`
 }
 
 // LKEClusterPoolUpdateOptions fields are those accepted by UpdateLKEClusterPool
 type LKEClusterPoolUpdateOptions struct {
-	Count int `json:"count"`
+	Count int       `json:"count,omitempty"`
+	Tags  *[]string `json:"tags,omitempty"`
 }
 
 // GetCreateOptions converts a LKEClusterPool to LKEClusterPoolCreateOptions for
@@ -55,12 +58,14 @@ type LKEClusterPoolUpdateOptions struct {
 func (l LKEClusterPool) GetCreateOptions() (o LKEClusterPoolCreateOptions) {
 	o.Count = l.Count
 	o.Disks = l.Disks
+	o.Tags = l.Tags
 	return
 }
 
 // GetUpdateOptions converts a LKEClusterPool to LKEClusterPoolUpdateOptions for use in UpdateLKEClusterPool
 func (l LKEClusterPool) GetUpdateOptions() (o LKEClusterPoolUpdateOptions) {
 	o.Count = l.Count
+	o.Tags = &l.Tags
 	return
 }
 

--- a/test/integration/fixtures/TestListLKEClusterPools.yaml
+++ b/test/integration/fixtures/TestListLKEClusterPools.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null}],"label":"a83ef3go2h76-linodego-testing","region":"us-central","k8s_version":"1.17","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"xf886ld17qx5-linodego-testing","region":"us-central","k8s_version":"1.21","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -10,13 +10,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 8265, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "a83ef3go2h76-linodego-testing", "region": "us-central",
-      "k8s_version": "1.17", "tags": ["testing"]}'
+    body: '{"id": 30053, "status": "ready", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "label": "xf886ld17qx5-linodego-testing", "region": "us-central", "k8s_version": "1.21", "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -31,15 +29,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "209"
+      - "210"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 27 Jul 2020 16:42:09 GMT
-      Retry-After:
-      - "53"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -57,19 +51,13 @@ interactions:
       - '*'
       X-Ratelimit-Limit:
       - "800"
-      X-Ratelimit-Remaining:
-      - "799"
-      X-Ratelimit-Reset:
-      - "1595868183"
-      X-Spec-Version:
-      - 4.69.2
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"count":1,"type":"g6-standard-2","disks":[{"size":1000,"type":"ext4"}]}'
+    body: '{"count":1,"type":"g6-standard-2","disks":[{"size":1000,"type":"ext4"}],"tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -77,13 +65,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/8265/pools
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/lke/clusters/30053/pools
     method: POST
   response:
-    body: '{"id": 10373, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "10373-5f1f03e19443",
-      "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}]}'
+    body: '{"id": 45025, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "45025-60d9e17880f8", "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -98,15 +84,11 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "178"
+      - "199"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 27 Jul 2020 16:42:09 GMT
-      Retry-After:
-      - "53"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -124,12 +106,6 @@ interactions:
       - '*'
       X-Ratelimit-Limit:
       - "800"
-      X-Ratelimit-Remaining:
-      - "798"
-      X-Ratelimit-Reset:
-      - "1595868183"
-      X-Spec-Version:
-      - 4.69.2
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -144,15 +120,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/8265/pools
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/lke/clusters/30053/pools
     method: GET
   response:
-    body: '{"data": [{"id": 10372, "type": "g6-standard-2", "count": 1, "nodes": [{"id":
-      "10372-5f1f03e14188", "instance_id": null, "status": "not_ready"}], "disks":
-      []}, {"id": 10373, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "10373-5f1f03e19443",
-      "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}]}], "page": 1, "pages": 1, "results": 2}'
+    body: '{"data": [{"id": 45024, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "45024-60d9e17805d6", "instance_id": null, "status": "not_ready"}], "disks": [], "tags": ["test"]}, {"id": 45025, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "45025-60d9e17880f8", "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "tags": ["testing"]}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -168,15 +140,11 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "377"
+      - "416"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 27 Jul 2020 16:42:09 GMT
-      Retry-After:
-      - "53"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -195,12 +163,6 @@ interactions:
       - '*'
       X-Ratelimit-Limit:
       - "800"
-      X-Ratelimit-Remaining:
-      - "797"
-      X-Ratelimit-Reset:
-      - "1595868183"
-      X-Spec-Version:
-      - 4.69.2
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -215,8 +177,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/8265/pools/10373
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/lke/clusters/30053/pools/45025
     method: DELETE
   response:
     body: '{}'
@@ -239,10 +201,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 27 Jul 2020 16:42:10 GMT
-      Retry-After:
-      - "52"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -260,12 +218,6 @@ interactions:
       - '*'
       X-Ratelimit-Limit:
       - "800"
-      X-Ratelimit-Remaining:
-      - "796"
-      X-Ratelimit-Reset:
-      - "1595868183"
-      X-Spec-Version:
-      - 4.69.2
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -280,8 +232,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/8265
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/lke/clusters/30053
     method: DELETE
   response:
     body: '{}'
@@ -304,10 +256,6 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 27 Jul 2020 16:42:10 GMT
-      Retry-After:
-      - "52"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -325,12 +273,6 @@ interactions:
       - '*'
       X-Ratelimit-Limit:
       - "800"
-      X-Ratelimit-Remaining:
-      - "795"
-      X-Ratelimit-Reset:
-      - "1595868183"
-      X-Spec-Version:
-      - 4.69.2
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestUpdateLKEClusterPool.yaml
+++ b/test/integration/fixtures/TestUpdateLKEClusterPool.yaml
@@ -14,7 +14,7 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 30070, "status": "ready", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "label": "xf886ld17qx5-linodego-testing", "region": "us-central", "k8s_version": "1.21", "tags": ["testing"]}'
+    body: '{"id": 30063, "status": "ready", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "label": "xf886ld17qx5-linodego-testing", "region": "us-central", "k8s_version": "1.21", "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -66,10 +66,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/30070/pools
+    url: https://api.linode.com/v4beta/lke/clusters/30063/pools
     method: POST
   response:
-    body: '{"id": 45057, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "45057-60d9f7fdc1e1", "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "tags": ["testing"]}'
+    body: '{"id": 45043, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "45043-60d9eec85eaa", "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -112,7 +112,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"count":2,"tags":[]}'
     form: {}
     headers:
       Accept:
@@ -121,10 +121,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/30070/pools/45057
-    method: GET
+    url: https://api.linode.com/v4beta/lke/clusters/30063/pools/45043
+    method: PUT
   response:
-    body: '{"id": 45057, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "45057-60d9f7fdc1e1", "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "tags": ["testing"]}'
+    body: '{"id": 45043, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "45043-60d9eec85eaa", "instance_id": null, "status": "not_ready"}, {"id": "45043-60d9eec91db0", "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -137,10 +137,9 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "199"
+      - "264"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -151,9 +150,63 @@ interactions:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - lke:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"count":3,"tags":["bar","foo","test"]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/lke/clusters/30063/pools/45043
+    method: PUT
+  response:
+    body: '{"id": 45043, "type": "g6-standard-2", "count": 3, "nodes": [{"id": "45043-60d9eec85eaa", "instance_id": null, "status": "not_ready"}, {"id": "45043-60d9eec91db0", "instance_id": null, "status": "not_ready"}, {"id": "45043-60d9eeca2313", "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "tags": ["bar", "foo", "test"]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "358"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
-      - lke:read_only
+      - lke:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -178,7 +231,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/30070/pools/45057
+    url: https://api.linode.com/v4beta/lke/clusters/30063/pools/45043
     method: DELETE
   response:
     body: '{}'
@@ -233,7 +286,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/30070
+    url: https://api.linode.com/v4beta/lke/clusters/30063
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -14,7 +14,7 @@ var testLKEClusterCreateOpts = linodego.LKEClusterCreateOptions{
 	Region:     "us-central",
 	K8sVersion: "1.21",
 	Tags:       []string{"testing"},
-	NodePools:  []linodego.LKEClusterPoolCreateOptions{{Count: 1, Type: "g6-standard-2"}},
+	NodePools:  []linodego.LKEClusterPoolCreateOptions{{Count: 1, Type: "g6-standard-2", Tags: []string{"test"}}},
 }
 
 func TestGetLKECluster_missing(t *testing.T) {


### PR DESCRIPTION
These changes add tag support to `CreateLKEClusterPool`, `UpdateLKEClusterPool`, and `GetLKEClusterPool`.