### PR TITLE
ref: Use error wrapping for returned errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -294,7 +294,7 @@ func (c *Client) InvalidateCache() {
 func (c *Client) InvalidateCacheEndpoint(endpoint string) error {
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return fmt.Errorf("failed to parse URL for caching: %s", err)
+		return fmt.Errorf("failed to parse URL for caching: %w", err)
 	}
 
 	c.cachedEntryLock.Lock()
@@ -439,7 +439,7 @@ func NewClientFromEnv(hc *http.Client) (*Client, error) {
 
 	// We should only load the config if the config file exists
 	if _, err := os.Stat(configPath); err != nil {
-		return nil, fmt.Errorf("error loading config file %s: %s", configPath, err)
+		return nil, fmt.Errorf("error loading config file %s: %w", configPath, err)
 	}
 
 	err = client.preLoadConfig(configPath)

--- a/config.go
+++ b/config.go
@@ -65,7 +65,7 @@ func (c *Client) LoadConfig(options *LoadConfigOptions) error {
 	if cfg.HasSection("default") {
 		err := cfg.Section("default").MapTo(&defaultConfig)
 		if err != nil {
-			return fmt.Errorf("failed to map default profile: %s", err)
+			return fmt.Errorf("failed to map default profile: %w", err)
 		}
 	}
 
@@ -76,7 +76,7 @@ func (c *Client) LoadConfig(options *LoadConfigOptions) error {
 
 		f := defaultConfig
 		if err := profile.MapTo(&f); err != nil {
-			return fmt.Errorf("failed to map values: %s", err)
+			return fmt.Errorf("failed to map values: %w", err)
 		}
 
 		result[name] = f
@@ -86,7 +86,7 @@ func (c *Client) LoadConfig(options *LoadConfigOptions) error {
 
 	if !options.SkipLoadProfile {
 		if err := c.UseProfile(profileOption); err != nil {
-			return fmt.Errorf("unable to use profile %s: %s", profileOption, err)
+			return fmt.Errorf("unable to use profile %s: %w", profileOption, err)
 		}
 	}
 

--- a/k8s/clientset.go
+++ b/k8s/clientset.go
@@ -20,12 +20,12 @@ func BuildClientsetFromConfig(
 ) (kubernetes.Interface, error) {
 	kubeConfigBytes, err := base64.StdEncoding.DecodeString(lkeKubeconfig.KubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode kubeconfig: %s", err)
+		return nil, fmt.Errorf("failed to decode kubeconfig: %w", err)
 	}
 
 	restClientConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfigBytes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse LKE cluster kubeconfig: %s", err)
+		return nil, fmt.Errorf("failed to parse LKE cluster kubeconfig: %w", err)
 	}
 
 	if transportWrapper != nil {
@@ -34,7 +34,7 @@ func BuildClientsetFromConfig(
 
 	clientset, err := kubernetes.NewForConfig(restClientConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build k8s client from LKE cluster kubeconfig: %s", err)
+		return nil, fmt.Errorf("failed to build k8s client from LKE cluster kubeconfig: %w", err)
 	}
 	return clientset, nil
 }

--- a/k8s/pkg/condition/lke.go
+++ b/k8s/pkg/condition/lke.go
@@ -20,7 +20,7 @@ func ClusterHasReadyNode(ctx context.Context, options linodego.ClusterConditionO
 
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, v1.ListOptions{})
 	if err != nil {
-		return false, fmt.Errorf("failed to get nodes for cluster: %s", err)
+		return false, fmt.Errorf("failed to get nodes for cluster: %w", err)
 	}
 
 	for _, node := range nodes.Items {

--- a/pagination.go
+++ b/pagination.go
@@ -39,7 +39,7 @@ func NewListOptions(page int, filter string) *ListOptions {
 func (l ListOptions) Hash() (string, error) {
 	data, err := json.Marshal(l)
 	if err != nil {
-		return "", fmt.Errorf("failed to cache ListOptions: %s", err)
+		return "", fmt.Errorf("failed to cache ListOptions: %w", err)
 	}
 
 	h := sha256.New()

--- a/vlans.go
+++ b/vlans.go
@@ -74,12 +74,12 @@ func (c *Client) GetVLANIPAMAddress(ctx context.Context, linodeID int, vlanLabel
 	f.AddField(Eq, "interfaces", vlanLabel)
 	vlanFilter, err := f.MarshalJSON()
 	if err != nil {
-		return "", fmt.Errorf("Unable to convert VLAN label: %s to a filterable object: %s", vlanLabel, err)
+		return "", fmt.Errorf("Unable to convert VLAN label: %s to a filterable object: %w", vlanLabel, err)
 	}
 
 	cfgs, err := c.ListInstanceConfigs(ctx, linodeID, &ListOptions{Filter: string(vlanFilter)})
 	if err != nil {
-		return "", fmt.Errorf("Fetching configs for instance %v failed: %s", linodeID, err)
+		return "", fmt.Errorf("Fetching configs for instance %v failed: %w", linodeID, err)
 	}
 
 	interfaces := cfgs[0].Interfaces
@@ -89,5 +89,5 @@ func (c *Client) GetVLANIPAMAddress(ctx context.Context, linodeID int, vlanLabel
 		}
 	}
 
-	return "", fmt.Errorf("Failed to find IPAMAddress for VLAN: %s", vlanLabel)
+	return "", fmt.Errorf("Failed to find IPAMAddress for VLAN: %w", vlanLabel)
 }

--- a/vlans.go
+++ b/vlans.go
@@ -89,5 +89,5 @@ func (c *Client) GetVLANIPAMAddress(ctx context.Context, linodeID int, vlanLabel
 		}
 	}
 
-	return "", fmt.Errorf("Failed to find IPAMAddress for VLAN: %w", vlanLabel)
+	return "", fmt.Errorf("Failed to find IPAMAddress for VLAN: %s", vlanLabel)
 }

--- a/waitfor.go
+++ b/waitfor.go
@@ -41,7 +41,7 @@ func (client Client) WaitForInstanceStatus(ctx context.Context, instanceID int, 
 				return instance, nil
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Instance %d status %s: %s", instanceID, status, ctx.Err())
+			return nil, fmt.Errorf("Error waiting for Instance %d status %s: %w", instanceID, status, ctx.Err())
 		}
 	}
 }
@@ -77,7 +77,7 @@ func (client Client) WaitForInstanceDiskStatus(ctx context.Context, instanceID i
 				}
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Instance %d Disk %d status %s: %s", instanceID, diskID, status, ctx.Err())
+			return nil, fmt.Errorf("Error waiting for Instance %d Disk %d status %s: %w", instanceID, diskID, status, ctx.Err())
 		}
 	}
 }
@@ -104,7 +104,7 @@ func (client Client) WaitForVolumeStatus(ctx context.Context, volumeID int, stat
 				return volume, nil
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Volume %d status %s: %s", volumeID, status, ctx.Err())
+			return nil, fmt.Errorf("Error waiting for Volume %d status %s: %w", volumeID, status, ctx.Err())
 		}
 	}
 }
