### PR TITLE
Remove 'seen' filter from WaitForEventFinished

### DIFF
--- a/test/integration/fixtures/TestListInstanceBackups.yaml
+++ b/test/integration/fixtures/TestListInstanceBackups.yaml
@@ -14,9 +14,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 28741100, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 29768952, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["50.116.15.68"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["45.33.110.22"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -56,8 +56,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -73,10 +71,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/configs
+    url: https://api.linode.com/v4beta/linode/instances/29768952/configs
     method: POST
   response:
-    body: '{"id": 30867596, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
+    body: '{"id": 31929877, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -117,8 +115,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -134,12 +130,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100
+    url: https://api.linode.com/v4beta/linode/instances/29768952
     method: GET
   response:
-    body: '{"id": 28741100, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 29768952, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["50.116.15.68"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["45.33.110.22"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -181,8 +177,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -198,10 +192,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768952/disks
     method: POST
   response:
-    body: '{"id": 58058123, "status": "not ready", "label": "snapshot-linodego-testing",
+    body: '{"id": 60108836, "status": "not ready", "label": "snapshot-linodego-testing",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
       "ext4", "size": 10}'
     headers:
@@ -238,8 +232,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -256,16 +248,16 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768952,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482848, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 211973717, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      8.0, "action": "disk_create", "username": "", "entity": {"label":
-      "linodego-test-instance-wo-disk", "id": 28741100, "type": "linode", "url": "/v4/linode/instances/28741100"},
-      "status": "finished", "secondary_entity": {"id": 58058123, "type": "disk", "label":
-      "snapshot-linodego-testing", "url": "/v4/linode/instances/28741100/disks/58058123"},
+      8.0, "action": "disk_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance-wo-disk", "id": 29768952, "type": "linode", "url": "/v4/linode/instances/29768952"},
+      "status": "finished", "secondary_entity": {"id": 60108836, "type": "disk", "label":
+      "snapshot-linodego-testing", "url": "/v4/linode/instances/29768952/disks/60108836"},
       "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -303,8 +295,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -320,7 +310,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/enable
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/enable
     method: POST
   response:
     body: '{}'
@@ -358,8 +348,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -375,10 +363,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups
     method: POST
   response:
-    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "pending",
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "pending",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
       null, "label": "snapshot-linodego-testing", "configs": [], "disks": []}'
     headers:
@@ -415,8 +403,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -433,15 +419,15 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768952,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 37, "time_remaining": null, "rate": null,
-      "duration": 14.709788, "action": "linode_snapshot", "username": "",
-      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
-      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
+    body: '{"data": [{"id": 211973790, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 49, "time_remaining": null, "rate": null,
+      "duration": 15.332327, "action": "linode_snapshot", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-instance-wo-disk", "id": 29768952, "type":
+      "linode", "url": "/v4/linode/instances/29768952"}, "status": "started", "secondary_entity":
       null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -479,8 +465,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -497,15 +481,15 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768952,"entity.type":"linode","id":{"+gte":211973790}}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 73, "time_remaining": null, "rate": null,
-      "duration": 29.71675, "action": "linode_snapshot", "username": "",
-      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
-      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
+    body: '{"data": [{"id": 211973790, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 76, "time_remaining": null, "rate": null,
+      "duration": 30.332963, "action": "linode_snapshot", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-instance-wo-disk", "id": 29768952, "type":
+      "linode", "url": "/v4/linode/instances/29768952"}, "status": "started", "secondary_entity":
       null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -522,7 +506,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "461"
+      - "462"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -543,8 +527,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -561,142 +543,14 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768952,"entity.type":"linode","id":{"+gte":211973790}}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 83, "time_remaining": null, "rate": null,
-      "duration": 44.71419, "action": "linode_snapshot", "username": "",
-      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
-      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
-      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "461"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 87, "time_remaining": null, "rate": null,
-      "duration": 59.71526, "action": "linode_snapshot", "username": "",
-      "entity": {"label": "linodego-test-instance-wo-disk", "id": 28741100, "type":
-      "linode", "url": "/v4/linode/instances/28741100"}, "status": "started", "secondary_entity":
-      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "461"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_snapshot","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741100,"entity.type":"linode","id":{"+gte":197482912},"seen":false}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 197482912, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 211973790, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      63.0, "action": "linode_snapshot", "username": "", "entity": {"label":
-      "linodego-test-instance-wo-disk", "id": 28741100, "type": "linode", "url": "/v4/linode/instances/28741100"},
+      42.0, "action": "linode_snapshot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance-wo-disk", "id": 29768952, "type": "linode", "url": "/v4/linode/instances/29768952"},
       "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
       "pages": 1, "results": 1}'
     headers:
