### PR TITLE
WaitForEventFinished respects minStart and action

### DIFF
--- a/test/integration/fixtures/TestListInstanceBackups.yaml
+++ b/test/integration/fixtures/TestListInstanceBackups.yaml
@@ -2,27 +2,26 @@
 version: 1
 interactions:
 - request:
-    body: '{"region":"us-west","type":"g6-nanode-1","label":"linodego-test-instance","booted":false}'
+    body: '{"region":"us-west","type":"g6-nanode-1","label":"linodego-test-instance-wo-disk","booted":false}'
     form: {}
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"watchdog_enabled": true, "id": 18438218, "status": "provisioning", "label":
-      "linodego-test-instance", "alerts": {"network_out": 10, "io": 10000, "transfer_quota":
-      80, "cpu": 90, "network_in": 10}, "hypervisor": "kvm", "created": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["10.20.30.40"], "region": "us-west", "updated":
-      "2018-01-02T03:04:05", "tags": [], "specs": {"disk": 25600, "transfer": 1000,
-      "gpus": 0, "vcpus": 1, "memory": 1024}, "backups": {"schedule": {"window": null,
-      "day": null}, "enabled": false}, "group": "", "image": null, "ipv6": "1234::5678/64"}'
+    body: '{"id": 28741100, "label": "linodego-test-instance-wo-disk", "group": "",
+      "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["50.116.15.68"], "ipv6": "1234::5678/128",
+      "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
+      "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "schedule": {"day": null, "window": null}, "last_successful": null},
+      "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -36,18 +35,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "598"
+      - "633"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:45:47 GMT
-      Retry-After:
-      - "118"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -64,39 +57,32 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739266"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-config","devices":{}}'
+    body: '{"label":"linodego-test-config","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/configs
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/configs
     method: POST
   response:
-    body: '{"comments": "", "initrd": null, "id": 19678878, "created": "2018-01-02T03:04:05",
-      "devices": {"sdc": null, "sdh": null, "sde": null, "sdf": null, "sdb": null,
-      "sdd": null, "sda": null, "sdg": null}, "helpers": {"network": true, "updatedb_disabled":
-      true, "modules_dep": true, "devtmpfs_automount": true, "distro": true}, "root_device":
-      "/dev/sda", "kernel": "linode/latest-64bit", "memory_limit": 0, "updated": "2018-01-02T03:04:05",
-      "run_level": "default", "virt_mode": "paravirt", "label": "linodego-test-config"}'
+    body: '{"id": 30867596, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
+      true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
+      true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
+      "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
+      "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
+      "virt_mode": "paravirt", "interfaces": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -110,18 +96,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "516"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:45:47 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -138,13 +118,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739267"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -156,23 +130,21 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100
     method: GET
   response:
-    body: '{"ipv6": "1234::5678/64", "ipv4": ["10.20.30.40"],
-      "alerts": {"transfer_quota": 80, "network_in": 10, "cpu": 90, "io": 10000, "network_out":
-      10}, "id": 18438218, "status": "offline", "updated": "2018-01-02T03:04:05",
-      "created": "2018-01-02T03:04:05", "tags": [], "region": "us-west", "label":
-      "linodego-test-instance", "specs": {"gpus": 0, "vcpus": 1, "memory": 1024, "disk":
-      25600, "transfer": 1000}, "group": "", "hypervisor": "kvm", "image": null, "type":
-      "g6-nanode-1", "watchdog_enabled": true, "backups": {"enabled": false, "schedule":
-      {"window": null, "day": null}}}'
+    body: '{"id": 28741100, "label": "linodego-test-instance-wo-disk", "group": "",
+      "status": "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["50.116.15.68"], "ipv6": "1234::5678/128",
+      "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
+      "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "schedule": {"day": null, "window": null}, "last_successful": null},
+      "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -187,18 +159,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "593"
+      - "628"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:46:02 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -216,13 +182,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739282"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -234,18 +194,16 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/disks
     method: POST
   response:
-    body: '{"size": 10, "label": "snapshot-linodego-testing", "id": 37817083, "created":
-      "2018-01-02T03:04:05", "filesystem": "ext4", "updated": "2018-01-02T03:04:05",
-      "status": "not ready"}'
+    body: '{"id": 58058123, "status": "not ready", "label": "snapshot-linodego-testing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
+      "ext4", "size": 10}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -259,18 +217,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "179"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:46:03 GMT
-      Retry-After:
-      - "118"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -287,13 +239,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739282"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -305,32 +251,22 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18438218,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"pages": 1, "page": 1, "data": [{"created": "2018-01-02T03:04:05", "time_remaining":
-      0, "secondary_entity": null, "action": "disk_create", "id": 59810183, "status":
-      "finished", "rate": null, "read": false, "entity": {"label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18438218", "id": 18438218, "type": "linode"}, "percent_complete":
-      100, "duration": 6.0, "username": "pccampbell", "seen": false}, {"created":
-      "2018-01-02T03:04:05", "time_remaining": null, "secondary_entity": null, "action":
-      "linode_config_create", "id": 59810173, "status": "notification", "rate": null,
-      "read": false, "entity": {"label": "linodego-test-instance", "url": "/v4/linode/instances/18438218",
-      "id": 18438218, "type": "linode"}, "percent_complete": null, "duration": null,
-      "username": "pccampbell", "seen": false}, {"created": "2018-01-02T03:04:05",
-      "time_remaining": 0, "secondary_entity": null, "action": "linode_create", "id":
-      59810172, "status": "finished", "rate": null, "read": false, "entity": {"label":
-      "linodego-test-instance", "url": "/v4/linode/instances/18438218", "id": 18438218,
-      "type": "linode"}, "percent_complete": 100, "duration": 5.0, "username": "pccampbell",
-      "seen": false}], "results": 3}'
+    body: '{"data": [{"id": 197482848, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      8.0, "action": "disk_create", "username": "", "entity": {"label":
+      "linodego-test-instance-wo-disk", "id": 28741100, "type": "linode", "url": "/v4/linode/instances/28741100"},
+      "status": "finished", "secondary_entity": {"id": 58058123, "type": "disk", "label":
+      "snapshot-linodego-testing", "url": "/v4/linode/instances/28741100/disks/58058123"},
+      "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -345,16 +281,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
+      Content-Length:
+      - "572"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:46:18 GMT
-      Retry-After:
-      - "103"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -372,13 +304,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1573739282"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -390,13 +316,11 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/enable
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/enable
     method: POST
   response:
     body: '{}'
@@ -413,18 +337,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:46:18 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -441,13 +359,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739298"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -459,18 +371,16 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups
     method: POST
   response:
