### PR TITLE
Grants List

### DIFF
--- a/account_user_grants.go
+++ b/account_user_grants.go
@@ -48,6 +48,7 @@ type UserGrants struct {
 	NodeBalancer []GrantedEntity `json:"nodebalancer"`
 	StackScript  []GrantedEntity `json:"stackscript"`
 	Volume       []GrantedEntity `json:"volume"`
+	Database     []GrantedEntity `json:"database"`
 
 	Global GlobalUserGrants `json:"global"`
 }

--- a/account_user_grants.go
+++ b/account_user_grants.go
@@ -40,6 +40,7 @@ type GrantedEntity struct {
 }
 
 type UserGrants struct {
+	Database     []GrantedEntity `json:"database"`
 	Domain       []GrantedEntity `json:"domain"`
 	Firewall     []GrantedEntity `json:"firewall"`
 	Image        []GrantedEntity `json:"image"`
@@ -48,7 +49,6 @@ type UserGrants struct {
 	NodeBalancer []GrantedEntity `json:"nodebalancer"`
 	StackScript  []GrantedEntity `json:"stackscript"`
 	Volume       []GrantedEntity `json:"volume"`
-	Database     []GrantedEntity `json:"database"`
 
 	Global GlobalUserGrants `json:"global"`
 }

--- a/account_user_grants.go
+++ b/account_user_grants.go
@@ -15,8 +15,8 @@ const (
 
 type GlobalUserGrants struct {
 	AccountAccess        *GrantPermissionLevel `json:"account_access"`
-	AddDomains           bool                  `json:"add_domains"`
 	AddDatabases         bool                  `json:"add_databases"`
+	AddDomains           bool                  `json:"add_domains"`
 	AddFirewalls         bool                  `json:"add_firewalls"`
 	AddImages            bool                  `json:"add_images"`
 	AddLinodes           bool                  `json:"add_linodes"`
@@ -54,6 +54,7 @@ type UserGrants struct {
 }
 
 type UserGrantsUpdateOptions struct {
+	Database     []GrantedEntity   `json:"database,omitempty"`
 	Domain       []EntityUserGrant `json:"domain,omitempty"`
 	Firewall     []EntityUserGrant `json:"firewall,omitempty"`
 	Image        []EntityUserGrant `json:"image,omitempty"`

--- a/errors.go
+++ b/errors.go
@@ -61,7 +61,7 @@ func coupleAPIErrors(r *resty.Response, err error) (*resty.Response, error) {
 			return nil, Error{Code: http.StatusBadGateway, Message: http.StatusText(http.StatusBadGateway)}
 		}
 
-		if responseContentType != expectedContentType {
+		if r.StatusCode() != 204 && responseContentType != expectedContentType {
 			msg := fmt.Sprintf(
 				"Unexpected Content-Type: Expected: %v, Received: %v\nResponse body: %s",
 				expectedContentType,

--- a/errors.go
+++ b/errors.go
@@ -61,7 +61,7 @@ func coupleAPIErrors(r *resty.Response, err error) (*resty.Response, error) {
 			return nil, Error{Code: http.StatusBadGateway, Message: http.StatusText(http.StatusBadGateway)}
 		}
 
-		if r.StatusCode() != 204 && responseContentType != expectedContentType {
+		if responseContentType != expectedContentType {
 			msg := fmt.Sprintf(
 				"Unexpected Content-Type: Expected: %v, Received: %v\nResponse body: %s",
 				expectedContentType,

--- a/profile_grants_list.go
+++ b/profile_grants_list.go
@@ -1,0 +1,25 @@
+package linodego
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type GrantsListResponse = UserGrants
+
+
+func (c *Client) GrantsList(ctx context.Context) (*GrantsListResponse, error) {
+	e := "profile/grants"
+	r, err := coupleAPIErrors(c.R(ctx).Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	if r.StatusCode() == 204 {
+		return nil, nil
+	}
+	var result GrantsListResponse
+	err = json.Unmarshal(r.Body(), &result)
+
+	return &result, err
+}

--- a/profile_grants_list.go
+++ b/profile_grants_list.go
@@ -7,7 +7,6 @@ import (
 
 type GrantsListResponse = UserGrants
 
-
 func (c *Client) GrantsList(ctx context.Context) (*GrantsListResponse, error) {
 	e := "profile/grants"
 	r, err := coupleAPIErrors(c.R(ctx).Get(e))

--- a/profile_grants_list.go
+++ b/profile_grants_list.go
@@ -2,6 +2,7 @@ package linodego
 
 import (
 	"context"
+	"log"
 )
 
 type GrantsListResponse = UserGrants
@@ -12,5 +13,13 @@ func (c *Client) GrantsList(ctx context.Context) (*GrantsListResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if r.StatusCode() == 204 {
+		log.Printf(
+			"[WARN] The user has a full account access, " +
+				"the instance of the struct would be empty",
+		)
+	}
+
 	return r.Result().(*GrantsListResponse), err
 }

--- a/profile_grants_list.go
+++ b/profile_grants_list.go
@@ -2,7 +2,6 @@ package linodego
 
 import (
 	"context"
-	"log"
 )
 
 type GrantsListResponse = UserGrants
@@ -12,13 +11,6 @@ func (c *Client) GrantsList(ctx context.Context) (*GrantsListResponse, error) {
 	r, err := coupleAPIErrors(c.R(ctx).SetResult(GrantsListResponse{}).Get(e))
 	if err != nil {
 		return nil, err
-	}
-
-	if r.StatusCode() == 204 {
-		log.Printf(
-			"[WARN] The user has a full account access, " +
-				"the instance of the struct would be empty",
-		)
 	}
 
 	return r.Result().(*GrantsListResponse), err

--- a/profile_grants_list.go
+++ b/profile_grants_list.go
@@ -3,6 +3,7 @@ package linodego
 import (
 	"context"
 	"encoding/json"
+	"log"
 )
 
 type GrantsListResponse = UserGrants
@@ -14,11 +15,15 @@ func (c *Client) GrantsList(ctx context.Context) (*GrantsListResponse, error) {
 		return nil, err
 	}
 
-	if r.StatusCode() == 204 {
-		return nil, nil
-	}
 	var result GrantsListResponse
-	err = json.Unmarshal(r.Body(), &result)
-
+	err = nil
+	if r.StatusCode() == 204 {
+		log.Printf(
+			"[WARN] The user has a full account access, " +
+				"the instance of the struct would be empty",
+		)
+	} else {
+		err = json.Unmarshal(r.Body(), &result)
+	}
 	return &result, err
 }

--- a/profile_grants_list.go
+++ b/profile_grants_list.go
@@ -2,28 +2,16 @@ package linodego
 
 import (
 	"context"
-	"encoding/json"
-	"log"
 )
 
 type GrantsListResponse = UserGrants
 
 func (c *Client) GrantsList(ctx context.Context) (*GrantsListResponse, error) {
 	e := "profile/grants"
-	r, err := coupleAPIErrors(c.R(ctx).Get(e))
+	r, err := coupleAPIErrors(c.R(ctx).SetResult(GrantsListResponse{}).Get(e))
 	if err != nil {
 		return nil, err
 	}
-
-	var result GrantsListResponse
-	err = nil
-	if r.StatusCode() == 204 {
-		log.Printf(
-			"[WARN] The user has a full account access, " +
-				"the instance of the struct would be empty",
-		)
-	} else {
-		err = json.Unmarshal(r.Body(), &result)
-	}
-	return &result, err
+	// TODO: handle 204 empty content response
+	return r.Result().(*GrantsListResponse), err
 }

--- a/profile_grants_list.go
+++ b/profile_grants_list.go
@@ -12,6 +12,5 @@ func (c *Client) GrantsList(ctx context.Context) (*GrantsListResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: handle 204 empty content response
 	return r.Result().(*GrantsListResponse), err
 }

--- a/test/integration/fixtures/TestGrantsList.yaml
+++ b/test/integration/fixtures/TestGrantsList.yaml
@@ -1,0 +1,56 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/profile/grants
+    method: GET
+  response:
+    body: ""
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 204 No Content
+    code: 204
+    duration: ""

--- a/test/integration/profile_grants_list_test.go
+++ b/test/integration/profile_grants_list_test.go
@@ -1,0 +1,16 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	//"github.com/google/go-cmp/cmp"
+	//"github.com/linode/linodego"
+)
+
+func TestGrantsList(t *testing.T) {
+	//username := usernamePrefix + "grantslist"
+
+	client, teardown := createTestClient(t, "fixtures/TestGrantsList")
+	client.GrantsList(context.Background())
+	defer teardown()
+}

--- a/test/integration/profile_grants_list_test.go
+++ b/test/integration/profile_grants_list_test.go
@@ -2,15 +2,113 @@ package integration
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jarcoal/httpmock"
+	"github.com/linode/linodego"
+	"reflect"
 	"testing"
-	//"github.com/google/go-cmp/cmp"
-	//"github.com/linode/linodego"
 )
 
 func TestGrantsList(t *testing.T) {
 	//username := usernamePrefix + "grantslist"
+	client := createMockClient(t)
+	accessLevel := linodego.AccessLevelReadOnly
+	desiredResponse := linodego.GrantsListResponse{
+		Database: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_write",
+			},
+		},
+		Domain: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_only",
+			},
+		},
+		Firewall: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_only",
+			},
+		},
+		Image: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_only",
+			},
+		},
+		Linode: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_write",
+			},
+		},
+		Longview: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_write",
+			},
+		},
+		NodeBalancer: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_only",
+			},
+		},
+		StackScript: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_only",
+			},
+		},
+		Volume: []linodego.GrantedEntity{
+			{
+				ID:          1,
+				Label:       "example-entity-label",
+				Permissions: "read_only",
+			},
+		},
 