@@ -131,7 +131,7 @@ func (client Client) WaitForSnapshotStatus(ctx context.Context, instanceID int, 
 				return snapshot, nil
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Instance %d Snapshot %d status %s: %s", instanceID, snapshotID, status, ctx.Err())
+			return nil, fmt.Errorf("Error waiting for Instance %d Snapshot %d status %s: %w", instanceID, snapshotID, status, ctx.Err())
 		}
 	}
 }
@@ -164,7 +164,7 @@ func (client Client) WaitForVolumeLinodeID(ctx context.Context, volumeID int, li
 				return volume, nil
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Volume %d to have Instance %v: %s", volumeID, linodeID, ctx.Err())
+			return nil, fmt.Errorf("Error waiting for Volume %d to have Instance %v: %w", volumeID, linodeID, ctx.Err())
 		}
 	}
 }
@@ -191,7 +191,7 @@ func (client Client) WaitForLKEClusterStatus(ctx context.Context, clusterID int,
 				return cluster, nil
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Cluster %d status %s: %s", clusterID, status, ctx.Err())
+			return nil, fmt.Errorf("Error waiting for Cluster %d status %s: %w", clusterID, status, ctx.Err())
 		}
 	}
 }
@@ -234,7 +234,7 @@ func (client Client) WaitForLKEClusterConditions(
 
 	lkeKubeConfig, err := client.GetLKEClusterKubeconfig(ctx, clusterID)
 	if err != nil {
-		return fmt.Errorf("failed to get Kubeconfig for LKE cluster %d: %s", clusterID, err)
+		return fmt.Errorf("failed to get Kubeconfig for LKE cluster %d: %w", clusterID, err)
 	}
 
 	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
@@ -260,7 +260,7 @@ func (client Client) WaitForLKEClusterConditions(
 				}
 
 			case <-ctx.Done():
-				return fmt.Errorf("Error waiting for cluster %d conditions: %s", clusterID, ctx.Err())
+				return fmt.Errorf("Error waiting for cluster %d conditions: %w", clusterID, ctx.Err())
 			}
 		}
 	}
@@ -291,7 +291,7 @@ func (client Client) WaitForEventFinished(ctx context.Context, id any, entityTyp
 		// All of the filter supported types have int ids
 		filterableEntityID, err := strconv.Atoi(fmt.Sprintf("%v", id))
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing Entity ID %q for optimized WaitForEventFinished EventType %q: %s", id, entityType, err)
+			return nil, fmt.Errorf("Error parsing Entity ID %q for optimized WaitForEventFinished EventType %q: %w", id, entityType, err)
 		}
 		filter.AddField(Eq, "entity.id", filterableEntityID)
 		filter.AddField(Eq, "entity.type", entityType)
