### PR TITLE
Add ListObjectStorageBucketsInCluster

### DIFF
--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -102,7 +102,7 @@ func (c *Client) ListObjectStorageBuckets(ctx context.Context, opts *ListOptions
 	return response.Data, nil
 }
 
-//ListObjectStorageBucketsInCluster lists all ObjectStorageBuckets of a cluster
+// ListObjectStorageBucketsInCluster lists all ObjectStorageBuckets of a cluster
 func (c *Client) ListObjectStorageBucketsInCluster(ctx context.Context, opts *ListOptions, clusterID string) ([]ObjectStorageBucket, error) {
 	response := ObjectStorageBucketsPagedResponse{}
 	err := c.listHelper(ctx, &response, opts, clusterID)

--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -102,6 +102,16 @@ func (c *Client) ListObjectStorageBuckets(ctx context.Context, opts *ListOptions
 	return response.Data, nil
 }
 
+//ListObjectStorageBucketsInCluster lists all ObjectStorageBuckets of a cluster
+func (c *Client) ListObjectStorageBucketsInCluster(ctx context.Context, opts *ListOptions, clusterID string) ([]ObjectStorageBucket, error) {
+	response := ObjectStorageBucketsPagedResponse{}
+	err := c.listHelper(ctx, &response, opts, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return response.Data, nil
+}
+
 // GetObjectStorageBucket gets the ObjectStorageBucket with the provided label
 func (c *Client) GetObjectStorageBucket(ctx context.Context, clusterID, label string) (*ObjectStorageBucket, error) {
 	e := fmt.Sprintf("object-storage/buckets/%s/%s", clusterID, label)

--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -78,8 +78,12 @@ type ObjectStorageBucketsPagedResponse struct {
 }
 
 // endpoint gets the endpoint URL for ObjectStorageBucket
-func (ObjectStorageBucketsPagedResponse) endpoint(_ ...any) string {
-	return "object-storage/buckets"
+func (ObjectStorageBucketsPagedResponse) endpoint(args ...any) string {
+	endpoint := "object-storage/buckets"
+	if len(args) > 0 {
+		endpoint = fmt.Sprintf(endpoint+"/%s", args[0])
+	}
+	return endpoint
 }
 
 func (resp *ObjectStorageBucketsPagedResponse) castResult(r *resty.Request, e string) (int, int, error) {

--- a/test/integration/fixtures/TestObjectStorageBucketsInCluster_List.yaml
+++ b/test/integration/fixtures/TestObjectStorageBucketsInCluster_List.yaml
@@ -68,7 +68,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/object-storage/buckets
+    url: https://api.linode.com/v4beta/object-storage/buckets/us-east-1
     method: GET
   response:
     body: '{"page": 1, "pages": 1, "results": 1, "data": [{"hostname": "go-bucket-test-def.us-east-1.linodeobjects.com",

--- a/test/integration/fixtures/TestObjectStorageBucketsInCluster_List.yaml
+++ b/test/integration/fixtures/TestObjectStorageBucketsInCluster_List.yaml
@@ -1,0 +1,174 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"cluster":"us-east-1","label":"go-bucket-test-def"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/object-storage/buckets
+    method: POST
+  response:
+    body: '{"hostname": "go-bucket-test-def.us-east-1.linodeobjects.com", "label":
+      "go-bucket-test-def", "created": "2018-01-02T03:04:05", "cluster": "us-east-1",
+      "size": 0, "objects": 0}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "176"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - object_storage:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/object-storage/buckets
+    method: GET
+  response:
+    body: '{"page": 1, "pages": 1, "results": 1, "data": [{"hostname": "go-bucket-test-def.us-east-1.linodeobjects.com",
+      "label": "go-bucket-test-def", "created": "2018-01-02T03:04:05", "cluster":
+      "us-east-1", "size": 0, "objects": 0}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "225"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - object_storage:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/object-storage/buckets/us-east-1/go-bucket-test-def
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - object_storage:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/object_storage_buckets_test.go
+++ b/test/integration/object_storage_buckets_test.go
@@ -99,6 +99,24 @@ func TestObjectStorageBuckets_List(t *testing.T) {
 	}
 }
 
+func TestObjectStorageBucketsInCluster_List(t *testing.T) {
+	client, bucket, teardown, err := setupObjectStorageBucket(t,
+        nil,
+        "fixtures/TestObjectStorageBucketsInCluster_List")
+    defer teardown()
+
+    i, err := client.ListObjectStorageBucketsInCluster(context.Background(), nil, bucket.Cluster)
+    if err!= nil {
+        t.Errorf("Error listing ObjectStorageBucketsInCluster, expected struct, got error %v", err)
+    }
+    if len(i) == 0 {
+        t.Errorf("Expected a list of ObjectStorageBucketsInCluster, but got none %v", i)
+    } else if i[0].Label == "" ||
+        i[0].Cluster == "" {
+        t.Errorf("Listed Object Storage Bucket in Cluster did not have attribuets %v", i)
+    }
+}
+
 func TestObjectStorageBucket_Access_Get(t *testing.T) {
 	corsEnabled := false
 

--- a/test/integration/object_storage_buckets_test.go
+++ b/test/integration/object_storage_buckets_test.go
@@ -101,20 +101,20 @@ func TestObjectStorageBuckets_List(t *testing.T) {
 
 func TestObjectStorageBucketsInCluster_List(t *testing.T) {
 	client, bucket, teardown, err := setupObjectStorageBucket(t,
-        nil,
-        "fixtures/TestObjectStorageBucketsInCluster_List")
-    defer teardown()
+		nil,
+		"fixtures/TestObjectStorageBucketsInCluster_List")
+	defer teardown()
 
-    i, err := client.ListObjectStorageBucketsInCluster(context.Background(), nil, bucket.Cluster)
-    if err!= nil {
-        t.Errorf("Error listing ObjectStorageBucketsInCluster, expected struct, got error %v", err)
-    }
-    if len(i) == 0 {
-        t.Errorf("Expected a list of ObjectStorageBucketsInCluster, but got none %v", i)
-    } else if i[0].Label == "" ||
-        i[0].Cluster == "" {
-        t.Errorf("Listed Object Storage Bucket in Cluster did not have attribuets %v", i)
-    }
+	i, err := client.ListObjectStorageBucketsInCluster(context.Background(), nil, bucket.Cluster)
+	if err != nil {
+		t.Errorf("Error listing ObjectStorageBucketsInCluster, expected struct, got error %v", err)
+	}
+	if len(i) == 0 {
+		t.Errorf("Expected a list of ObjectStorageBucketsInCluster, but got none %v", i)
+	} else if i[0].Label == "" ||
+		i[0].Cluster == "" {
+		t.Errorf("Listed Object Storage Bucket in Cluster did not have attribuets %v", i)
+	}
 }
 
 func TestObjectStorageBucket_Access_Get(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

Add the support to [ListObjectStorageBucketsInCluster](https://www.linode.com/docs/api/object-storage/#object-storage-buckets-in-cluster-list) and allow users to list all of the buckets for a given cluster. 

## ✔️ How to Test

`make testunit`
`make testint`

```
=== RUN   TestObjectStorageBucketsInCluster_List
--- PASS: TestObjectStorageBucketsInCluster_List (0.00s)

...
PASS
ok  	github.com/linode/linodego/test/integration	135.946s
```