### PR TITLE
fix: Add omitempty to Backups `Enabled` field

### DIFF
--- a/instances.go
+++ b/instances.go
@@ -77,7 +77,7 @@ type InstanceBackup struct {
 	Schedule struct {
 		Day    string `json:"day,omitempty"`
 		Window string `json:"window,omitempty"`
-	}
+	} `json:"schedule,omitempty"`
 }
 
 // InstanceTransfer pool stats for a Linode Instance during the current billing month

--- a/instances.go
+++ b/instances.go
@@ -73,7 +73,7 @@ type InstanceAlert struct {
 
 // InstanceBackup represents backup settings for an instance
 type InstanceBackup struct {
-	Enabled  bool `json:"enabled"`
+	Enabled  bool `json:"enabled,omitempty"`
 	Schedule struct {
 		Day    string `json:"day,omitempty"`
 		Window string `json:"window,omitempty"`


### PR DESCRIPTION
This change is necessary for the `InstanceUpdateOptions` struct to update the backups window correctly.