### PR TITLE
fix: Continue polling on notification events

### DIFF
--- a/waitfor.go
+++ b/waitfor.go
@@ -714,11 +714,11 @@ func (p *EventPoller) WaitForFinished(
 			}
 
 			switch event.Status {
-			case EventFinished, EventNotification:
+			case EventFinished:
 				return event, nil
 			case EventFailed:
 				return nil, fmt.Errorf("event %d has failed", event.ID)
-			case EventScheduled, EventStarted:
+			case EventScheduled, EventStarted, EventNotification:
 				continue
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
This pull request alters the `EventPoller` logic to continue polling on `notification` event statuses. This is necessary for scheduled events that haven't run yet.