### PR TITLE
Add NetworkProtocol for IPENCAP support

### DIFF
--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -10,9 +10,10 @@ type NetworkProtocol string
 
 // NetworkProtocol enum values
 const (
-	TCP  NetworkProtocol = "TCP"
-	UDP  NetworkProtocol = "UDP"
-	ICMP NetworkProtocol = "ICMP"
+	TCP     NetworkProtocol = "TCP"
+	UDP     NetworkProtocol = "UDP"
+	ICMP    NetworkProtocol = "ICMP"
+	IPENCAP NetworkProtocol = "IPENCAP"
 )
 
 // NetworkAddresses are arrays of ipv4 and v6 addresses


### PR DESCRIPTION
Adds a new NetworkProtocol for IPENCAP. Support for IPENCAP was added to the [Linode API](https://www.linode.com/docs/api/networking/#firewall-rules-update) to allow encapsulated IPIP layer3 traffic (no layer4 protocol). This is necessary to support attaching a Firewall to an LKE Cluster

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)
