### PR TITLE
fix: Use hex notation for ListOptions.Hash(...)

### DIFF
--- a/pagination.go
+++ b/pagination.go
@@ -44,7 +44,9 @@ func (l ListOptions) Hash() (string, error) {
 
 	h := sha256.New()
 
-	return string(h.Sum(data)), nil
+	h.Write(data)
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
 func applyListOptionsToRequest(opts *ListOptions, req *resty.Request) {


### PR DESCRIPTION
## 📝 Description

This pull request alters the `ListOptions.Hash(...)` function to output in hexidecimal notation rather than attempting to encode a byte slice.