@@ -735,8 +589,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -752,10 +604,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
     method: GET
   response:
-    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
       "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
       "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
@@ -795,8 +647,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -812,10 +662,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups
     method: GET
   response:
-    body: '{"automatic": [], "snapshot": {"current": null, "in_progress": {"id": 183221972,
+    body: '{"automatic": [], "snapshot": {"current": null, "in_progress": {"id": 187079751,
       "region": "us-west", "type": "snapshot", "status": "needsPostProcessing", "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished": "2018-01-02T03:04:05",
       "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"], "disks":
@@ -856,8 +706,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -873,10 +721,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
     method: GET
   response:
-    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
       "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
       "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
@@ -916,8 +764,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -933,10 +779,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
     method: GET
   response:
-    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
       "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
       "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
@@ -976,8 +822,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -993,10 +837,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
     method: GET
   response:
-    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
       "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
       "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
@@ -1036,8 +880,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1053,10 +895,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
     method: GET
   response:
-    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
       "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
       "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
@@ -1096,8 +938,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1113,10 +953,242 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
     method: GET
   response:
-    body: '{"id": 183221972, "region": "us-west", "type": "snapshot", "status": "successful",
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "354"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
+    method: GET
+  response:
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "354"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
+    method: GET
+  response:
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "354"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
+    method: GET
+  response:
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "needsPostProcessing",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
+      "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
+      "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "354"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751
+    method: GET
+  response:
+    body: '{"id": 187079751, "region": "us-west", "type": "snapshot", "status": "successful",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "finished":
       "2018-01-02T03:04:05", "label": "snapshot-linodego-testing", "configs": ["linodego-test-config"],
       "disks": [{"label": "snapshot-linodego-testing", "size": 10, "filesystem": "ext4"}]}'
@@ -1156,15 +1228,13 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"linode_id":28741100,"overwrite":true}'
+    body: '{"linode_id":29768952,"overwrite":true}'
     form: {}
     headers:
       Accept:
@@ -1173,7 +1243,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/183221972/restore
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/187079751/restore
     method: POST
   response:
     body: '{}'
@@ -1211,8 +1281,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1228,7 +1296,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100/backups/cancel
+    url: https://api.linode.com/v4beta/linode/instances/29768952/backups/cancel
     method: POST
   response:
     body: '{}'
@@ -1266,8 +1334,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -1283,7 +1349,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741100
+    url: https://api.linode.com/v4beta/linode/instances/29768952
     method: DELETE
   response:
     body: '{}'
@@ -1321,8 +1387,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestMultiplePrivateInstanceDiskInitial.yaml
+++ b/test/integration/fixtures/TestMultiplePrivateInstanceDiskInitial.yaml
@@ -14,9 +14,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 28741014, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 29768731, "label": "linodego-test-instance", "group": "", "status":
       "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.105.19.7"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.105.8.77"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -56,8 +56,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -73,7 +71,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741014/boot
+    url: https://api.linode.com/v4beta/linode/instances/29768731/boot
     method: POST
   response:
     body: '{}'
@@ -111,8 +109,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -128,12 +124,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741014
+    url: https://api.linode.com/v4beta/linode/instances/29768731
     method: GET
   response:
-    body: '{"id": 28741014, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 29768731, "label": "linodego-test-instance", "group": "", "status":
       "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.105.19.7"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.105.8.77"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -175,8 +171,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -192,12 +186,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741014
+    url: https://api.linode.com/v4beta/linode/instances/29768731
     method: GET
   response:
-    body: '{"id": 28741014, "label": "linodego-test-instance", "group": "", "status":
-      "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.105.19.7"], "ipv6": "1234::5678/128",
+    body: '{"id": 29768731, "label": "linodego-test-instance", "group": "", "status":
+      "booting", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["172.105.8.77"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -239,8 +233,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -256,12 +248,74 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741014/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768731
     method: GET
   response:
-    body: '{"data": [{"id": 58057943, "status": "ready", "label": "Debian 9 Disk",
+    body: '{"id": 29768731, "label": "linodego-test-instance", "group": "", "status":
+      "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["172.105.8.77"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "ca-central", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "635"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/29768731/disks
+    method: GET
+  response:
+    body: '{"data": [{"id": 60108418, "status": "ready", "label": "Debian 9 Disk",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
-      "ext4", "size": 25088}, {"id": 58057944, "status": "ready", "label": "512 MB
+      "ext4", "size": 25088}, {"id": 60108419, "status": "ready", "label": "512 MB
       Swap Image", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
       "filesystem": "swap", "size": 512}], "page": 1, "pages": 1, "results": 2}'
     headers:
@@ -300,8 +354,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -317,12 +369,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741014/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768731/disks
     method: GET
   response:
-    body: '{"data": [{"id": 58057943, "status": "ready", "label": "Debian 9 Disk",
+    body: '{"data": [{"id": 60108418, "status": "ready", "label": "Debian 9 Disk",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
-      "ext4", "size": 25088}, {"id": 58057944, "status": "ready", "label": "512 MB
+      "ext4", "size": 25088}, {"id": 60108419, "status": "ready", "label": "512 MB
       Swap Image", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
       "filesystem": "swap", "size": 512}], "page": 1, "pages": 1, "results": 2}'
     headers:
@@ -361,15 +413,13 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"disk_id":58057943,"label":"linodego-test-image"}'
+    body: '{"disk_id":60108418,"label":"linodego-test-image"}'
     form: {}
     headers:
       Accept:
@@ -381,9 +431,9 @@ interactions:
     url: https://api.linode.com/v4beta/images
     method: POST
   response:
-    body: '{"id": "private/13141500", "label": "linodego-test-image", "description":
+    body: '{"id": "private/13651329", "label": "linodego-test-image", "description":
       "", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "size":
-      25088, "created_by": "", "type": "manual", "is_public": false, "deprecated":
+      25088, "created_by": "lgarber-dev", "type": "manual", "is_public": false, "deprecated":
       false, "vendor": null, "expiry": null, "eol": null, "status": "creating"}'
     headers:
       Access-Control-Allow-Credentials:
@@ -419,8 +469,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -436,7 +484,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/images/private/13141500
+    url: https://api.linode.com/v4beta/images/private/13651329
     method: DELETE
   response:
     body: '{}'
@@ -474,8 +522,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -491,7 +537,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741014
+    url: https://api.linode.com/v4beta/linode/instances/29768731
     method: DELETE
   response:
     body: '{}'
