### PR TITLE
fix: Add omitempty to MySQLUpdateOptions

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -64,8 +64,8 @@ type MySQLCreateOptions struct {
 
 // MySQLUpdateOptions fields are used when altering the existing MySQL Database
 type MySQLUpdateOptions struct {
-	Label     string   `json:"label"`
-	AllowList []string `json:"allow_list"`
+	Label     string   `json:"label,omitempty"`
+	AllowList []string `json:"allow_list,omitempty"`
 }
 
 // MySQLDatabaseBackup is information for interacting with a backup for the existing MySQL Database


### PR DESCRIPTION
This pull request excludes unspecified fields from the MySQLUpdateOptions request body. This allows users to only specify certain fields for update.