### PR TITLE
Allow setting LINODE_API_VERSION and LINODE_URL concurrently

### DIFF
--- a/client.go
+++ b/client.go
@@ -276,13 +276,13 @@ func NewClient(hc *http.Client) (client Client) {
 
 	if baseURLExists {
 		client.SetBaseURL(baseURL)
+	}
+
+	apiVersion, apiVersionExists := os.LookupEnv(APIVersionVar)
+	if apiVersionExists {
+		client.SetAPIVersion(apiVersion)
 	} else {
-		apiVersion, apiVersionExists := os.LookupEnv(APIVersionVar)
-		if apiVersionExists {
-			client.SetAPIVersion(apiVersion)
-		} else {
-			client.SetAPIVersion(APIVersion)
-		}
+		client.SetAPIVersion(APIVersion)
 	}
 
 	certPath, certPathExists := os.LookupEnv(APIHostCert)


### PR DESCRIPTION
This pull request resolves a conflict that would arise when setting the `LINODE_API_VERSION` and `LINODE_URL` environment variables. Previously, the base URL would override the API version, but the API version could not be set in the base URL.