### PR TITLE
new: Add NewEventPollerWithoutEntity func 

### DIFF
--- a/test/integration/fixtures/TestEventPoller_InstancePower.yaml
+++ b/test/integration/fixtures/TestEventPoller_InstancePower.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"region":"us-southeast","type":"g6-nanode-1","label":"linodego-test-instance","root_pass":"R34lBAdP455","image":"linode/debian9","booted":false}'
+    body: '{"region":"us-southeast","type":"g6-nanode-1","label":"linodego-test-eventpoller","root_pass":"c00lp@ss!","image":"linode/ubuntu22.04","booted":false}'
     form: {}
     headers:
       Accept:
@@ -14,10 +14,10 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 37699012, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37916092, "label": "linodego-test-eventpoller", "group": "", "status":
       "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
-      "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
+      "type": "g6-nanode-1", "ipv4": ["170.187.155.44"], "ipv6": "1234::5678/128",
+      "image": "linode/ubuntu22.04", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
       "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
@@ -36,7 +36,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "642"
+      - "651"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -74,7 +74,325 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37699012,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":37916092,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
+      "duration": null, "action": "linode_create", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url":
+      "/v4/linode/instances/37916092"}, "status": "scheduled", "secondary_entity":
+      {"id": "linode/ubuntu22.04", "type": "image", "label": "Ubuntu 22.04 LTS", "url":
+      "/v4/images/linode/ubuntu22.04"}, "message": ""}], "page": 1, "pages": 1, "results":
+      1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "561"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346122578
+    method: GET
+  response:
+    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
+      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
+      "status": "scheduled", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
+      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "512"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346122578
+    method: GET
+  response:
+    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 54, "time_remaining": null, "rate": null, "duration":
+      34.585077, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
+      "status": "started", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
+      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "516"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346122578
+    method: GET
+  response:
+    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 60, "time_remaining": null, "rate": null, "duration":
+      49.559202, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
+      "status": "started", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
+      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "516"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346122578
+    method: GET
+  response:
+    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      57.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
+      "status": "finished", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
+      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "510"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37916092,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -132,7 +450,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37699012/boot
+    url: https://api.linode.com/v4beta/linode/instances/37916092/boot
     method: POST
   response:
     body: '{}'
@@ -188,17 +506,17 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37699012,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37916092,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
-      "duration": null, "action": "linode_boot", "username": "lgarber-dev", "entity":
-      {"label": "linodego-test-instance", "id": 37699012, "type": "linode", "url":
-      "/v4/linode/instances/37699012"}, "status": "scheduled", "secondary_entity":
-      {"id": 40155616, "type": "linode_config", "label": "My Debian 9 Disk Profile",
-      "url": "/v4/linode/instances/37699012/configs/40155616"}, "message": ""}], "page":
+    body: '{"data": [{"id": 346122938, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 52, "time_remaining": null, "rate": null,
+      "duration": 14.911683, "action": "linode_boot", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url":
+      "/v4/linode/instances/37916092"}, "status": "started", "secondary_entity": {"id":
+      40387739, "type": "linode_config", "label": "My Ubuntu 22.04 LTS Disk Profile",
+      "url": "/v4/linode/instances/37916092/configs/40387739"}, "message": ""}], "page":
       1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -215,7 +533,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "577"
+      - "592"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -253,15 +571,15 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/341342457
+    url: https://api.linode.com/v4beta/account/events/346122938
     method: GET
   response:
-    body: '{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
-      "status": "scheduled", "secondary_entity": {"id": 40155616, "type": "linode_config",
-      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37699012/configs/40155616"},
+    body: '{"id": 346122938, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 55, "time_remaining": null, "rate": null, "duration":
+      15.00237, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
+      "status": "started", "secondary_entity": {"id": 40387739, "type": "linode_config",
+      "label": "My Ubuntu 22.04 LTS Disk Profile", "url": "/v4/linode/instances/37916092/configs/40387739"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -278,7 +596,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "528"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -316,78 +634,15 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/341342457
+    url: https://api.linode.com/v4beta/account/events/346122938
     method: GET
   response:
-    body: '{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
-      "status": "scheduled", "secondary_entity": {"id": 40155616, "type": "linode_config",
-      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37699012/configs/40155616"},
-      "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "528"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/341342457
-    method: GET
-  response:
-    body: '{"id": 341342457, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 346122938, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      43.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
-      "status": "finished", "secondary_entity": {"id": 40155616, "type": "linode_config",
-      "label": "My Debian 9 Disk Profile", "url": "/v4/linode/instances/37699012/configs/40155616"},
+      16.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
+      "status": "finished", "secondary_entity": {"id": 40387739, "type": "linode_config",
+      "label": "My Ubuntu 22.04 LTS Disk Profile", "url": "/v4/linode/instances/37916092/configs/40387739"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -404,7 +659,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "526"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -442,13 +697,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37699012
+    url: https://api.linode.com/v4beta/linode/instances/37916092
     method: GET
   response:
-    body: '{"id": 37699012, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37916092, "label": "linodego-test-eventpoller", "group": "", "status":
       "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
-      "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
+      "type": "g6-nanode-1", "ipv4": ["170.187.155.44"], "ipv6": "1234::5678/128",
+      "image": "linode/ubuntu22.04", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
       "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
@@ -468,7 +723,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "637"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -507,7 +762,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37699012,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37916092,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -565,7 +820,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37699012/shutdown
+    url: https://api.linode.com/v4beta/linode/instances/37916092/shutdown
     method: POST
   response:
     body: '{}'
@@ -621,16 +876,16 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37699012,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37916092,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 341342684, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      14.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
-      "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
-      "pages": 1, "results": 1}'
+    body: '{"data": [{"id": 346123095, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 41, "time_remaining": null, "rate": null,
+      "duration": 15.304352, "action": "linode_shutdown", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode",
+      "url": "/v4/linode/instances/37916092"}, "status": "started", "secondary_entity":
+      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -646,7 +901,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "448"
+      - "457"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -684,13 +939,75 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/341342684
+    url: https://api.linode.com/v4beta/account/events/346123095
     method: GET
   response:
-    body: '{"id": 341342684, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 346123095, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 41, "time_remaining": null, "rate": null, "duration":
+      15.42827, "action": "linode_shutdown", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url":
+      "/v4/linode/instances/37916092"}, "status": "started", "secondary_entity": null,
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "407"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346123095
+    method: GET
+  response:
+    body: '{"id": 346123095, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      14.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-instance", "id": 37699012, "type": "linode", "url": "/v4/linode/instances/37699012"},
+      26.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
       "status": "finished", "secondary_entity": null, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -707,7 +1024,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "399"
+      - "402"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -745,13 +1062,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37699012
+    url: https://api.linode.com/v4beta/linode/instances/37916092
     method: GET
   response:
-    body: '{"id": 37699012, "label": "linodego-test-instance", "group": "", "status":
+    body: '{"id": 37916092, "label": "linodego-test-eventpoller", "group": "", "status":
       "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["139.144.29.4"], "ipv6": "1234::5678/128",
-      "image": "linode/debian9", "region": "us-southeast", "specs": {"disk": 25600,
+      "type": "g6-nanode-1", "ipv4": ["170.187.155.44"], "ipv6": "1234::5678/128",
+      "image": "linode/ubuntu22.04", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
       "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
@@ -771,7 +1088,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "637"
+      - "646"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -809,7 +1126,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37699012
+    url: https://api.linode.com/v4beta/linode/instances/37916092
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestEventPoller_InstancePower.yaml
+++ b/test/integration/fixtures/TestEventPoller_InstancePower.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"region":"us-southeast","type":"g6-nanode-1","label":"linodego-test-eventpoller","root_pass":"c00lp@ss!","image":"linode/ubuntu22.04","booted":false}'
+    body: '{"region":"us-southeast","type":"g6-nanode-1","label":"linodego-test-eventpoller-instancepower","root_pass":"c00lp@ss!","image":"linode/ubuntu22.04","booted":false}'
     form: {}
     headers:
       Accept:
@@ -14,9 +14,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 37916092, "label": "linodego-test-eventpoller", "group": "", "status":
-      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["170.187.155.44"], "ipv6": "1234::5678/128",
+    body: '{"id": 37916151, "label": "linodego-test-eventpoller-instancepower", "group":
+      "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["173.230.136.30"], "ipv6": "1234::5678/128",
       "image": "linode/ubuntu22.04", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -36,7 +36,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "651"
+      - "665"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -74,449 +74,17 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":37916092,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":37916151,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
-      "duration": null, "action": "linode_create", "username": "lgarber-dev", "entity":
-      {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url":
-      "/v4/linode/instances/37916092"}, "status": "scheduled", "secondary_entity":
-      {"id": "linode/ubuntu22.04", "type": "image", "label": "Ubuntu 22.04 LTS", "url":
-      "/v4/images/linode/ubuntu22.04"}, "message": ""}], "page": 1, "pages": 1, "results":
-      1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "561"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346122578
-    method: GET
-  response:
-    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
-      "status": "scheduled", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
-      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
-      "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "512"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346122578
-    method: GET
-  response:
-    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 54, "time_remaining": null, "rate": null, "duration":
-      34.585077, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
-      "status": "started", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
-      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
-      "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "516"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346122578
-    method: GET
-  response:
-    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 60, "time_remaining": null, "rate": null, "duration":
-      49.559202, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
-      "status": "started", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
-      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
-      "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "516"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346122578
-    method: GET
-  response:
-    body: '{"id": 346122578, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      57.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
-      "status": "finished", "secondary_entity": {"id": "linode/ubuntu22.04", "type":
-      "image", "label": "Ubuntu 22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"},
-      "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "510"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37916092,"entity.type":"linode"}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [], "page": 1, "pages": 1, "results": 0}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "49"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37916092/boot
-    method: POST
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "2"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_write
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37916092,"entity.type":"linode"}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 346122938, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 52, "time_remaining": null, "rate": null,
-      "duration": 14.911683, "action": "linode_boot", "username": "lgarber-dev", "entity":
-      {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url":
-      "/v4/linode/instances/37916092"}, "status": "started", "secondary_entity": {"id":
-      40387739, "type": "linode_config", "label": "My Ubuntu 22.04 LTS Disk Profile",
-      "url": "/v4/linode/instances/37916092/configs/40387739"}, "message": ""}], "page":
+    body: '{"data": [{"id": 346123429, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 53, "time_remaining": null, "rate": null,
+      "duration": 19.644612, "action": "linode_create", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-eventpoller-instancepower", "id": 37916151,
+      "type": "linode", "url": "/v4/linode/instances/37916151"}, "status": "started",
+      "secondary_entity": {"id": "linode/ubuntu22.04", "type": "image", "label": "Ubuntu
+      22.04 LTS", "url": "/v4/images/linode/ubuntu22.04"}, "message": ""}], "page":
       1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -533,7 +101,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "592"
+      - "579"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -571,16 +139,16 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346122938
+    url: https://api.linode.com/v4beta/account/events/346123429
     method: GET
   response:
-    body: '{"id": 346122938, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 55, "time_remaining": null, "rate": null, "duration":
-      15.00237, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
-      "status": "started", "secondary_entity": {"id": 40387739, "type": "linode_config",
-      "label": "My Ubuntu 22.04 LTS Disk Profile", "url": "/v4/linode/instances/37916092/configs/40387739"},
-      "message": ""}'
+    body: '{"id": 346123429, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 53, "time_remaining": null, "rate": null, "duration":
+      19.724651, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller-instancepower", "id": 37916151, "type": "linode",
+      "url": "/v4/linode/instances/37916151"}, "status": "started", "secondary_entity":
+      {"id": "linode/ubuntu22.04", "type": "image", "label": "Ubuntu 22.04 LTS", "url":
+      "/v4/images/linode/ubuntu22.04"}, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -596,7 +164,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "542"
+      - "530"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -634,16 +202,79 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346122938
+    url: https://api.linode.com/v4beta/account/events/346123429
     method: GET
   response:
-    body: '{"id": 346122938, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 346123429, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 59, "time_remaining": null, "rate": null, "duration":
+      34.623233, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller-instancepower", "id": 37916151, "type": "linode",
+      "url": "/v4/linode/instances/37916151"}, "status": "started", "secondary_entity":
+      {"id": "linode/ubuntu22.04", "type": "image", "label": "Ubuntu 22.04 LTS", "url":
+      "/v4/images/linode/ubuntu22.04"}, "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "530"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346123429
+    method: GET
+  response:
+    body: '{"id": 346123429, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      16.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
-      "status": "finished", "secondary_entity": {"id": 40387739, "type": "linode_config",
-      "label": "My Ubuntu 22.04 LTS Disk Profile", "url": "/v4/linode/instances/37916092/configs/40387739"},
-      "message": ""}'
+      45.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller-instancepower", "id": 37916151, "type": "linode",
+      "url": "/v4/linode/instances/37916151"}, "status": "finished", "secondary_entity":
+      {"id": "linode/ubuntu22.04", "type": "image", "label": "Ubuntu 22.04 LTS", "url":
+      "/v4/images/linode/ubuntu22.04"}, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -659,7 +290,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "537"
+      - "524"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -673,70 +304,6 @@ interactions:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37916092
-    method: GET
-  response:
-    body: '{"id": 37916092, "label": "linodego-test-eventpoller", "group": "", "status":
-      "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["170.187.155.44"], "ipv6": "1234::5678/128",
-      "image": "linode/ubuntu22.04", "region": "us-southeast", "specs": {"disk": 25600,
-      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
-      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
-      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
-      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "646"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -762,7 +329,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37916092,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37916151,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -820,7 +387,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37916092/shutdown
+    url: https://api.linode.com/v4beta/linode/instances/37916151/boot
     method: POST
   response:
     body: '{}'
@@ -876,16 +443,18 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37916092,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_boot","entity.id":37916151,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 346123095, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 41, "time_remaining": null, "rate": null,
-      "duration": 15.304352, "action": "linode_shutdown", "username": "lgarber-dev",
-      "entity": {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode",
-      "url": "/v4/linode/instances/37916092"}, "status": "started", "secondary_entity":
-      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
+    body: '{"data": [{"id": 346123705, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 49, "time_remaining": null, "rate": null,
+      "duration": 15.061685, "action": "linode_boot", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-eventpoller-instancepower", "id": 37916151, "type":
+      "linode", "url": "/v4/linode/instances/37916151"}, "status": "started", "secondary_entity":
+      {"id": 40387797, "type": "linode_config", "label": "My Ubuntu 22.04 LTS Disk
+      Profile", "url": "/v4/linode/instances/37916151/configs/40387797"}, "message":
+      ""}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -901,7 +470,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "457"
+      - "606"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -939,15 +508,17 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346123095
+    url: https://api.linode.com/v4beta/account/events/346123705
     method: GET
   response:
-    body: '{"id": 346123095, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 41, "time_remaining": null, "rate": null, "duration":
-      15.42827, "action": "linode_shutdown", "username": "lgarber-dev", "entity":
-      {"label": "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url":
-      "/v4/linode/instances/37916092"}, "status": "started", "secondary_entity": null,
-      "message": ""}'
+    body: '{"id": 346123705, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 49, "time_remaining": null, "rate": null, "duration":
+      15.183067, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller-instancepower", "id": 37916151, "type": "linode",
+      "url": "/v4/linode/instances/37916151"}, "status": "started", "secondary_entity":
+      {"id": 40387797, "type": "linode_config", "label": "My Ubuntu 22.04 LTS Disk
+      Profile", "url": "/v4/linode/instances/37916151/configs/40387797"}, "message":
+      ""}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -963,7 +534,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "407"
+      - "557"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -1001,14 +572,17 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/346123095
+    url: https://api.linode.com/v4beta/account/events/346123705
     method: GET
   response:
-    body: '{"id": 346123095, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 346123705, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      26.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
-      "linodego-test-eventpoller", "id": 37916092, "type": "linode", "url": "/v4/linode/instances/37916092"},
-      "status": "finished", "secondary_entity": null, "message": ""}'
+      17.0, "action": "linode_boot", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller-instancepower", "id": 37916151, "type": "linode",
+      "url": "/v4/linode/instances/37916151"}, "status": "finished", "secondary_entity":
+      {"id": 40387797, "type": "linode_config", "label": "My Ubuntu 22.04 LTS Disk
+      Profile", "url": "/v4/linode/instances/37916151/configs/40387797"}, "message":
+      ""}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -1024,7 +598,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "402"
+      - "551"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -1062,12 +636,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37916092
+    url: https://api.linode.com/v4beta/linode/instances/37916151
     method: GET
   response:
-    body: '{"id": 37916092, "label": "linodego-test-eventpoller", "group": "", "status":
-      "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["170.187.155.44"], "ipv6": "1234::5678/128",
+    body: '{"id": 37916151, "label": "linodego-test-eventpoller-instancepower", "group":
+      "", "status": "running", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["173.230.136.30"], "ipv6": "1234::5678/128",
       "image": "linode/ubuntu22.04", "region": "us-southeast", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
       90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
@@ -1088,7 +662,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "646"
+      - "660"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -1126,7 +700,374 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/37916092
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37916151,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [], "page": 1, "pages": 1, "results": 0}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "49"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37916151/shutdown
+    method: POST
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_shutdown","entity.id":37916151,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 346123825, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 26, "time_remaining": null, "rate": null,
+      "duration": 15.487352, "action": "linode_shutdown", "username": "lgarber-dev",
+      "entity": {"label": "linodego-test-eventpoller-instancepower", "id": 37916151,
+      "type": "linode", "url": "/v4/linode/instances/37916151"}, "status": "started",
+      "secondary_entity": null, "message": ""}], "page": 1, "pages": 1, "results":
+      1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "471"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346123825
+    method: GET
+  response:
+    body: '{"id": 346123825, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
+      15.595717, "action": "linode_shutdown", "username": "lgarber-dev", "entity":
+      {"label": "linodego-test-eventpoller-instancepower", "id": 37916151, "type":
+      "linode", "url": "/v4/linode/instances/37916151"}, "status": "started", "secondary_entity":
+      null, "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "422"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/346123825
+    method: GET
+  response:
+    body: '{"id": 346123825, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      20.0, "action": "linode_shutdown", "username": "lgarber-dev", "entity": {"label":
+      "linodego-test-eventpoller-instancepower", "id": 37916151, "type": "linode",
+      "url": "/v4/linode/instances/37916151"}, "status": "finished", "secondary_entity":
+      null, "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "416"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37916151
+    method: GET
+  response:
+    body: '{"id": 37916151, "label": "linodego-test-eventpoller-instancepower", "group":
+      "", "status": "offline", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["173.230.136.30"], "ipv6": "1234::5678/128",
+      "image": "linode/ubuntu22.04", "region": "us-southeast", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "660"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/37916151
     method: DELETE
   response:
     body: '{}'

--- a/waitfor.go
+++ b/waitfor.go
@@ -591,6 +591,26 @@ func (client Client) NewEventPoller(
 	return &result, nil
 }
 
+// NewEventPollerWithoutEntity initializes a new Linode event poller without a target entity ID.
+// This is useful for create events where the ID of the entity is not yet known.
+// For example:
+// p, _ := client.NewEventPollerWithoutEntity(...)
+// inst, _ := client.CreateInstance(...)
+// p.EntityID = inst.ID
+// ...
+func (client Client) NewEventPollerWithoutEntity(entityType EntityType, action EventAction) (*EventPoller, error) {
+	result := EventPoller{
+		EntityType:     entityType,
+		Action:         action,
+		EntityID:       0,
+		previousEvents: make(map[int]bool, 0),
+
+		client: client,
+	}
+
+	return &result, nil
+}
+
 // PreTask stores all current events for the given entity to prevent them from being
 // processed on subsequent runs.
 func (p *EventPoller) PreTask(ctx context.Context) error {


### PR DESCRIPTION
This pull request adds a `NewEventPollerWithoutEntity` function for initializing event pollers _before_ the entity ID is known.