### PR TITLE
fix: Make WeekOfMonth nullable

### DIFF
--- a/mysql.go
+++ b/mysql.go
@@ -76,7 +76,7 @@ type MySQLDatabaseMaintenanceWindow struct {
 	Duration    int                          `json:"duration"`
 	Frequency   DatabaseMaintenanceFrequency `json:"frequency"`
 	HourOfDay   int                          `json:"hour_of_day"`
-	WeekOfMonth int                          `json:"week_of_month,omitempty"`
+	WeekOfMonth *int                         `json:"week_of_month"`
 }
 
 // MySQLUpdateOptions fields are used when altering the existing MySQL Database

--- a/test/integration/databases_test.go
+++ b/test/integration/databases_test.go
@@ -135,12 +135,14 @@ func TestDatabase_Suite(t *testing.T) {
 		t.Errorf("got wrong db from GetMySQLDatabase: %v", db)
 	}
 
+	week := 3
+
 	updatedWindow := linodego.MySQLDatabaseMaintenanceWindow{
 		DayOfWeek:   linodego.DatabaseMaintenanceDayWednesday,
 		Duration:    1,
 		Frequency:   linodego.DatabaseMaintenanceFrequencyMonthly,
 		HourOfDay:   8,
-		WeekOfMonth: 3,
+		WeekOfMonth: &week,
 	}
 
 	opts := linodego.MySQLUpdateOptions{


### PR DESCRIPTION
This pull request makes the `WeekOfMonth` field nullable. This is required when configuring a weekly update cycle.