-	client, teardown := createTestClient(t, "fixtures/TestGrantsList")
-	client.GrantsList(context.Background())
-	defer teardown()
+		Global: linodego.GlobalUserGrants{
+			AccountAccess:        &accessLevel,
+			AddDomains:           false,
+			AddDatabases:         true,
+			AddFirewalls:         false,
+			AddImages:            true,
+			AddLinodes:           true,
+			AddLongview:          true,
+			AddNodeBalancers:     true,
+			AddStackScripts:      true,
+			AddVolumes:           false,
+			CancelAccount:        false,
+			LongviewSubscription: true,
+		},
+	}
+
+	httpmock.RegisterRegexpResponder(
+		"GET",
+		mockRequestURL(t, "/profile/grants"),
+		httpmock.NewJsonResponderOrPanic(200, &desiredResponse),
+	)
+	grants, err := client.GrantsList(context.Background())
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(*grants, desiredResponse) {
+		t.Fatalf(
+			"actual response does not equal desired response: %s",
+			cmp.Diff(grants, desiredResponse),
+		)
+	}
 }


### PR DESCRIPTION
<strike>#### Current issues:
1. [The existing utility function](https://github.com/linode/linodego/blob/cfc31f1d4d543943a8b880221304eaa64bd6cf5f/errors.go#L64) that's used to access the API will throw an error when 204 response received because of the expected `content-type` `application/json` defined [here](https://github.com/linode/linodego/blob/cfc31f1d4d543943a8b880221304eaa64bd6cf5f/client.go#L111).
2. There is not an obvious way to test grants list because the test client cannot access the token of a newly created user with some grants. And only that user (or app with the token of the user) can access its own grants via grants list API.


#### Possible and hopefully not the only solutions:
1. Manually testing and merge without an integration test. (Oh no!)
2. Making this ticket as blocked until we fix the utility function. (We will do it, right?)

Update 01/27:
Potential braking change: ignoring content type mismatch error when the response body is empty (204 response).
</strike>
Update 01/31:
Made this PR simple and postpone the potential breaking change.
Grants API docs added database options/attributes recently, so updated it here as well.