### PR TITLE
fix: Retry on NGINX LB errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -239,6 +239,7 @@ func (c *Client) SetRetries() *Client {
 		addRetryConditional(tooManyRequestsRetryCondition).
 		addRetryConditional(serviceUnavailableRetryCondition).
 		addRetryConditional(requestTimeoutRetryCondition).
+		addRetryConditional(requestNGINXRetryCondition).
 		SetRetryMaxWaitTime(APIRetryMaxWaitTime)
 	configureRetries(c)
 	return c

--- a/retries.go
+++ b/retries.go
@@ -74,6 +74,10 @@ func requestTimeoutRetryCondition(r *resty.Response, _ error) bool {
 	return r.StatusCode() == http.StatusRequestTimeout
 }
 
+func requestNGINXRetryCondition(r *resty.Response, _ error) bool {
+	return r.StatusCode() == http.StatusBadRequest && r.Header().Get("server") == "nginx"
+}
+
 func respectRetryAfter(client *resty.Client, resp *resty.Response) (time.Duration, error) {
 	retryAfterStr := resp.Header().Get(retryAfterHeaderName)
 	if retryAfterStr == "" {

--- a/retries.go
+++ b/retries.go
@@ -75,7 +75,10 @@ func requestTimeoutRetryCondition(r *resty.Response, _ error) bool {
 }
 
 func requestNGINXRetryCondition(r *resty.Response, _ error) bool {
-	return r.StatusCode() == http.StatusBadRequest && r.Header().Get("server") == "nginx"
+	return r.StatusCode() == http.StatusBadRequest &&
+		r.Header().Get("Server") == "nginx" &&
+		r.Header().Get("Content-Type") == "text/html"
+
 }
 
 func respectRetryAfter(client *resty.Client, resp *resty.Response) (time.Duration, error) {

--- a/retries.go
+++ b/retries.go
@@ -78,7 +78,6 @@ func requestNGINXRetryCondition(r *resty.Response, _ error) bool {
 	return r.StatusCode() == http.StatusBadRequest &&
 		r.Header().Get("Server") == "nginx" &&
 		r.Header().Get("Content-Type") == "text/html"
-
 }
 
 func respectRetryAfter(client *resty.Client, resp *resty.Response) (time.Duration, error) {

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -1,6 +1,10 @@
 package integration
 
 import (
+	"context"
+	"github.com/jarcoal/httpmock"
+	"github.com/linode/linodego"
+	"net/http"
 	"testing"
 )
 
@@ -24,5 +28,43 @@ func TestClient_Aliases(t *testing.T) {
 	}
 	if client.Volumes == nil {
 		t.Error("Expected alias for Volumes to return a *Resource")
+	}
+}
+
+func TestClient_NGINXRetry(t *testing.T) {
+	client := createMockClient(t)
+
+	// Recreate the NGINX LB error
+	nginxErrorFunc := func(request *http.Request) (*http.Response, error) {
+		resp, err := httpmock.NewJsonResponse(400, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		resp.Header.Add("Server", "nginx")
+
+		return resp, nil
+	}
+
+	step := 0
+
+	httpmock.RegisterRegexpResponder("PUT",
+		mockRequestURL(t, "/profile"), func(request *http.Request) (*http.Response, error) {
+			if step == 0 {
+				step = 1
+				return nginxErrorFunc(request)
+			}
+
+			step = 2
+			return httpmock.NewJsonResponse(200, nil)
+		})
+
+	if _, err := client.UpdateProfile(context.Background(),
+		linodego.ProfileUpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if step != 2 {
+		t.Fatalf("retry checks did not finish")
 	}
 }

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -36,12 +36,10 @@ func TestClient_NGINXRetry(t *testing.T) {
 
 	// Recreate the NGINX LB error
 	nginxErrorFunc := func(request *http.Request) (*http.Response, error) {
-		resp, err := httpmock.NewJsonResponse(400, nil)
-		if err != nil {
-			return nil, err
-		}
+		resp := httpmock.NewStringResponse(400, "")
 
 		resp.Header.Add("Server", "nginx")
+		resp.Header.Set("Content-Type", "text/html")
 
 		return resp, nil
 	}
@@ -51,11 +49,11 @@ func TestClient_NGINXRetry(t *testing.T) {
 	httpmock.RegisterRegexpResponder("PUT",
 		mockRequestURL(t, "/profile"), func(request *http.Request) (*http.Response, error) {
 			if step == 0 {
-				step = 1
+				step++
 				return nginxErrorFunc(request)
 			}
 
-			step = 2
+			step++
 			return httpmock.NewJsonResponse(200, nil)
 		})
 


### PR DESCRIPTION
This change enables automatic retries on intermittent NGINX HTML errors. This is necessary as these errors return `text/html` rather than the expected JSON, which causes unhandled errors to be thrown.