### PR TITLE
new: Add EventPoller object

### DIFF
--- a/test/integration/fixtures/TestEventPoller_InstancePower.yaml
+++ b/test/integration/fixtures/TestEventPoller_InstancePower.yaml
@@ -1,0 +1,730 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"region":"us-southeast","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances
+    method: POST
+  response:
+    body: '{"id": 37678567, "label": "linodego-test-instance", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["170.187.136.251"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "645"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "10"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678567,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [], "page": 1, "pages": 1, "results": 0}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "49"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37678567/boot
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678567,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 340956793, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 7, "time_remaining": null, "rate": null,
+      "duration": 15.079016, "action": "linode_boot", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-instance", "id": 37678567, "type": "linode", "url":
+      "/v4/linode/instances/37678567"}, "status": "started", "secondary_entity": {"id":
+      40133237, "type": "linode_config", "label": "My Debian 9 Disk Profile", "url":
+      "/v4/linode/instances/37678567/configs/40133237"}, "message": ""}], "page":
+      1, "pages": 1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "580"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/340956793
+    method: GET
+  response:
+    body: '{"id": 340956793, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      20.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37678567, "type": "linode", "url": "/v4/linode/instances/37678567"},
+      "status": "finished", "secondary_entity": {"id": 40133237, "type": "linode_config",
+      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37678567/configs/40133237"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "526"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37678567
+    method: GET
+  response:
+    body: '{"id": 37678567, "label": "linodego-test-instance", "group": "", "status":
+      "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["170.187.136.251"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "640"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678567,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [], "page": 1, "pages": 1, "results": 0}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "49"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37678567/shutdown
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678567,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 340957031, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      13.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37678567, "type": "linode", "url": "/v4/linode/instances/37678567"},
+      "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
+      "pages": 1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "448"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/340957031
+    method: GET
+  response:
+    body: '{"id": 340957031, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      13.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37678567, "type": "linode", "url": "/v4/linode/instances/37678567"},
+      "status": "finished", "secondary_entity": null, "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "399"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37678567
+    method: GET
+  response:
+    body: '{"id": 37678567, "label": "linodego-test-instance", "group": "", "status":
+      "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["170.187.136.251"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "640"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37678567
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/fixtures/TestEventPoller_InstancePower.yaml
+++ b/test/integration/fixtures/TestEventPoller_InstancePower.yaml
@@ -14,7 +14,7 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 37678834, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37699012, "label": "linodego-test-instance", "group": "", "status":
       "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
       "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
@@ -74,7 +74,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678834,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37699012,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -132,7 +132,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678834/boot
+    url: https://api.linode.com/v4beta/linode/instances/37699012/boot
     method: POST
   response:
     body: '{}'
@@ -188,17 +188,17 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678834,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37699012,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 340963811, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 20, "time_remaining": null, "rate": null,
-      "duration": 14.98714, "action": "linode_boot", "username": "lgarber-dev", "entity":
-      {"label": "linodego-test-instance", "id": 37678834, "type": "linode", "url":
-      "/v4/linode/instances/37678834"}, "status": "started", "secondary_entity": {"id":
-      40133549, "type": "linode_config", "label": "My Debian 9 Disk Profile", "url":
-      "/v4/linode/instances/37678834/configs/40133549"}, "message": ""}], "page":
+    body: '{"data": [{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
+      "duration": null, "action": "linode_boot", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-instance", "id": 37699012, "type": "linode", "url":
+      "/v4/linode/instances/37699012"}, "status": "scheduled", "secondary_entity":
+      {"id": 40155616, "type": "linode_config", "label": "My Debian 9 Disk Profile",
+      "url": "/v4/linode/instances/37699012/configs/40155616"}, "message": ""}], "page":
       1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -215,7 +215,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "580"
+      - "577"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -253,15 +253,15 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/340963811
+    url: https://api.linode.com/v4beta/account/events/341342457
     method: GET
   response:
-    body: '{"id": 340963811, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      15.090375, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
-      "status": "started", "secondary_entity": {"id": 40133549, "type": "linode_config",
-      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37678834/configs/40133549"},
+    body: '{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
+      null, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
+      "status": "scheduled", "secondary_entity": {"id": 40155616, "type": "linode_config",
+      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37699012/configs/40155616"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -278,7 +278,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "532"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -316,15 +316,78 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/340963811
+    url: https://api.linode.com/v4beta/account/events/341342457
     method: GET
   response:
-    body: '{"id": 340963811, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
+      null, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
+      "status": "scheduled", "secondary_entity": {"id": 40155616, "type": "linode_config",
+      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37699012/configs/40155616"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "528"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/341342457
+    method: GET
+  response:
+    body: '{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      18.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
-      "status": "finished", "secondary_entity": {"id": 40133549, "type": "linode_config",
-      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37678834/configs/40133549"},
+      43.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
+      "status": "finished", "secondary_entity": {"id": 40155616, "type": "linode_config",
+      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37699012/configs/40155616"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -379,10 +442,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678834
+    url: https://api.linode.com/v4beta/linode/instances/37699012
     method: GET
   response:
-    body: '{"id": 37678834, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37699012, "label": "linodego-test-instance", "group": "", "status":
       "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
       "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
@@ -444,7 +507,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678834,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37699012,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -502,7 +565,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678834/shutdown
+    url: https://api.linode.com/v4beta/linode/instances/37699012/shutdown
     method: POST
   response:
     body: '{}'
@@ -558,14 +621,14 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678834,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37699012,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 340963964, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 341342684, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      10.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
+      14.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
       "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
       "pages": 1, "results": 1}'
     headers:
@@ -621,13 +684,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/340963964
+    url: https://api.linode.com/v4beta/account/events/341342684
     method: GET
   response:
-    body: '{"id": 340963964, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 341342684, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      10.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
+      14.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
       "status": "finished", "secondary_entity": null, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -682,10 +745,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678834
+    url: https://api.linode.com/v4beta/linode/instances/37699012
     method: GET
   response:
-    body: '{"id": 37678834, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37699012, "label": "linodego-test-instance", "group": "", "status":
       "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
       "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
@@ -746,7 +809,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678834
+    url: https://api.linode.com/v4beta/linode/instances/37699012
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestEventPoller_InstancePower.yaml
+++ b/test/integration/fixtures/TestEventPoller_InstancePower.yaml
@@ -14,9 +14,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 37678567, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37678834, "label": "linodego-test-instance", "group": "", "status":
       "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["170.187.136.251"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -36,7 +36,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "645"
+      - "642"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -74,7 +74,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678567,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678834,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -132,7 +132,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678567/boot
+    url: https://api.linode.com/v4beta/linode/instances/37678834/boot
     method: POST
   response:
     body: '{}'
@@ -188,17 +188,17 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678567,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37678834,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 340956793, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 7, "time_remaining": null, "rate": null,
-      "duration": 15.079016, "action": "linode_boot", "username": "lgarber-dev", "entity":
-      {"label": "linodego-test-instance", "id": 37678567, "type": "linode", "url":
-      "/v4/linode/instances/37678567"}, "status": "started", "secondary_entity": {"id":
-      40133237, "type": "linode_config", "label": "My Debian 9 Disk Profile", "url":
-      "/v4/linode/instances/37678567/configs/40133237"}, "message": ""}], "page":
+    body: '{"data": [{"id": 340963811, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 20, "time_remaining": null, "rate": null,
+      "duration": 14.98714, "action": "linode_boot", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-instance", "id": 37678834, "type": "linode", "url":
+      "/v4/linode/instances/37678834"}, "status": "started", "secondary_entity": {"id":
+      40133549, "type": "linode_config", "label": "My Debian 9 Disk Profile", "url":
+      "/v4/linode/instances/37678834/configs/40133549"}, "message": ""}], "page":
       1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -253,15 +253,78 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/340956793
+    url: https://api.linode.com/v4beta/account/events/340963811
     method: GET
   response:
-    body: '{"id": 340956793, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 340963811, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
+      15.090375, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
+      "status": "started", "secondary_entity": {"id": 40133549, "type": "linode_config",
+      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37678834/configs/40133549"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "532"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/340963811
+    method: GET
+  response:
+    body: '{"id": 340963811, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      20.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37678567, "type": "linode", "url": "/v4/linode/instances/37678567"},
-      "status": "finished", "secondary_entity": {"id": 40133237, "type": "linode_config",
-      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37678567/configs/40133237"},
+      18.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
+      "status": "finished", "secondary_entity": {"id": 40133549, "type": "linode_config",
+      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37678834/configs/40133549"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -316,12 +379,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678567
+    url: https://api.linode.com/v4beta/linode/instances/37678834
     method: GET
   response:
-    body: '{"id": 37678567, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37678834, "label": "linodego-test-instance", "group": "", "status":
       "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["170.187.136.251"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -342,7 +405,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "640"
+      - "637"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -381,7 +444,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678567,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678834,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -439,7 +502,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678567/shutdown
+    url: https://api.linode.com/v4beta/linode/instances/37678834/shutdown
     method: POST
   response:
     body: '{}'
@@ -495,14 +558,14 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678567,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37678834,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 340957031, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 340963964, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      13.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37678567, "type": "linode", "url": "/v4/linode/instances/37678567"},
+      10.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
       "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
       "pages": 1, "results": 1}'
     headers:
@@ -558,13 +621,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/340957031
+    url: https://api.linode.com/v4beta/account/events/340963964
     method: GET
   response:
-    body: '{"id": 340957031, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 340963964, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      13.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37678567, "type": "linode", "url": "/v4/linode/instances/37678567"},
+      10.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-instance", "id": 37678834, "type": "linode", "url": "/v4/linode/instances/37678834"},
       "status": "finished", "secondary_entity": null, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -619,12 +682,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678567
+    url: https://api.linode.com/v4beta/linode/instances/37678834
     method: GET
   response:
-    body: '{"id": 37678567, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37678834, "label": "linodego-test-instance", "group": "", "status":
       "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["170.187.136.251"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -645,7 +708,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "640"
+      - "637"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -683,7 +746,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37678567
+    url: https://api.linode.com/v4beta/linode/instances/37678834
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -14,7 +14,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 	}
 
 	// Wait for the instance to be booted