@@ -529,8 +575,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestMultiplePrivateInstanceDiskSecond.yaml
+++ b/test/integration/fixtures/TestMultiplePrivateInstanceDiskSecond.yaml
@@ -14,9 +14,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 28741031, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 29768746, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["173.230.147.236"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["74.207.241.43"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -36,7 +36,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "636"
+      - "634"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -56,8 +56,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -73,10 +71,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/configs
+    url: https://api.linode.com/v4beta/linode/instances/29768746/configs
     method: POST
   response:
-    body: '{"id": 30867525, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
+    body: '{"id": 31929676, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -117,8 +115,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -134,12 +130,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031
+    url: https://api.linode.com/v4beta/linode/instances/29768746
     method: GET
   response:
-    body: '{"id": 28741031, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 29768746, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["173.230.147.236"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["74.207.241.43"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -160,7 +156,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "631"
+      - "629"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -181,8 +177,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -199,16 +193,16 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768731,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 77, "time_remaining": null, "rate": null,
-      "duration": 32.299015, "action": "disk_imagize", "username": "",
-      "entity": {"label": "linodego-test-instance", "id": 28741014, "type": "linode",
-      "url": "/v4/linode/instances/28741014"}, "status": "started", "secondary_entity":
-      {"id": 13141500, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13141500"},
+    body: '{"data": [{"id": 211971885, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 80, "time_remaining": null, "rate": null,
+      "duration": 32.543322, "action": "disk_imagize", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-instance", "id": 29768731, "type": "linode",
+      "url": "/v4/linode/instances/29768731"}, "status": "started", "secondary_entity":
+      {"id": 13651329, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13651329"},
       "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -246,8 +240,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -264,16 +256,16 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","id":{"+gte":197482198},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768731,"entity.type":"linode","id":{"+gte":211971885}}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 84, "time_remaining": null, "rate": null,
-      "duration": 47.303279, "action": "disk_imagize", "username": "",
-      "entity": {"label": "linodego-test-instance", "id": 28741014, "type": "linode",
-      "url": "/v4/linode/instances/28741014"}, "status": "started", "secondary_entity":
-      {"id": 13141500, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13141500"},
+    body: '{"data": [{"id": 211971885, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 86, "time_remaining": null, "rate": null,
+      "duration": 47.554669, "action": "disk_imagize", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-instance", "id": 29768731, "type": "linode",
+      "url": "/v4/linode/instances/29768731"}, "status": "started", "secondary_entity":
+      {"id": 13651329, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13651329"},
       "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -311,8 +303,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -329,16 +319,16 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","id":{"+gte":197482198},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768731,"entity.type":"linode","id":{"+gte":211971885}}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 88, "time_remaining": null, "rate": null,
-      "duration": 62.295388, "action": "disk_imagize", "username": "",
-      "entity": {"label": "linodego-test-instance", "id": 28741014, "type": "linode",
-      "url": "/v4/linode/instances/28741014"}, "status": "started", "secondary_entity":
-      {"id": 13141500, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13141500"},
+    body: '{"data": [{"id": 211971885, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 89, "time_remaining": null, "rate": null,
+      "duration": 62.528055, "action": "disk_imagize", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-instance", "id": 29768731, "type": "linode",
+      "url": "/v4/linode/instances/29768731"}, "status": "started", "secondary_entity":
+      {"id": 13651329, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13651329"},
       "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -376,8 +366,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -394,16 +382,142 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741014,"entity.type":"linode","id":{"+gte":197482198},"seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768731,"entity.type":"linode","id":{"+gte":211971885}}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197482198, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 211971885, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 91, "time_remaining": null, "rate": null,
+      "duration": 77.532219, "action": "disk_imagize", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-instance", "id": 29768731, "type": "linode",
+      "url": "/v4/linode/instances/29768731"}, "status": "started", "secondary_entity":
+      {"id": 13651329, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13651329"},
+      "message": ""}], "page": 1, "pages": 1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "550"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768731,"entity.type":"linode","id":{"+gte":211971885}}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 211971885, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 92, "time_remaining": null, "rate": null,
+      "duration": 92.530162, "action": "disk_imagize", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-instance", "id": 29768731, "type": "linode",
+      "url": "/v4/linode/instances/29768731"}, "status": "started", "secondary_entity":
+      {"id": 13651329, "type": "image", "label": "linodego-test-image", "url": "/v4/images/private/13651329"},
+      "message": ""}], "page": 1, "pages": 1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "550"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"disk_imagize","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768731,"entity.type":"linode","id":{"+gte":211971885}}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 211971885, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      73.0, "action": "disk_imagize", "username": "", "entity": {"label":
-      "linodego-test-instance", "id": 28741014, "type": "linode", "url": "/v4/linode/instances/28741014"},
-      "status": "finished", "secondary_entity": {"id": 13141500, "type": "image",
-      "label": "linodego-test-image", "url": "/v4/images/private/13141500"}, "message":
+      100.0, "action": "disk_imagize", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 29768731, "type": "linode", "url": "/v4/linode/instances/29768731"},
+      "status": "finished", "secondary_entity": {"id": 13651329, "type": "image",
+      "label": "linodego-test-image", "url": "/v4/images/private/13651329"}, "message":
       ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -420,7 +534,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "544"
+      - "545"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -441,15 +555,13 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-instancedisk","size":2000,"image":"private/13141500","root_pass":"R34lBAdP455"}'
+    body: '{"label":"linodego-test-instancedisk","size":2000,"image":"private/13651329","root_pass":"R34lBAdP455"}'
     form: {}
     headers:
       Accept:
@@ -458,10 +570,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: POST
   response:
-    body: '{"id": 58058027, "status": "not ready", "label": "linodego-test-instancedisk",
+    body: '{"id": 60108518, "status": "not ready", "label": "linodego-test-instancedisk",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
       "ext4", "size": 1096}'
     headers:
@@ -498,8 +610,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -515,7 +625,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -538,8 +648,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -553,7 +661,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -576,8 +684,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -591,7 +697,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -614,8 +720,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -629,7 +733,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -652,8 +756,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -667,7 +769,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -690,8 +792,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -705,10 +805,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: POST
   response:
-    body: '{"id": 58058082, "status": "not ready", "label": "linodego-test-2", "created":
+    body: '{"id": 60108547, "status": "not ready", "label": "linodego-test-2", "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
       "size": 2000}'
     headers:
@@ -745,8 +845,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -762,12 +860,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031/disks
+    url: https://api.linode.com/v4beta/linode/instances/29768746/disks
     method: GET
   response:
-    body: '{"data": [{"id": 58058027, "status": "not ready", "label": "linodego-test-instancedisk",
+    body: '{"data": [{"id": 60108518, "status": "not ready", "label": "linodego-test-instancedisk",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
-      "ext4", "size": 2000}, {"id": 58058082, "status": "not ready", "label": "linodego-test-2",
+      "ext4", "size": 2000}, {"id": 60108547, "status": "not ready", "label": "linodego-test-2",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
       "ext4", "size": 2000}], "page": 1, "pages": 1, "results": 2}'
     headers:
@@ -806,8 +904,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -823,7 +919,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741031
+    url: https://api.linode.com/v4beta/linode/instances/29768746
     method: DELETE
   response:
     body: '{}'
@@ -861,8 +957,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestRebuildInstance.yaml
+++ b/test/integration/fixtures/TestRebuildInstance.yaml
@@ -14,9 +14,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 28741001, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 29768935, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["45.33.61.135"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["45.33.110.5"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -36,7 +36,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -56,8 +56,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -73,10 +71,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741001/configs
+    url: https://api.linode.com/v4beta/linode/instances/29768935/configs
     method: POST
   response:
-    body: '{"id": 30867492, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
+    body: '{"id": 31929863, "label": "linodego-test-config", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -117,8 +115,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -135,14 +131,14 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":28741001,"entity.type":"linode","seen":false}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":29768935,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 197481782, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 211973497, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      8.0, "action": "linode_create", "username": "", "entity": {"label":
-      "linodego-test-instance-wo-disk", "id": 28741001, "type": "linode", "url": "/v4/linode/instances/28741001"},
+      7.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance-wo-disk", "id": 29768935, "type": "linode", "url": "/v4/linode/instances/29768935"},
       "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
       "pages": 1, "results": 1}'
     headers:
@@ -181,8 +177,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -198,12 +192,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741001/rebuild
+    url: https://api.linode.com/v4beta/linode/instances/29768935/rebuild
     method: POST
   response:
-    body: '{"id": 28741001, "label": "linodego-test-instance-wo-disk", "group": "",
+    body: '{"id": 29768935, "label": "linodego-test-instance-wo-disk", "group": "",
       "status": "rebuilding", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["45.33.61.135"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["45.33.110.5"], "ipv6": "1234::5678/128",
       "image": "linode/alpine3.11", "region": "us-west", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -223,7 +217,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "646"
+      - "645"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -243,8 +237,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -260,7 +252,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/28741001
+    url: https://api.linode.com/v4beta/linode/instances/29768935
     method: DELETE
   response:
     body: '{}'
@@ -298,8 +290,6 @@ interactions:
       - DENY
       X-Oauth-Scopes:
       - '*'
-      X-Ratelimit-Limit:
-      - "800"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/waitfor.go
+++ b/waitfor.go
@@ -268,11 +268,6 @@ func (client Client) WaitForEventFinished(ctx context.Context, id interface{}, e
 			"+gte": minStart.UTC().Format("2006-01-02T15:04:05"),
 		},
 
-		// With potentially 1000+ events coming back, we should filter on something
-		// Warning: This optimization has the potential to break if users are clearing
-		// events before we see them.
-		"seen": false,
-
 		// Float the latest events to page 1
 		"+order_by": "created",
 		"+order":    "desc",


### PR DESCRIPTION
This change removes the `seen` filter from the API requests made during `WaitForEventFinished`. This flag should no longer be necessary as we can now use API-level timestamp filtering to narrow down event results.

See https://github.com/linode/terraform-provider-linode/issues/454