@@ -397,7 +397,7 @@ func (client Client) WaitForEventFinished(ctx context.Context, id any, entityTyp
 				lastLog = nextLog
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Event Status '%s' of %s %v action '%s': %s", EventFinished, titledEntityType, id, action, ctx.Err())
+			return nil, fmt.Errorf("Error waiting for Event Status '%s' of %s %v action '%s': %w", EventFinished, titledEntityType, id, action, ctx.Err())
 		}
 	}
 }
@@ -424,7 +424,7 @@ func (client Client) WaitForImageStatus(ctx context.Context, imageID string, sta
 				return image, nil
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for Image %s status %s: %s", imageID, status, ctx.Err())
+			return nil, fmt.Errorf("failed to wait for Image %s status %s: %w", imageID, status, ctx.Err())
 		}
 	}
 }
@@ -451,7 +451,7 @@ func (client Client) WaitForMySQLDatabaseBackup(ctx context.Context, dbID int, l
 				}
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for backup %s: %s", label, ctx.Err())
+			return nil, fmt.Errorf("failed to wait for backup %s: %w", label, ctx.Err())
 		}
 	}
 }
@@ -478,7 +478,7 @@ func (client Client) WaitForMongoDatabaseBackup(ctx context.Context, dbID int, l
 				}
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for backup %s: %s", label, ctx.Err())
+			return nil, fmt.Errorf("failed to wait for backup %s: %w", label, ctx.Err())
 		}
 	}
 }
@@ -505,7 +505,7 @@ func (client Client) WaitForPostgresDatabaseBackup(ctx context.Context, dbID int
 				}
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for backup %s: %s", label, ctx.Err())
+			return nil, fmt.Errorf("failed to wait for backup %s: %w", label, ctx.Err())
 		}
 	}
 }
@@ -559,14 +559,14 @@ func (client Client) WaitForDatabaseStatus(
 
 			currentStatus, err := statusHandler(ctx, client, dbID)
 			if err != nil {
-				return fmt.Errorf("failed to get db status: %s", err)
+				return fmt.Errorf("failed to get db status: %w", err)
 			}
 
 			if currentStatus == status {
 				return nil
 			}
 		case <-ctx.Done():
-			return fmt.Errorf("failed to wait for database %d status: %s", dbID, ctx.Err())
+			return fmt.Errorf("failed to wait for database %d status: %w", dbID, ctx.Err())
 		}
 	}
 }
@@ -585,7 +585,7 @@ func (client Client) NewEventPoller(
 	}
 
 	if err := result.PreTask(ctx); err != nil {
-		return nil, fmt.Errorf("failed to run pretask: %s", err)
+		return nil, fmt.Errorf("failed to run pretask: %w", err)
 	}
 
 	return &result, nil
@@ -632,7 +632,7 @@ func (p *EventPoller) PreTask(ctx context.Context) error {
 		PageOptions: &PageOptions{Page: 1},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list events: %s", err)
+		return fmt.Errorf("failed to list events: %w", err)
 	}
 
 	eventIDs := make(map[int]bool, len(events))
@@ -672,7 +672,7 @@ func (p *EventPoller) WaitForLatestUnknownEvent(ctx context.Context) (*Event, er
 		case <-ticker.C:
 			events, err := p.client.ListEvents(ctx, &listOpts)
 			if err != nil {
-				return nil, fmt.Errorf("failed to list events: %s", err)
+				return nil, fmt.Errorf("failed to list events: %w", err)
 			}
 
 			for _, event := range events {
@@ -685,7 +685,7 @@ func (p *EventPoller) WaitForLatestUnknownEvent(ctx context.Context) (*Event, er
 				}
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for event: %s", ctx.Err())
+			return nil, fmt.Errorf("failed to wait for event: %w", ctx.Err())
 		}
 	}
 }
@@ -702,7 +702,7 @@ func (p *EventPoller) WaitForFinished(
 
 	event, err := p.WaitForLatestUnknownEvent(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to wait for event: %s", err)
+		return nil, fmt.Errorf("failed to wait for event: %w", err)
 	}
 
 	for {
@@ -710,7 +710,7 @@ func (p *EventPoller) WaitForFinished(
 		case <-ticker.C:
 			event, err := p.client.GetEvent(ctx, event.ID)
 			if err != nil {
-				return nil, fmt.Errorf("failed to get event: %s", err)
+				return nil, fmt.Errorf("failed to get event: %w", err)
 			}
 
 			switch event.Status {
@@ -722,7 +722,7 @@ func (p *EventPoller) WaitForFinished(
 				continue
 			}
 		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for event: %s", ctx.Err())
+			return nil, fmt.Errorf("failed to wait for event: %w", ctx.Err())
 		}
 	}
 }


### PR DESCRIPTION
## 📝 Description

This pull request alters all "wrapped" errors to use `%w` for formatting. This allows downstream consumers to parse the underlying error of a returned error.
