### PR TITLE
fix: Evil allow_list pointer

### DIFF
--- a/mongo.go
+++ b/mongo.go
@@ -92,7 +92,7 @@ type MongoCreateOptions struct {
 // MongoUpdateOptions fields are used when altering the existing Mongo Database
 type MongoUpdateOptions struct {
 	Label     string                     `json:"label,omitempty"`
-	AllowList []string                   `json:"allow_list,omitempty"`
+	AllowList *[]string                  `json:"allow_list,omitempty"`
 	Updates   *DatabaseMaintenanceWindow `json:"updates,omitempty"`
 }
 

--- a/mysql.go
+++ b/mysql.go
@@ -75,7 +75,7 @@ type MySQLCreateOptions struct {
 // MySQLUpdateOptions fields are used when altering the existing MySQL Database
 type MySQLUpdateOptions struct {
 	Label     string                     `json:"label,omitempty"`
-	AllowList []string                   `json:"allow_list,omitempty"`
+	AllowList *[]string                  `json:"allow_list,omitempty"`
 	Updates   *DatabaseMaintenanceWindow `json:"updates,omitempty"`
 }
 

--- a/test/integration/mongo_test.go
+++ b/test/integration/mongo_test.go
@@ -70,8 +70,10 @@ func TestDatabase_Mongo_Suite(t *testing.T) {
 		WeekOfMonth: &week,
 	}
 
+	allowList := []string{"128.173.205.21", "123.177.200.20"}
+
 	opts := linodego.MongoUpdateOptions{
-		AllowList: []string{"128.173.205.21", "123.177.200.20"},
+		AllowList: &allowList,
 		Label:     fmt.Sprintf("%s-updated", database.Label),
 		Updates:   &updatedWindow,
 	}

--- a/test/integration/mysql_test.go
+++ b/test/integration/mysql_test.go
@@ -71,8 +71,10 @@ func TestDatabase_MySQL_Suite(t *testing.T) {
 		WeekOfMonth: &week,
 	}
 
+	allowList := []string{"128.173.205.21", "123.177.200.20"}
+
 	opts := linodego.MySQLUpdateOptions{
-		AllowList: []string{"128.173.205.21", "123.177.200.20"},
+		AllowList: &allowList,
 		Label:     fmt.Sprintf("%s-updated", database.Label),
 		Updates:   &updatedWindow,
 	}


### PR DESCRIPTION
This pull request changes the `AllowList` field from a `[]string` to a `*[]string`. This is to prevent an empty slice from being omitted from the update request.