-    body: '{"configs": [], "region": "us-west", "finished": null, "disks": [], "id":
-      131181244, "status": "pending", "type": "snapshot", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "label": "snapshot-linodego-testing"}'
+    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "pending",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      null, "label": "snapshot-linodego-testing", "configs": [], "disks": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -484,18 +394,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "231"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:46:30 GMT
-      Retry-After:
-      - "107"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -512,13 +416,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739298"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -530,41 +428,21 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18438218,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"results": 5, "page": 1, "pages": 1, "data": [{"created": "2018-01-02T03:04:05",
-      "read": false, "seen": false, "percent_complete": 49, "username": "pccampbell",
-      "secondary_entity": null, "duration": 15.486478, "entity": {"type": "linode",
-      "label": "linodego-test-instance", "url": "/v4/linode/instances/18438218", "id":
-      18438218}, "action": "linode_snapshot", "time_remaining": null, "rate": null,
-      "status": "started", "id": 59810232}, {"created": "2018-01-02T03:04:05", "read":
-      false, "seen": false, "percent_complete": null, "username": "pccampbell", "secondary_entity":
-      null, "duration": null, "entity": {"type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18438218", "id": 18438218}, "action": "backups_enable",
-      "time_remaining": null, "rate": null, "status": "notification", "id": 59810211},
-      {"created": "2018-01-02T03:04:05", "read": false, "seen": false, "percent_complete":
-      100, "username": "pccampbell", "secondary_entity": null, "duration": 6.0, "entity":
-      {"type": "linode", "label": "linodego-test-instance", "url": "/v4/linode/instances/18438218",
-      "id": 18438218}, "action": "disk_create", "time_remaining": 0, "rate": null,
-      "status": "finished", "id": 59810183}, {"created": "2018-01-02T03:04:05", "read":
-      false, "seen": false, "percent_complete": null, "username": "pccampbell", "secondary_entity":
-      null, "duration": null, "entity": {"type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18438218", "id": 18438218}, "action": "linode_config_create",
-      "time_remaining": null, "rate": null, "status": "notification", "id": 59810173},
-      {"created": "2018-01-02T03:04:05", "read": false, "seen": false, "percent_complete":
-      100, "username": "pccampbell", "secondary_entity": null, "duration": 5.0, "entity":
-      {"type": "linode", "label": "linodego-test-instance", "url": "/v4/linode/instances/18438218",
-      "id": 18438218}, "action": "linode_create", "time_remaining": 0, "rate": null,
-      "status": "finished", "id": 59810172}]}'
+    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 37, "time_remaining": null, "rate": null,
+      "duration": 14.709788, "action": "linode_snapshot", "username": "",
+      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
+      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
+      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -579,16 +457,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
+      Content-Length:
+      - "462"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:46:45 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -606,13 +480,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739325"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -624,23 +492,21 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18438218,"entity.type":"linode","id":{"+gte":59810232},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"results": 1, "page": 1, "pages": 1, "data": [{"created": "2018-01-02T03:04:05",
-      "read": false, "seen": false, "percent_complete": 76, "username": "pccampbell",
-      "secondary_entity": null, "duration": 30.49007, "entity": {"type": "linode",
-      "label": "linodego-test-instance", "url": "/v4/linode/instances/18438218", "id":
-      18438218}, "action": "linode_snapshot", "time_remaining": null, "rate": null,
-      "status": "started", "id": 59810232}]}'
+    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 73, "time_remaining": null, "rate": null,
+      "duration": 29.71675, "action": "linode_snapshot", "username": "",
+      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
+      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
+      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -655,18 +521,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "436"
+      - "461"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:47:00 GMT
-      Retry-After:
-      - "104"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -684,13 +544,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1573739325"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -702,23 +556,21 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18438218,"entity.type":"linode","id":{"+gte":59810232},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"pages": 1, "page": 1, "data": [{"created": "2018-01-02T03:04:05", "time_remaining":
-      0, "secondary_entity": null, "action": "linode_snapshot", "id": 59810232, "status":
-      "finished", "rate": null, "read": false, "entity": {"label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18438218", "id": 18438218, "type": "linode"}, "percent_complete":
-      100, "duration": 35.0, "username": "pccampbell", "seen": false}], "results":
-      1}'
+    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 83, "time_remaining": null, "rate": null,
+      "duration": 44.71419, "action": "linode_snapshot", "username": "",
+      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
+      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
+      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -733,18 +585,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "431"
+      - "461"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:47:15 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -762,13 +608,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739355"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -780,20 +620,21 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
+    url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"type": "snapshot", "id": 131181244, "configs": ["linodego-test-config"],
-      "status": "needsPostProcessing", "region": "us-west", "updated": "2018-01-02T03:04:05",
-      "label": "snapshot-linodego-testing", "created": "2018-01-02T03:04:05", "finished":
-      "2018-01-02T03:04:05", "disks": [{"size": 1, "filesystem": "ext4", "label":
-      "snapshot-linodego-testing"}]}'
+    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 87, "time_remaining": null, "rate": null,
+      "duration": 59.71526, "action": "linode_snapshot", "username": "",
+      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
+      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
+      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -808,18 +649,136 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "353"
+      - "461"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:47:15 GMT
-      Retry-After:
-      - "30"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      63.0, "action": "linode_snapshot", "username": "", "entity": {"label":
+      "linodego-test-instance-wo-disk", "id": 28741100, "type": "linode", "url": "/v4/linode/instances/28741100"},
+      "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
+      "pages": 1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "456"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
+    method: GET
+  response:
+    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "354"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
       Server:
       - nginx
       Strict-Transport-Security:
@@ -837,13 +796,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1573739266"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -855,21 +808,18 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups
     method: GET
   response:
-    body: '{"snapshot": {"in_progress": {"configs": ["linodego-test-config"], "region":
-      "us-west", "finished": "2018-01-02T03:04:05", "disks": [{"filesystem": "ext4",
-      "size": 1, "label": "snapshot-linodego-testing"}], "id": 131181244, "status":
-      "needsPostProcessing", "type": "snapshot", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "label": "snapshot-linodego-testing"}, "current":
-      null}, "automatic": []}'
+    body: '{"automatic": [], "snapshot": {"current": null, "in_progress": {"id": 183221972,
+      "region": "us-west", "type": "snapshot", "status": "needsPostProcessing", "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished": "2018-01-02T03:04:05",
+      "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"], "disks":
+      [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}}}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -884,18 +834,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "418"
+      - "419"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:47:15 GMT
-      Retry-After:
-      - "46"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -913,13 +857,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1573739282"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -931,20 +869,17 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
     method: GET
   response:
-    body: '{"configs": ["linodego-test-config"], "region": "us-west", "finished":
-      "2018-01-02T03:04:05", "disks": [{"filesystem": "ext4", "size": 1, "label":
-      "snapshot-linodego-testing"}], "id": 131181244, "status": "needsPostProcessing",
-      "type": "snapshot", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "label": "snapshot-linodego-testing"}'
+    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -959,18 +894,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "353"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:47:31 GMT
-      Retry-After:
-      - "118"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -988,13 +917,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739370"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1006,20 +929,17 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
     method: GET
   response:
-    body: '{"type": "snapshot", "disks": [{"size": 1, "filesystem": "ext4", "label":
-      "snapshot-linodego-testing"}], "configs": ["linodego-test-config"], "label":
-      "snapshot-linodego-testing", "id": 131181244, "status": "needsPostProcessing",
-      "finished": "2018-01-02T03:04:05", "region": "us-west", "updated": "2018-01-02T03:04:05",
-      "created": "2018-01-02T03:04:05"}'
+    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1034,18 +954,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "353"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:47:45 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1063,13 +977,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739385"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1081,20 +989,17 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
     method: GET
   response:
-    body: '{"type": "snapshot", "disks": [{"size": 1, "label": "snapshot-linodego-testing",
-      "filesystem": "ext4"}], "id": 131181244, "created": "2018-01-02T03:04:05", "label":
-      "snapshot-linodego-testing", "region": "us-west", "updated": "2018-01-02T03:04:05",
-      "status": "needsPostProcessing", "finished": "2018-01-02T03:04:05", "configs":
-      ["linodego-test-config"]}'
+    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1109,18 +1014,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "353"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:48:00 GMT
-      Retry-After:
-      - "1"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1138,13 +1037,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "397"
-      X-Ratelimit-Reset:
-      - "1573739282"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1156,20 +1049,17 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
     method: GET
   response:
-    body: '{"label": "snapshot-linodego-testing", "region": "us-west", "updated":
-      "2018-01-02T03:04:05", "type": "snapshot", "id": 131181244, "created": "2018-01-02T03:04:05",
-      "finished": "2018-01-02T03:04:05", "status": "needsPostProcessing", "configs":
-      ["linodego-test-config"], "disks": [{"label": "snapshot-linodego-testing", "size":
-      1, "filesystem": "ext4"}]}'
+    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1184,18 +1074,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "353"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:48:15 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1213,13 +1097,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739415"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1231,20 +1109,17 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
     method: GET
   response:
-    body: '{"type": "snapshot", "disks": [{"size": 1, "label": "snapshot-linodego-testing",
-      "filesystem": "ext4"}], "id": 131181244, "created": "2018-01-02T03:04:05", "label":
-      "snapshot-linodego-testing", "region": "us-west", "updated": "2018-01-02T03:04:05",
-      "status": "needsPostProcessing", "finished": "2018-01-02T03:04:05", "configs":
-      ["linodego-test-config"]}'
+    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "successful",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1259,18 +1134,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "353"
+      - "345"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:48:30 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1288,329 +1157,23 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739430"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"linode_id":28741100,"overwrite":true}'
     form: {}
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
-    method: GET
-  response:
-    body: '{"type": "snapshot", "id": 131181244, "configs": ["linodego-test-config"],
-      "status": "needsPostProcessing", "region": "us-west", "updated": "2018-01-02T03:04:05",
-      "label": "snapshot-linodego-testing", "created": "2018-01-02T03:04:05", "finished":
-      "2018-01-02T03:04:05", "disks": [{"size": 1, "filesystem": "ext4", "label":
-      "snapshot-linodego-testing"}]}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "353"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:48:45 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739445"
-      X-Spec-Version:
-      - 4.7.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
-    method: GET
-  response:
-    body: '{"type": "snapshot", "finished": "2018-01-02T03:04:05", "created": "2018-01-02T03:04:05",
-      "id": 131181244, "disks": [{"size": 1, "filesystem": "ext4", "label": "snapshot-linodego-testing"}],
-      "region": "us-west", "updated": "2018-01-02T03:04:05", "label": "snapshot-linodego-testing",
-      "configs": ["linodego-test-config"], "status": "needsPostProcessing"}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "353"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:49:00 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739460"
-      X-Spec-Version:
-      - 4.7.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
-    method: GET
-  response:
-    body: '{"type": "snapshot", "id": 131181244, "configs": ["linodego-test-config"],
-      "status": "needsPostProcessing", "region": "us-west", "updated": "2018-01-02T03:04:05",
-      "label": "snapshot-linodego-testing", "created": "2018-01-02T03:04:05", "finished":
-      "2018-01-02T03:04:05", "disks": [{"size": 1, "filesystem": "ext4", "label":
-      "snapshot-linodego-testing"}]}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "353"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:49:15 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739475"
-      X-Spec-Version:
-      - 4.7.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244
-    method: GET
-  response:
-    body: '{"label": "snapshot-linodego-testing", "region": "us-west", "updated":
-      "2018-01-02T03:04:05", "type": "snapshot", "id": 131181244, "created": "2018-01-02T03:04:05",
-      "finished": "2018-01-02T03:04:05", "status": "successful", "configs": ["linodego-test-config"],
-      "disks": [{"label": "snapshot-linodego-testing", "size": 1, "filesystem": "ext4"}]}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "344"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:49:31 GMT
-      Retry-After:
-      - "118"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739490"
-      X-Spec-Version:
-      - 4.7.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"linode_id":18438218,"overwrite":true}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/131181244/restore
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972/restore
     method: POST
   response:
     body: '{}'
@@ -1627,18 +1190,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:49:31 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1655,13 +1212,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739491"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1673,13 +1224,11 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218/backups/cancel
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/cancel
     method: POST
   response:
     body: '{}'
@@ -1696,18 +1245,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:49:31 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1724,13 +1267,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739491"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1742,13 +1279,11 @@ interactions:
     headers:
       Accept:
       - application/json
-      Authorization:
-      - Bearer awesometokenawesometokenawesometoken
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18438218
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741100
     method: DELETE
   response:
     body: '{}'
@@ -1765,18 +1300,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 14 Nov 2019 13:49:31 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1793,13 +1322,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1573739491"
-      X-Spec-Version:
-      - 4.7.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestMultiplePrivateInstanceDiskInitial.yaml
+++ b/test/integration/fixtures/TestMultiplePrivateInstanceDiskInitial.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"region":"us-west","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
+    body: '{"region":"ca-central","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -10,18 +10,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 18673799, "label": "linodego-test-instance", "tags": [], "status":
-      "provisioning", "ipv6": "1234::5678/64", "group": "", "image":
-      "linode/debian9", "updated": "2018-01-02T03:04:05", "ipv4": ["10.20.30.40"],
-      "created": "2018-01-02T03:04:05", "watchdog_enabled": true, "specs": {"gpus":
-      0, "disk": 25600, "memory": 1024, "transfer": 1000, "vcpus": 1}, "region": "us-west",
-      "hypervisor": "kvm", "type": "g6-nanode-1", "alerts": {"cpu": 90, "network_in":
-      10, "io": 10000, "transfer_quota": 80, "network_out": 10}, "backups": {"schedule":
-      {"window": null, "day": null}, "enabled": false}}'
+    body: '{"id": 28741014, "label": "linodego-test-instance", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["172.105.19.7"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -35,18 +35,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "610"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:39 GMT
-      Retry-After:
-      - "117"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -63,13 +57,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308917"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -84,8 +72,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799/boot
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741014/boot
     method: POST
   response:
     body: '{}'
@@ -102,18 +90,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:40 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -130,13 +112,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308917"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -151,18 +127,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741014
     method: GET
   response:
-    body: '{"region": "us-west", "specs": {"memory": 1024, "vcpus": 1, "disk": 25600,
-      "gpus": 0, "transfer": 1000}, "label": "linodego-test-instance", "group": "",
-      "tags": [], "image": "linode/debian9", "id": 18673799, "hypervisor": "kvm",
-      "created": "2018-01-02T03:04:05", "ipv6": "1234::5678/64",
-      "backups": {"schedule": {"window": null, "day": null}, "enabled": false}, "status":
-      "booting", "updated": "2018-01-02T03:04:05", "ipv4": ["10.20.30.40"], "type":
-      "g6-nanode-1", "alerts": {"network_out": 10, "network_in": 10, "io": 10000,
-      "transfer_quota": 80, "cpu": 90}, "watchdog_enabled": true}'
+    body: '{"id": 28741014, "label": "linodego-test-instance", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["172.105.19.7"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -177,18 +153,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "605"
+      - "640"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:43 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -206,13 +176,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308923"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -227,18 +191,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741014
     method: GET
   response:
-    body: '{"id": 18673799, "label": "linodego-test-instance", "tags": [], "status":
-      "booting", "ipv6": "1234::5678/64", "group": "", "image":
-      "linode/debian9", "updated": "2018-01-02T03:04:05", "ipv4": ["10.20.30.40"],
-      "created": "2018-01-02T03:04:05", "watchdog_enabled": true, "specs": {"gpus":
-      0, "disk": 25600, "memory": 1024, "transfer": 1000, "vcpus": 1}, "region": "us-west",
-      "hypervisor": "kvm", "type": "g6-nanode-1", "alerts": {"cpu": 90, "network_in":
-      10, "io": 10000, "transfer_quota": 80, "network_out": 10}, "backups": {"schedule":
-      {"window": null, "day": null}, "enabled": false}}'
+    body: '{"id": 28741014, "label": "linodego-test-instance", "group": "", "status":
+      "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["172.105.19.7"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -253,18 +217,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "605"
+      - "635"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:46 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -282,13 +240,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308926"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -303,18 +255,15 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741014/disks
     method: GET
   response:
-    body: '{"group": "", "type": "g6-nanode-1", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "backups": {"schedule": {"day": null, "window":
-      null}, "enabled": false}, "specs": {"memory": 1024, "gpus": 0, "disk": 25600,
-      "vcpus": 1, "transfer": 1000}, "id": 18673799, "ipv4": ["10.20.30.40"], "status":
-      "booting", "tags": [], "hypervisor": "kvm", "ipv6": "1234::5678/64",
-      "watchdog_enabled": true, "label": "linodego-test-instance", "alerts": {"cpu":
-      90, "network_in": 10, "io": 10000, "transfer_quota": 80, "network_out": 10},
-      "image": "linode/debian9", "region": "us-west"}'
+    body: '{"data": [{"id": 58057943, "status": "ready", "label": "Debian 9 Disk",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
+      "ext4", "size": 25088}, {"id": 58057944, "status": "ready", "label": "512 MB
+      Swap Image", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "filesystem": "swap", "size": 512}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -329,623 +278,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:49 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308929"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
-    method: GET
-  response:
-    body: '{"group": "", "type": "g6-nanode-1", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "backups": {"schedule": {"day": null, "window":
-      null}, "enabled": false}, "specs": {"memory": 1024, "gpus": 0, "disk": 25600,
-      "vcpus": 1, "transfer": 1000}, "id": 18673799, "ipv4": ["10.20.30.40"], "status":
-      "booting", "tags": [], "hypervisor": "kvm", "ipv6": "1234::5678/64",
-      "watchdog_enabled": true, "label": "linodego-test-instance", "alerts": {"cpu":
-      90, "network_in": 10, "io": 10000, "transfer_quota": 80, "network_out": 10},
-      "image": "linode/debian9", "region": "us-west"}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:52 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308932"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
-    method: GET
-  response:
-    body: '{"label": "linodego-test-instance", "created": "2018-01-02T03:04:05", "ipv4":
-      ["10.20.30.40"], "watchdog_enabled": true, "image": "linode/debian9", "status":
-      "booting", "hypervisor": "kvm", "updated": "2018-01-02T03:04:05", "ipv6": "1234::5678/64",
-      "id": 18673799, "alerts": {"network_out": 10, "io": 10000, "network_in": 10,
-      "transfer_quota": 80, "cpu": 90}, "type": "g6-nanode-1", "region": "us-west",
-      "backups": {"enabled": false, "schedule": {"window": null, "day": null}}, "specs":
-      {"disk": 25600, "transfer": 1000, "gpus": 0, "memory": 1024, "vcpus": 1}, "tags":
-      [], "group": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:55 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308935"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
-    method: GET
-  response:
-    body: '{"image": "linode/debian9", "specs": {"memory": 1024, "transfer": 1000,
-      "vcpus": 1, "disk": 25600, "gpus": 0}, "tags": [], "ipv4": ["10.20.30.40"],
-      "type": "g6-nanode-1", "updated": "2018-01-02T03:04:05", "region": "us-west",
-      "id": 18673799, "ipv6": "1234::5678/64", "group": "", "label":
-      "linodego-test-instance", "status": "booting", "created": "2018-01-02T03:04:05",
-      "watchdog_enabled": true, "backups": {"enabled": false, "schedule": {"window":
-      null, "day": null}}, "hypervisor": "kvm", "alerts": {"cpu": 90, "transfer_quota":
-      80, "io": 10000, "network_in": 10, "network_out": 10}}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:46:58 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308938"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
-    method: GET
-  response:
-    body: '{"group": "", "type": "g6-nanode-1", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "backups": {"schedule": {"day": null, "window":
-      null}, "enabled": false}, "specs": {"memory": 1024, "gpus": 0, "disk": 25600,
-      "vcpus": 1, "transfer": 1000}, "id": 18673799, "ipv4": ["10.20.30.40"], "status":
-      "booting", "tags": [], "hypervisor": "kvm", "ipv6": "1234::5678/64",
-      "watchdog_enabled": true, "label": "linodego-test-instance", "alerts": {"cpu":
-      90, "network_in": 10, "io": 10000, "transfer_quota": 80, "network_out": 10},
-      "image": "linode/debian9", "region": "us-west"}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:01 GMT
-      Retry-After:
-      - "110"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308932"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
-    method: GET
-  response:
-    body: '{"image": "linode/debian9", "status": "booting", "created": "2018-01-02T03:04:05",
-      "tags": [], "updated": "2018-01-02T03:04:05", "label": "linodego-test-instance",
-      "id": 18673799, "type": "g6-nanode-1", "backups": {"enabled": false, "schedule":
-      {"day": null, "window": null}}, "alerts": {"cpu": 90, "network_in": 10, "transfer_quota":
-      80, "io": 10000, "network_out": 10}, "specs": {"disk": 25600, "vcpus": 1, "transfer":
-      1000, "gpus": 0, "memory": 1024}, "group": "", "region": "us-west", "watchdog_enabled":
-      true, "ipv4": ["10.20.30.40"], "ipv6": "1234::5678/64",
-      "hypervisor": "kvm"}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:04 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308944"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
-    method: GET
-  response:
-    body: '{"image": "linode/debian9", "status": "booting", "created": "2018-01-02T03:04:05",
-      "tags": [], "updated": "2018-01-02T03:04:05", "label": "linodego-test-instance",
-      "id": 18673799, "type": "g6-nanode-1", "backups": {"enabled": false, "schedule":
-      {"day": null, "window": null}}, "alerts": {"cpu": 90, "network_in": 10, "transfer_quota":
-      80, "io": 10000, "network_out": 10}, "specs": {"disk": 25600, "vcpus": 1, "transfer":
-      1000, "gpus": 0, "memory": 1024}, "group": "", "region": "us-west", "watchdog_enabled":
-      true, "ipv4": ["10.20.30.40"], "ipv6": "1234::5678/64",
-      "hypervisor": "kvm"}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:07 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308947"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
-    method: GET
-  response:
-    body: '{"image": "linode/debian9", "specs": {"memory": 1024, "transfer": 1000,
-      "vcpus": 1, "disk": 25600, "gpus": 0}, "tags": [], "ipv4": ["10.20.30.40"],
-      "type": "g6-nanode-1", "updated": "2018-01-02T03:04:05", "region": "us-west",
-      "id": 18673799, "ipv6": "1234::5678/64", "group": "", "label":
-      "linodego-test-instance", "status": "running", "created": "2018-01-02T03:04:05",
-      "watchdog_enabled": true, "backups": {"enabled": false, "schedule": {"window":
-      null, "day": null}}, "hypervisor": "kvm", "alerts": {"cpu": 90, "transfer_quota":
-      80, "io": 10000, "network_in": 10, "network_out": 10}}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "605"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:10 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308950"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799/disks
-    method: GET
-  response:
-    body: '{"pages": 1, "results": 2, "data": [{"size": 25088, "id": 38285887, "filesystem":
-      "ext4", "status": "ready", "created": "2018-01-02T03:04:05", "label": "Debian
-      9 Disk", "updated": "2018-01-02T03:04:05"}, {"size": 512, "id": 38285888, "filesystem":
-      "swap", "status": "ready", "created": "2018-01-02T03:04:05", "label": "512 MB
-      Swap Image", "updated": "2018-01-02T03:04:05"}], "page": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "385"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:10 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -963,13 +301,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308947"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -984,15 +316,15 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741014/disks
     method: GET
   response:
-    body: '{"data": [{"filesystem": "ext4", "label": "Debian 9 Disk", "status": "ready",
-      "updated": "2018-01-02T03:04:05", "size": 25088, "id": 38285887, "created":
-      "2018-01-02T03:04:05"}, {"filesystem": "swap", "label": "512 MB Swap Image",
-      "status": "ready", "updated": "2018-01-02T03:04:05", "size": 512, "id": 38285888,
-      "created": "2018-01-02T03:04:05"}], "pages": 1, "results": 2, "page": 1}'
+    body: '{"data": [{"id": 58057943, "status": "ready", "label": "Debian 9 Disk",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
+      "ext4", "size": 25088}, {"id": 58057944, "status": "ready", "label": "512 MB
+      Swap Image", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "filesystem": "swap", "size": 512}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1007,18 +339,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "385"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:13 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1036,20 +362,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308953"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"disk_id":38285887,"label":"linodego-test-image"}'
+    body: '{"disk_id":58057943,"label":"linodego-test-image"}'
     form: {}
     headers:
       Accept:
@@ -1057,13 +377,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/images
     method: POST
   response:
-    body: '{"description": "", "created": "2018-01-02T03:04:05", "expiry": null, "label":
-      "linodego-test-image", "created_by": "pccampbell", "type": "manual", "vendor":
-      null, "size": 25088, "is_public": false, "deprecated": false, "id": "private/7805155"}'
+    body: '{"id": "private/13141500", "label": "linodego-test-image", "description":
+      "", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "size":
+      25088, "created_by": "", "type": "manual", "is_public": false, "deprecated":
+      false, "vendor": null, "expiry": null, "eol": null, "status": "creating"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1077,18 +398,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "244"
+      - "315"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:14 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1096,7 +411,7 @@ interactions:
       Vary:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
