### PR TITLE
fix: don't retry requests during API maintenance events

### DIFF
--- a/retries.go
+++ b/retries.go
@@ -63,7 +63,7 @@ func serviceUnavailableRetryCondition(r *resty.Response, _ error) bool {
 	// an `X-MAINTENANCE-MODE` header. Don't retry during maintenance
 	// events, only for legitimate 503s.
 	if serviceUnavailable && r.Header().Get(maintenanceModeHeaderName) != "" {
-		log.Printf("[INFO] Linode API is under maintenance, request will not be retried")
+		log.Printf("[INFO] Linode API is under maintenance, request will not be retried - please see status.linode.com for more information")
 		return false
 	}
 

--- a/retries_test.go
+++ b/retries_test.go
@@ -58,3 +58,19 @@ func TestLinodeServiceUnavailableRetryCondition(t *testing.T) {
 		t.Errorf("expected retryAfter to be 20 but got %d", retryAfter)
 	}
 }
+
+func TestLinodeServiceMaintenanceModeRetryCondition(t *testing.T) {
+	request := resty.Request{}
+	rawResponse := http.Response{StatusCode: http.StatusServiceUnavailable, Header: http.Header{
+		retryAfterHeaderName:      []string{"20"},
+		maintenanceModeHeaderName: []string{"Currently in maintenance mode."},
+	}}
+	response := resty.Response{
+		Request:     &request,
+		RawResponse: &rawResponse,
+	}
+
+	if retry := serviceUnavailableRetryCondition(&response, nil); retry {
+		t.Error("expected retry to be skipped due to maintenance mode header")
+	}
+}


### PR DESCRIPTION
During Linode API maintenance events (like the [upcoming maintenance on 09/23/21](https://status.linode.com/incidents/khfqpfsfdh0g)), the API will return a `503` and set a header (`X-MAINTENANCE-MODE`) indicating that maintenance is in progress. The linodego client shouldn't bother retrying requests during maintenance events, as it's known and expected that it will not work. 

An additional test for maintenance mode has been added:

```
=== RUN   TestLinodeServiceMaintenanceModeRetryCondition
2021/09/10 10:33:34 [INFO] Linode API is under maintenance, request will not be retried
--- PASS: TestLinodeServiceMaintenanceModeRetryCondition (0.00s)
```