### PR TITLE
new: Add ActionImageUpload enum

### DIFF
--- a/account_events.go
+++ b/account_events.go
@@ -95,6 +95,7 @@ const (
 	ActionHostReboot               EventAction = "host_reboot"
 	ActionImageDelete              EventAction = "image_delete"
 	ActionImageUpdate              EventAction = "image_update"
+	ActionImageUpload              EventAction = "image_upload"
 	ActionLassieReboot             EventAction = "lassie_reboot"
 	ActionLinodeAddIP              EventAction = "linode_addip"
 	ActionLinodeBoot               EventAction = "linode_boot"


### PR DESCRIPTION
## 📝 Description

This change adds a simple ActionImageUpload (`image_upload`) enum that was previous missing.