-	p, err := client.InitializeEventPoller(
+	p, err := client.NewEventPoller(
 		context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionLinodeBoot)
 	if err != nil {
 		t.Fatal(err)
@@ -24,7 +24,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	event, err := p.WaitForNewEventFinished(context.Background(), 200)
+	event, err := p.WaitForFinished(context.Background(), 200)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 	}
 
 	// Wait for the instance to be shut down
-	p, err = client.InitializeEventPoller(
+	p, err = client.NewEventPoller(
 		context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionLinodeShutdown)
 	if err != nil {
 		t.Fatal(err)
@@ -49,7 +49,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	event, err = p.WaitForNewEventFinished(context.Background(), 200)
+	event, err = p.WaitForFinished(context.Background(), 200)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -1,0 +1,69 @@
+package integration
+
+import (
+	"context"
+	"github.com/linode/linodego"
+	"testing"
+)
+
+func TestEventPoller_InstancePower(t *testing.T) {
+	client, instance, teardown, err := setupInstance(t, "fixtures/TestEventPoller_InstancePower")
+	defer teardown()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Wait for the instance to be booted
+	p, err := client.InitializeEventPoller(
+		context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionLinodeBoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.BootInstance(context.Background(), instance.ID, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	event, err := p.WaitForNewEventFinished(context.Background(), 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inst, err := client.GetInstance(context.Background(), instance.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if inst.Status != linodego.InstanceRunning {
+		t.Fatalf("instance expected to be running, got %s", inst.Status)
+	}
+
+	// Wait for the instance to be shut down
+	p, err = client.InitializeEventPoller(
+		context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionLinodeShutdown)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.ShutdownInstance(context.Background(), instance.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	event, err = p.WaitForNewEventFinished(context.Background(), 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if event.Action != linodego.ActionLinodeShutdown {
+		t.Fatalf("action type mismatch: %s != %s", event.Action, linodego.ActionLinodeShutdown)
+	}
+
+	inst, err = client.GetInstance(context.Background(), instance.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if inst.Status != linodego.InstanceOffline {
+		t.Fatalf("instance expected to be offline, got %s", inst.Status)
+	}
+}

--- a/waitfor.go
+++ b/waitfor.go
@@ -686,7 +686,7 @@ func (p EventPoller) WaitForNewEventFinished(
 				return event, nil
 			case EventFailed:
 				return nil, fmt.Errorf("event %d has failed", event.ID)
-			default:
+			case EventScheduled, EventStarted:
 				continue
 			}
 		case <-ctx.Done():

--- a/waitfor.go
+++ b/waitfor.go
@@ -574,7 +574,8 @@ func (client Client) WaitForDatabaseStatus(
 // InitializeEventPoller initializes a new Linode event poller. This should be run before the event is triggered as it stores
 // the previous state of the entity's events.
 func (client Client) InitializeEventPoller(
-	ctx context.Context, id any, entityType EntityType, action EventAction) (*EventPoller, error) {
+	ctx context.Context, id any, entityType EntityType, action EventAction,
+) (*EventPoller, error) {
 	f := Filter{
 		OrderBy: "created",
 		Order:   Descending,
@@ -612,7 +613,9 @@ func (client Client) InitializeEventPoller(
 }
 
 // WaitForNewEventFinished waits for a new event to be finished.
-func (p EventPoller) WaitForNewEventFinished(ctx context.Context, timeoutSeconds int) (*Event, error) {
+func (p EventPoller) WaitForNewEventFinished(
+	ctx context.Context, timeoutSeconds int,
+) (*Event, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
@@ -683,6 +686,8 @@ func (p EventPoller) WaitForNewEventFinished(ctx context.Context, timeoutSeconds
 				return event, nil
 			case EventFailed:
 				return nil, fmt.Errorf("event %d has failed", event.ID)
+			default:
+				continue
 			}
 		case <-ctx.Done():
 			return nil, fmt.Errorf("failed to wait for event: %s", ctx.Err())

--- a/waitfor.go
+++ b/waitfor.go
@@ -652,6 +652,10 @@ func (p EventPoller) WaitForLatestUnknownEvent(ctx context.Context) (*Event, err
 				}
 
 				if isValid {
+					// Store this event so it is no longer picked up
+					// on subsequent jobs
+					p.PreviousEvents = append(p.PreviousEvents, event.ID)
+
 					return &event, nil
 				}
 			}


### PR DESCRIPTION
This pull request adds an `EventPoller` object that allows users to poll on events without relying on a minStart time. This is necessary as minStart cannot reliably determine the newest event and is subject to various time sync issues.