### PR TITLE
doc: Use standard `pull_request_template.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,13 @@
-### General:
+## 📝 Description
 
-* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
-* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?
+**What does this PR do and why is this change necessary?**
 
-### Pull Request Guidelines:
+## ✔️ How to Test
 
-1. [ ] Does your submission pass tests?
-1. [ ] Have you added tests? 
-1. [ ] Are you addressing a single feature in this PR? 
-1. [ ] Are your commits atomic, addressing one change per commit?
-1. [ ] Are you following the conventions of the language? 
-1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
-1. [ ] Have you explained your rationale for why this feature is needed? 
-1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)
+**What are the steps to reproduce the issue or verify the changes?**
+
+**How do I run the relevant unit/integration tests?**
+
+## 📷 Preview
+
+**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**


### PR DESCRIPTION
## 📝 Description

This change adds a template that will be used by default on new pull requests. This is useful for standardizing the format of our PRs and encouraging detailed PR descriptions.