-      - linodes:read_only,images:read_write
+      - images:read_write,linodes:read_only
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1105,13 +420,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308954"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1126,8 +435,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/images/private/7805155
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/images/private/13141500
     method: DELETE
   response:
     body: '{}'
@@ -1144,18 +453,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:49:33 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1172,13 +475,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309093"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1193,8 +490,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673799
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741014
     method: DELETE
   response:
     body: '{}'
@@ -1211,18 +508,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:49:34 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1239,13 +530,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309094"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestMultiplePrivateInstanceDiskSecond.yaml
+++ b/test/integration/fixtures/TestMultiplePrivateInstanceDiskSecond.yaml
@@ -10,18 +10,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"group": "", "type": "g6-nanode-1", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "backups": {"schedule": {"day": null, "window":
-      null}, "enabled": false}, "specs": {"memory": 1024, "gpus": 0, "disk": 25600,
-      "vcpus": 1, "transfer": 1000}, "id": 18673809, "ipv4": ["10.20.30.40"], "status":
-      "provisioning", "tags": [], "hypervisor": "kvm", "ipv6": "1234::5678/64",
-      "watchdog_enabled": true, "label": "linodego-test-instance-wo-disk", "alerts":
-      {"cpu": 90, "network_in": 10, "io": 10000, "transfer_quota": 80, "network_out":
-      10}, "image": null, "region": "us-west"}'
+    body: '{"id": 28741031, "label": "linodego-test-instance-wo-disk", "group": "",
+      "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["173.230.147.236"], "ipv6": "1234::5678/128",
+      "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
+      "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "schedule": {"day": null, "window": null}, "last_successful": null},
+      "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -35,18 +35,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "609"
+      - "636"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:16 GMT
-      Retry-After:
-      - "117"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -63,20 +57,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308954"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-config","devices":{}}'
+    body: '{"label":"linodego-test-config","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -84,17 +72,17 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/configs
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/configs
     method: POST
   response:
-    body: '{"id": 19924146, "kernel": "linode/latest-64bit", "run_level": "default",
-      "label": "linodego-test-config", "created": "2018-01-02T03:04:05", "comments":
-      "", "updated": "2018-01-02T03:04:05", "initrd": null, "helpers": {"updatedb_disabled":
-      true, "network": true, "distro": true, "modules_dep": true, "devtmpfs_automount":
-      true}, "memory_limit": 0, "devices": {"sdh": null, "sdc": null, "sdf": null,
-      "sdd": null, "sde": null, "sda": null, "sdg": null, "sdb": null}, "virt_mode":
-      "paravirt", "root_device": "/dev/sda"}'
+    body: '{"id": 30867525, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
+      true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
+      true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
+      "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
+      "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
+      "virt_mode": "paravirt", "interfaces": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -108,18 +96,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "516"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:18 GMT
-      Retry-After:
-      - "117"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -136,13 +118,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308956"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -157,18 +133,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031
     method: GET
   response:
-    body: '{"region": "us-west", "specs": {"memory": 1024, "vcpus": 1, "disk": 25600,
-      "gpus": 0, "transfer": 1000}, "label": "linodego-test-instance-wo-disk", "group":
-      "", "tags": [], "image": null, "id": 18673809, "hypervisor": "kvm", "created":
-      "2018-01-02T03:04:05", "ipv6": "1234::5678/64", "backups":
-      {"schedule": {"window": null, "day": null}, "enabled": false}, "status": "provisioning",
-      "updated": "2018-01-02T03:04:05", "ipv4": ["10.20.30.40"], "type": "g6-nanode-1",
-      "alerts": {"network_out": 10, "network_in": 10, "io": 10000, "transfer_quota":
-      80, "cpu": 90}, "watchdog_enabled": true}'
+    body: '{"id": 28741031, "label": "linodego-test-instance-wo-disk", "group": "",
+      "status": "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["173.230.147.236"], "ipv6": "1234::5678/128",
+      "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
+      "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "schedule": {"day": null, "window": null}, "last_successful": null},
+      "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -183,18 +159,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "609"
+      - "631"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:21 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -212,13 +182,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308961"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -233,259 +197,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809
-    method: GET
-  response:
-    body: '{"id": 18673809, "label": "linodego-test-instance-wo-disk", "tags": [],
-      "status": "provisioning", "ipv6": "1234::5678/64", "group":
-      "", "image": null, "updated": "2018-01-02T03:04:05", "ipv4": ["10.20.30.40"],
-      "created": "2018-01-02T03:04:05", "watchdog_enabled": true, "specs": {"gpus":
-      0, "disk": 25600, "memory": 1024, "transfer": 1000, "vcpus": 1}, "region": "us-west",
-      "hypervisor": "kvm", "type": "g6-nanode-1", "alerts": {"cpu": 90, "network_in":
-      10, "io": 10000, "transfer_quota": 80, "network_out": 10}, "backups": {"schedule":
-      {"window": null, "day": null}, "enabled": false}}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "609"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:24 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308964"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809
-    method: GET
-  response:
-    body: '{"image": null, "specs": {"memory": 1024, "transfer": 1000, "vcpus": 1,
-      "disk": 25600, "gpus": 0}, "tags": [], "ipv4": ["10.20.30.40"], "type": "g6-nanode-1",
-      "updated": "2018-01-02T03:04:05", "region": "us-west", "id": 18673809, "ipv6":
-      "1234::5678/64", "group": "", "label": "linodego-test-instance-wo-disk",
-      "status": "provisioning", "created": "2018-01-02T03:04:05", "watchdog_enabled":
-      true, "backups": {"enabled": false, "schedule": {"window": null, "day": null}},
-      "hypervisor": "kvm", "alerts": {"cpu": 90, "transfer_quota": 80, "io": 10000,
-      "network_in": 10, "network_out": 10}}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "609"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:27 GMT
-      Retry-After:
-      - "102"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308950"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809
-    method: GET
-  response:
-    body: '{"id": 18673809, "label": "linodego-test-instance-wo-disk", "tags": [],
-      "status": "offline", "ipv6": "1234::5678/64", "group": "",
-      "image": null, "updated": "2018-01-02T03:04:05", "ipv4": ["10.20.30.40"],
-      "created": "2018-01-02T03:04:05", "watchdog_enabled": true, "specs": {"gpus":
-      0, "disk": 25600, "memory": 1024, "transfer": 1000, "vcpus": 1}, "region": "us-west",
-      "hypervisor": "kvm", "type": "g6-nanode-1", "alerts": {"cpu": 90, "network_in":
-      10, "io": 10000, "transfer_quota": 80, "network_out": 10}, "backups": {"schedule":
-      {"window": null, "day": null}, "enabled": false}}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "604"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:30 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308970"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"pages": 1, "results": 3, "data": [{"percent_complete": 52, "seen": false,
-      "rate": null, "created": "2018-01-02T03:04:05", "status": "started", "entity":
-      {"id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode", "label":
-      "linodego-test-instance"}, "action": "disk_imagize", "read": false, "id": 62501935,
-      "secondary_entity": {"url": "/v4/images/private/7805155", "id": 7805155, "type":
-      "image", "label": "linodego-test-image"}, "duration": 19.632761, "time_remaining":
-      null, "username": "pccampbell"}, {"percent_complete": 100, "seen": false, "rate":
-      null, "created": "2018-01-02T03:04:05", "status": "finished", "entity": {"id":
-      18673799, "url": "/v4/linode/instances/18673799", "type": "linode", "label":
-      "linodego-test-instance"}, "action": "linode_boot", "read": false, "id": 62501866,
-      "secondary_entity": {"id": 19924137, "url": "/v4/linode/instances/18673799/configs/19924137",
-      "type": "linode_config", "label": "My Debian 9 Disk Profile"}, "duration": 28.0,
-      "time_remaining": 0, "username": "pccampbell"}, {"percent_complete": 100, "seen":
-      false, "rate": null, "created": "2018-01-02T03:04:05", "status": "finished",
-      "entity": {"id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode",
-      "label": "linodego-test-instance"}, "action": "linode_create", "read": false,
-      "id": 62501865, "secondary_entity": {"id": "linode/debian9", "url": "/v4/images/linode/debian9",
-      "type": "image", "label": "Debian 9"}, "duration": 3.0, "time_remaining": 0,
-      "username": "pccampbell"}], "page": 1}'
+    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 77, "time_remaining": null, "rate": null,
+      "duration": 32.299015, "action": "disk_imagize", "username": "",
+      "entity": {"label": "linodego-test-instance", "id": 28741014, "type": "linode",
+      "url": "/v4/linode/instances/28741014"}, "status": "started", "secondary_entity":
+      {"id": 13141500, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13141500"},
+      "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -500,16 +224,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
+      Content-Length:
+      - "550"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:33 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -527,13 +247,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308973"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -548,19 +262,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","id":{"+gte":197482198},"seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"pages": 1, "results": 1, "data": [{"percent_complete": 60, "seen": false,
-      "rate": null, "created": "2018-01-02T03:04:05", "status": "started", "entity":
-      {"id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode", "label":
-      "linodego-test-instance"}, "action": "disk_imagize", "read": false, "id": 62501935,
-      "secondary_entity": {"url": "/v4/images/private/7805155", "id": 7805155, "type":
-      "image", "label": "linodego-test-image"}, "duration": 22.613508, "time_remaining":
-      null, "username": "pccampbell"}], "page": 1}'
+    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 84, "time_remaining": null, "rate": null,
+      "duration": 47.303279, "action": "disk_imagize", "username": "",
+      "entity": {"label": "linodego-test-instance", "id": 28741014, "type": "linode",
+      "url": "/v4/linode/instances/28741014"}, "status": "started", "secondary_entity":
+      {"id": 13141500, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13141500"},
+      "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -575,18 +289,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "531"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:36 GMT
-      Retry-After:
-      - "116"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -604,13 +312,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308973"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -625,19 +327,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","id":{"+gte":197482198},"seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"pages": 1, "results": 1, "data": [{"percent_complete": 66, "seen": false,
-      "rate": null, "created": "2018-01-02T03:04:05", "status": "started", "entity":
-      {"id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode", "label":
-      "linodego-test-instance"}, "action": "disk_imagize", "read": false, "id": 62501935,
-      "secondary_entity": {"url": "/v4/images/private/7805155", "id": 7805155, "type":
-      "image", "label": "linodego-test-image"}, "duration": 25.636888, "time_remaining":
-      null, "username": "pccampbell"}], "page": 1}'
+    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 88, "time_remaining": null, "rate": null,
+      "duration": 62.295388, "action": "disk_imagize", "username": "",
+      "entity": {"label": "linodego-test-instance", "id": 28741014, "type": "linode",
+      "url": "/v4/linode/instances/28741014"}, "status": "started", "secondary_entity":
+      {"id": 13141500, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13141500"},
+      "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -652,18 +354,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "531"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:39 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -681,13 +377,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308979"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -702,19 +392,19 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","id":{"+gte":197482198},"seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"page": 1, "results": 1, "data": [{"read": false, "username": "pccampbell",
-      "created": "2018-01-02T03:04:05", "action": "disk_imagize", "duration": 28.593076,
-      "entity": {"id": 18673799, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799"}, "seen": false, "secondary_entity":
-      {"id": 7805155, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/7805155"},
-      "id": 62501935, "percent_complete": 71, "time_remaining": null, "status": "started",
-      "rate": null}], "pages": 1}'
+    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      73.0, "action": "disk_imagize", "username": "", "entity": {"label":
+      "linodego-test-instance", "id": 28741014, "type": "linode", "url": "/v4/linode/instances/28741014"},
+      "status": "finished", "secondary_entity": {"id": 13141500, "type": "image",
+      "label": "linodego-test-image", "url": "/v4/images/private/13141500"}, "message":
+      ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -729,18 +419,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "531"
+      - "544"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:42 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -758,20 +442,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308982"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"label":"linodego-test-instancedisk","size":2000,"image":"private/13141500","root_pass":"R34lBAdP455"}'
     form: {}
     headers:
       Accept:
@@ -779,1167 +457,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"page": 1, "results": 1, "data": [{"read": false, "username": "pccampbell",
-      "created": "2018-01-02T03:04:05", "action": "disk_imagize", "duration": 31.589961,
-      "entity": {"id": 18673799, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799"}, "seen": false, "secondary_entity":
-      {"id": 7805155, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/7805155"},
-      "id": 62501935, "percent_complete": 74, "time_remaining": null, "status": "started",
-      "rate": null}], "pages": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:45 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308985"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"created": "2018-01-02T03:04:05", "percent_complete": 77, "action":
-      "disk_imagize", "id": 62501935, "rate": null, "secondary_entity": {"url": "/v4/images/private/7805155",
-      "label": "linodego-test-image", "id": 7805155, "type": "image"}, "time_remaining":
-      null, "duration": 34.682592, "status": "started", "username": "pccampbell",
-      "read": false, "entity": {"id": 18673799, "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799", "type": "linode"}, "seen": false}],
-      "pages": 1, "page": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:48 GMT
-      Retry-After:
-      - "63"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "397"
-      X-Ratelimit-Reset:
-      - "1575308932"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 62501935, "read": false, "entity": {"label": "linodego-test-instance",
-      "id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode"}, "status":
-      "started", "duration": 37.660314, "percent_complete": 79, "created": "2018-01-02T03:04:05",
-      "seen": false, "time_remaining": null, "secondary_entity": {"label": "linodego-test-image",
-      "type": "image", "id": 7805155, "url": "/v4/images/private/7805155"}, "rate":
-      null, "username": "pccampbell", "action": "disk_imagize"}], "pages": 1, "results":
-      1, "page": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:51 GMT
-      Retry-After:
-      - "92"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308964"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"page": 1, "results": 1, "data": [{"read": false, "username": "pccampbell",
-      "created": "2018-01-02T03:04:05", "action": "disk_imagize", "duration": 40.590256,
-      "entity": {"id": 18673799, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799"}, "seen": false, "secondary_entity":
-      {"id": 7805155, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/7805155"},
-      "id": 62501935, "percent_complete": 81, "time_remaining": null, "status": "started",
-      "rate": null}], "pages": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:54 GMT
-      Retry-After:
-      - "110"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308985"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"created": "2018-01-02T03:04:05", "percent_complete": 82, "action":
-      "disk_imagize", "id": 62501935, "rate": null, "secondary_entity": {"url": "/v4/images/private/7805155",
-      "label": "linodego-test-image", "id": 7805155, "type": "image"}, "time_remaining":
-      null, "duration": 43.613573, "status": "started", "username": "pccampbell",
-      "read": false, "entity": {"id": 18673799, "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799", "type": "linode"}, "seen": false}],
-      "pages": 1, "page": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:47:57 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575308997"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"page": 1, "results": 1, "data": [{"read": false, "username": "pccampbell",
-      "created": "2018-01-02T03:04:05", "action": "disk_imagize", "duration": 46.621273,
-      "entity": {"id": 18673799, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799"}, "seen": false, "secondary_entity":
-      {"id": 7805155, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/7805155"},
-      "id": 62501935, "percent_complete": 83, "time_remaining": null, "status": "started",
-      "rate": null}], "pages": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:00 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309000"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"created": "2018-01-02T03:04:05", "percent_complete": 84, "action":
-      "disk_imagize", "id": 62501935, "rate": null, "secondary_entity": {"url": "/v4/images/private/7805155",
-      "label": "linodego-test-image", "id": 7805155, "type": "image"}, "time_remaining":
-      null, "duration": 49.65902, "status": "started", "username": "pccampbell", "read":
-      false, "entity": {"id": 18673799, "label": "linodego-test-instance", "url":
-      "/v4/linode/instances/18673799", "type": "linode"}, "seen": false}], "pages":
-      1, "page": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "530"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:03 GMT
-      Retry-After:
-      - "48"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "396"
-      X-Ratelimit-Reset:
-      - "1575308932"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"created": "2018-01-02T03:04:05", "percent_complete": 85, "action":
-      "disk_imagize", "id": 62501935, "rate": null, "secondary_entity": {"url": "/v4/images/private/7805155",
-      "label": "linodego-test-image", "id": 7805155, "type": "image"}, "time_remaining":
-      null, "duration": 52.619016, "status": "started", "username": "pccampbell",
-      "read": false, "entity": {"id": 18673799, "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799", "type": "linode"}, "seen": false}],
-      "pages": 1, "page": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:06 GMT
-      Retry-After:
-      - "110"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308997"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"results": 1, "pages": 1, "data": [{"created": "2018-01-02T03:04:05",
-      "read": false, "percent_complete": 86, "time_remaining": null, "secondary_entity":
-      {"type": "image", "url": "/v4/images/private/7805155", "label": "linodego-test-image",
-      "id": 7805155}, "id": 62501935, "action": "disk_imagize", "status": "started",
-      "entity": {"type": "linode", "url": "/v4/linode/instances/18673799", "label":
-      "linodego-test-instance", "id": 18673799}, "seen": false, "duration": 55.713027,
-      "username": "pccampbell", "rate": null}], "page": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:09 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309009"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"secondary_entity": {"url": "/v4/images/private/7805155", "type":
-      "image", "label": "linodego-test-image", "id": 7805155}, "entity": {"url": "/v4/linode/instances/18673799",
-      "type": "linode", "label": "linodego-test-instance", "id": 18673799}, "time_remaining":
-      null, "read": false, "percent_complete": 87, "id": 62501935, "created": "2018-01-02T03:04:05",
-      "seen": false, "rate": null, "action": "disk_imagize", "username": "pccampbell",
-      "duration": 58.601449, "status": "started"}], "pages": 1, "results": 1, "page":
-      1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:12 GMT
-      Retry-After:
-      - "60"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308953"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"secondary_entity": {"url": "/v4/images/private/7805155", "type":
-      "image", "label": "linodego-test-image", "id": 7805155}, "entity": {"url": "/v4/linode/instances/18673799",
-      "type": "linode", "label": "linodego-test-instance", "id": 18673799}, "time_remaining":
-      null, "read": false, "percent_complete": 87, "id": 62501935, "created": "2018-01-02T03:04:05",
-      "seen": false, "rate": null, "action": "disk_imagize", "username": "pccampbell",
-      "duration": 61.650661, "status": "started"}], "pages": 1, "results": 1, "page":
-      1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:15 GMT
-      Retry-After:
-      - "119"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309015"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 62501935, "read": false, "entity": {"label": "linodego-test-instance",
-      "id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode"}, "status":
-      "started", "duration": 64.64959, "percent_complete": 88, "created": "2018-01-02T03:04:05",
-      "seen": false, "time_remaining": null, "secondary_entity": {"label": "linodego-test-image",
-      "type": "image", "id": 7805155, "url": "/v4/images/private/7805155"}, "rate":
-      null, "username": "pccampbell", "action": "disk_imagize"}], "pages": 1, "results":
-      1, "page": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "530"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:18 GMT
-      Retry-After:
-      - "27"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308926"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"pages": 1, "results": 1, "data": [{"percent_complete": 89, "seen": false,
-      "rate": null, "created": "2018-01-02T03:04:05", "status": "started", "entity":
-      {"id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode", "label":
-      "linodego-test-instance"}, "action": "disk_imagize", "read": false, "id": 62501935,
-      "secondary_entity": {"url": "/v4/images/private/7805155", "id": 7805155, "type":
-      "image", "label": "linodego-test-image"}, "duration": 67.609905, "time_remaining":
-      null, "username": "pccampbell"}], "page": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:21 GMT
-      Retry-After:
-      - "45"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "397"
-      X-Ratelimit-Reset:
-      - "1575308947"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"page": 1, "results": 1, "data": [{"read": false, "username": "pccampbell",
-      "created": "2018-01-02T03:04:05", "action": "disk_imagize", "duration": 70.589054,
-      "entity": {"id": 18673799, "type": "linode", "label": "linodego-test-instance",
-      "url": "/v4/linode/instances/18673799"}, "seen": false, "secondary_entity":
-      {"id": 7805155, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/7805155"},
-      "id": 62501935, "percent_complete": 89, "time_remaining": null, "status": "started",
-      "rate": null}], "pages": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "531"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:24 GMT
-      Retry-After:
-      - "51"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308956"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":18673799,"entity.type":"linode","id":{"+gte":62501935},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"pages": 1, "results": 1, "data": [{"percent_complete": 100, "seen": false,
-      "rate": null, "created": "2018-01-02T03:04:05", "status": "finished", "entity":
-      {"id": 18673799, "url": "/v4/linode/instances/18673799", "type": "linode", "label":
-      "linodego-test-instance"}, "action": "disk_imagize", "read": false, "id": 62501935,
-      "secondary_entity": {"url": "/v4/images/private/7805155", "id": 7805155, "type":
-      "image", "label": "linodego-test-image"}, "duration": 72.0, "time_remaining":
-      0, "username": "pccampbell"}], "page": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "525"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:27 GMT
-      Retry-After:
-      - "71"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "398"
-      X-Ratelimit-Reset:
-      - "1575308979"
-      X-Spec-Version:
-      - 4.9.0
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"label":"linodego-test-instancedisk","size":2000,"image":"private/7805155","root_pass":"R34lBAdP455"}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: POST
   response:
-    body: '{"id": 38285918, "label": "linodego-test-instancedisk", "created": "2018-01-02T03:04:05",
-      "status": "not ready", "filesystem": "ext4", "size": 1395, "updated": "2018-01-02T03:04:05"}'
+    body: '{"id": 58058027, "status": "not ready", "label": "linodego-test-instancedisk",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
+      "ext4", "size": 1096}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1953,18 +477,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "182"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:27 GMT
-      Retry-After:
-      - "77"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -1981,13 +499,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "397"
-      X-Ratelimit-Reset:
-      - "1575308985"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -2002,8 +514,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -2014,16 +526,10 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
-      Connection:
-      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:27 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       X-Accepted-Oauth-Scopes:
@@ -2033,14 +539,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309027"
-      X-Spec-Version:
-      - 4.9.0
-    status: 400 BAD REQUEST
+      - "800"
+    status: 400 Bad Request
     code: 400
     duration: ""
 - request:
@@ -2052,8 +552,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -2064,16 +564,10 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
-      Connection:
-      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:30 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       X-Accepted-Oauth-Scopes:
@@ -2083,14 +577,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309030"
-      X-Spec-Version:
-      - 4.9.0
-    status: 400 BAD REQUEST
+      - "800"
+    status: 400 Bad Request
     code: 400
     duration: ""
 - request:
@@ -2102,8 +590,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -2114,16 +602,10 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
-      Connection:
-      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:35 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       X-Accepted-Oauth-Scopes:
@@ -2133,14 +615,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309035"
-      X-Spec-Version:
-      - 4.9.0
-    status: 400 BAD REQUEST
+      - "800"
+    status: 400 Bad Request
     code: 400
     duration: ""
 - request:
@@ -2152,8 +628,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -2164,16 +640,10 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
-      Connection:
-      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:48:46 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       X-Accepted-Oauth-Scopes:
@@ -2183,14 +653,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309046"
-      X-Spec-Version:
-      - 4.9.0
-    status: 400 BAD REQUEST
+      - "800"
+    status: 400 Bad Request
     code: 400
     duration: ""
 - request:
@@ -2202,8 +666,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -2214,16 +678,10 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
-      Connection:
-      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:49:06 GMT
-      Retry-After:
-      - "0"
       Server:
       - nginx
       X-Accepted-Oauth-Scopes:
@@ -2233,14 +691,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "396"
-      X-Ratelimit-Reset:
-      - "1575308947"
-      X-Spec-Version:
-      - 4.9.0
-    status: 400 BAD REQUEST
+      - "800"
+    status: 400 Bad Request
     code: 400
     duration: ""
 - request:
@@ -2252,12 +704,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: POST
   response:
-    body: '{"filesystem": "ext4", "label": "linodego-test-2", "status": "not ready",
-      "updated": "2018-01-02T03:04:05", "size": 2000, "id": 38285937, "created": "2018-01-02T03:04:05"}'
+    body: '{"id": 58058082, "status": "not ready", "label": "linodego-test-2", "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
+      "size": 2000}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -2271,18 +724,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "171"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:49:32 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2299,13 +746,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309092"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -2320,16 +761,15 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809/disks
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
     method: GET
   response:
-    body: '{"data": [{"id": 38285918, "label": "linodego-test-instancedisk", "created":
-      "2018-01-02T03:04:05", "status": "not ready", "filesystem": "ext4", "updated":
-      "2018-01-02T03:04:05", "size": 2000}, {"id": 38285937, "label": "linodego-test-2",
-      "created": "2018-01-02T03:04:05", "status": "not ready", "filesystem": "ext4",
-      "updated": "2018-01-02T03:04:05", "size": 2000}], "pages": 1, "results": 2,
-      "page": 1}'
+    body: '{"data": [{"id": 58058027, "status": "not ready", "label": "linodego-test-instancedisk",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
+      "ext4", "size": 2000}, {"id": 58058082, "status": "not ready", "label": "linodego-test-2",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
+      "ext4", "size": 2000}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -2344,18 +784,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "404"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:49:33 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2373,13 +807,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309093"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -2394,8 +822,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/18673809
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741031
     method: DELETE
   response:
     body: '{}'
@@ -2412,18 +840,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Mon, 02 Dec 2019 17:49:33 GMT
-      Retry-After:
-      - "119"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -2440,13 +862,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "400"
-      X-Ratelimit-Remaining:
-      - "399"
-      X-Ratelimit-Reset:
-      - "1575309093"
-      X-Spec-Version:
-      - 4.9.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestRebuildInstance.yaml
+++ b/test/integration/fixtures/TestRebuildInstance.yaml
@@ -10,13 +10,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 19977966, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 28741001, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["10.20.30.40"], "ipv6": "1234::5678/64",
+      "type": "g6-nanode-1", "ipv4": ["45.33.61.135"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -35,18 +35,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "632"
+      - "633"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 02 Apr 2020 13:34:23 GMT
-      Retry-After:
-      - "80"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -63,20 +57,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1584"
-      X-Ratelimit-Reset:
-      - "1585834544"
-      X-Spec-Version:
-      - 4.60.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-config","devices":{}}'
+    body: '{"label":"linodego-test-config","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -84,17 +72,17 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/19977966/configs
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741001/configs
     method: POST
   response:
-    body: '{"id": 21359003, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
+    body: '{"id": 30867492, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt"}'
+      "virt_mode": "paravirt", "interfaces": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -108,18 +96,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "516"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 02 Apr 2020 13:34:24 GMT
-      Retry-After:
-      - "80"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -136,13 +118,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1583"
-      X-Ratelimit-Reset:
-      - "1585834545"
-      X-Spec-Version:
-      - 4.60.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -157,24 +133,18 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
+      - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","entity.id":19977966,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741001,"entity.type":"linode","seen":false}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 79314392, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": null, "time_remaining": null, "rate": null,
-      "duration": null, "action": "linode_config_create", "username": "pccampbell",
-      "entity": {"label": "linodego-test-instance-wo-disk", "id": 19977966, "type":
-      "linode", "url": "/v4/linode/instances/19977966"}, "status": "notification",
-      "secondary_entity": {"id": 21359003, "type": "linode_config", "label": "linodego-test-config",
-      "url": "/v4/linode/instances/19977966/configs/21359003"}}, {"id": 79314390,
-      "created": "2018-01-02T03:04:05", "seen": false, "read": false, "percent_complete":
-      100, "time_remaining": 0, "rate": null, "duration": 5.0, "action": "linode_create",
-      "username": "pccampbell", "entity": {"label": "linodego-test-instance-wo-disk",
-      "id": 19977966, "type": "linode", "url": "/v4/linode/instances/19977966"}, "status":
-      "finished", "secondary_entity": null}], "page": 1, "pages": 1, "results": 2}'
+    body: '{"data": [{"id": 197481782, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      8.0, "action": "linode_create", "username": "", "entity": {"label":
+      "linodego-test-instance-wo-disk", "id": 28741001, "type": "linode", "url": "/v4/linode/instances/28741001"},
+      "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
+      "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -189,18 +159,12 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "968"
+      - "453"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 02 Apr 2020 13:34:39 GMT
-      Retry-After:
-      - "64"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -218,13 +182,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1582"
-      X-Ratelimit-Reset:
-      - "1585834544"
-      X-Spec-Version:
-      - 4.60.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -239,13 +197,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/19977966/rebuild
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741001/rebuild
     method: POST
   response:
-    body: '{"id": 19977966, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 28741001, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "rebuilding", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["10.20.30.40"], "ipv6": "1234::5678/64",
+      "type": "g6-nanode-1", "ipv4": ["45.33.61.135"], "ipv6": "1234::5678/128",
       "image": "linode/alpine3.11", "region": "us-west", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -264,18 +222,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
-      - "645"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 02 Apr 2020 13:34:40 GMT
-      Retry-After:
-      - "64"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -292,13 +244,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1581"
-      X-Ratelimit-Reset:
-      - "1585834545"
-      X-Spec-Version:
-      - 4.60.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -313,8 +259,8 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - linodego 0.12.0 https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/19977966
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/28741001
     method: DELETE
   response:
     body: '{}'
@@ -331,18 +277,12 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Date:
-      - Thu, 02 Apr 2020 13:34:40 GMT
-      Retry-After:
-      - "63"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -359,13 +299,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
-      X-Ratelimit-Remaining:
-      - "1580"
-      X-Ratelimit-Reset:
-      - "1585834544"
-      X-Spec-Version:
-      - 4.60.0
+      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/waitfor.go
+++ b/waitfor.go
@@ -261,13 +261,12 @@ func (client Client) WaitForEventFinished(ctx context.Context, id interface{}, e
 	titledEntityType := strings.Title(string(entityType))
 	filterStruct := map[string]interface{}{
 		// Nor is action
-		//"action": action,
+		"action": action,
 
-		// Created is not correctly filtered by the API
-		// We'll have to verify these values manually, for now.
-		//"created": map[string]interface{}{
-		//	"+gte": minStart.Format(time.RFC3339),
-		//},
+		"created": map[string]interface{}{
+			// The API uses UTC time, so we need to ensure the time is converted
+			"+gte": minStart.UTC().Format("2006-01-02T15:04:05"),
+		},
 
 		// With potentially 1000+ events coming back, we should filter on something
 		// Warning: This optimization has the potential to break if users are clearing
@@ -338,10 +337,6 @@ func (client Client) WaitForEventFinished(ctx context.Context, id interface{}, e
 			for _, event := range events {
 				event := event
 
-				if event.Action != action {
-					// log.Println("action mismatch", event.Action, action)
-					continue
-				}
 				if event.Entity == nil || event.Entity.Type != entityType {
 					// log.Println("type mismatch", event.Entity.Type, entityType)
 					continue
@@ -377,10 +372,6 @@ func (client Client) WaitForEventFinished(ctx context.Context, id interface{}, e
 				// that the ListEvents method is not populating it correctly
 				if event.Created == nil {
 					log.Printf("[WARN] event.Created is nil when API returned: %#+v", event.Created)
-				} else if *event.Created != minStart && !event.Created.After(minStart) {
-					// Not the event we were looking for
-					// log.Println(event.Created, "is not >=", minStart)
-					continue
 				}
 
 				// This is the event we are looking for. Save our place.


### PR DESCRIPTION
This change defers event filtering logic for creation date and action to the Linode API, which should reduce the number of events returned by the API.