### PR TITLE
fix: Disable the `depguard` linter and properly align tags

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,4 +78,5 @@ linters:
     - cyclop
     - godot
     - exhaustive
+    - depguard
   fast: false

--- a/pagination.go
+++ b/pagination.go
@@ -16,8 +16,8 @@ import (
 
 // PageOptions are the pagination parameters for List endpoints
 type PageOptions struct {
-	Page    int `url:"page,omitempty" json:"page"`
-	Pages   int `url:"pages,omitempty" json:"pages"`
+	Page    int `url:"page,omitempty"    json:"page"`
+	Pages   int `url:"pages,omitempty"   json:"pages"`
 	Results int `url:"results,omitempty" json:"results"`
 }
 

--- a/pagination.go
+++ b/pagination.go
@@ -16,9 +16,9 @@ import (
 
 // PageOptions are the pagination parameters for List endpoints
 type PageOptions struct {
-	Page    int `url:"page,omitempty"    json:"page"`
-	Pages   int `url:"pages,omitempty"   json:"pages"`
-	Results int `url:"results,omitempty" json:"results"`
+	Page    int `json:"page"    url:"page,omitempty"`
+	Pages   int `json:"pages"   url:"pages,omitempty"`
+	Results int `json:"results" url:"results,omitempty"`
 }
 
 // ListOptions are the pagination and filtering (TODO) parameters for endpoints


### PR DESCRIPTION
## 📝 Description

This change makes some minor changes to support newer versions of `golangci-lint`. This should resolve the failing workflow on the `main` branch. 