### PR TITLE
TPT 2123: Add missing fields to account_users

### DIFF
--- a/account_users.go
+++ b/account_users.go
@@ -10,11 +10,13 @@ import (
 
 // User represents a User object
 type User struct {
-	Username   string   `json:"username"`
-	Email      string   `json:"email"`
-	Restricted bool     `json:"restricted"`
-	TFAEnabled bool     `json:"tfa_enabled"`
-	SSHKeys    []string `json:"ssh_keys"`
+	Username            string   `json:"username"`
+	Email               string   `json:"email"`
+	Restricted          bool     `json:"restricted"`
+	TFAEnabled          bool     `json:"tfa_enabled"`
+	SSHKeys             []string `json:"ssh_keys"`
+	PasswordCreated     string   `json:"password_created"`
+	VerifiedPhoneNumber string   `json:"verified_phone_number"`
 }
 
 // UserCreateOptions fields are those accepted by CreateUser

--- a/test/integration/account_users_test.go
+++ b/test/integration/account_users_test.go
@@ -58,6 +58,15 @@ func TestUser_Get(t *testing.T) {
 	if !user.Restricted {
 		t.Error("expected user to be restricted")
 	}
+	if user.TFAEnabled {
+		t.Error("expected TFA is disabled")
+	}
+	if user.PasswordCreated != "" {
+		t.Error("expected password is not set")
+	}
+	if user.VerifiedPhoneNumber != "" {
+		t.Error("expected phone number is not set")
+	}
 }
 
 func TestUser_Update(t *testing.T) {
@@ -134,6 +143,15 @@ func TestUsers_List(t *testing.T) {
 	}
 	if newUser.Restricted {
 		t.Error("expected user to not be restricted")
+	}
+	if newUser.TFAEnabled {
+		t.Error("expected TFA is disabled")
+	}
+	if newUser.PasswordCreated != "" {
+		t.Error("expected password is not set")
+	}
+	if newUser.VerifiedPhoneNumber != "" {
+		t.Error("expected phone number is not set")
 	}
 }
 

--- a/test/integration/fixtures/TestUser_Get.yaml
+++ b/test/integration/fixtures/TestUser_Get.yaml
@@ -16,7 +16,7 @@ interactions:
   response:
     body: '{"username": "linodegotest-getuser", "email": "linodegotest-getuser@example.com",
       "restricted": true, "ssh_keys": [], "tfa_enabled": false, "verified_phone_number":
-      null}'
+      null, "password_created": null}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -31,7 +31,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "170"
+      - "196"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -73,7 +73,7 @@ interactions:
   response:
     body: '{"username": "linodegotest-getuser", "email": "linodegotest-getuser@example.com",
       "restricted": true, "ssh_keys": [], "tfa_enabled": false, "verified_phone_number":
-      null}'
+      null, "password_created": null}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -89,7 +89,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "170"
+      - "196"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:

--- a/test/integration/fixtures/TestUsers_List.yaml
+++ b/test/integration/fixtures/TestUsers_List.yaml
@@ -16,7 +16,7 @@ interactions:
   response:
     body: '{"username": "linodegotest-listuser", "email": "linodegotest-listuser@example.com",
       "restricted": false, "ssh_keys": [], "tfa_enabled": false, "verified_phone_number":
-      null}'
+      null, "password_created": null}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -31,7 +31,7 @@ interactions:
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "173"
+      - "199"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -71,12 +71,11 @@ interactions:
     url: https://api.linode.com/v4beta/account/users
     method: GET
   response:
-    body: '{"data": [{"username": "lgarber-dev", "email": "REDACTED", "restricted":
-      false, "ssh_keys": ["tf_test_authorized_keys", "main", "tf_test_authorized_keys",
-      "dev-server-rsa", "tf_test_authorized_keys"], "tfa_enabled": true, "verified_phone_number":
+    body: '{"data": [{"username": "ychen123", "email": "yechen@akamai.com", "restricted":
+      false, "ssh_keys": [], "tfa_enabled": true, "verified_phone_number": null, "password_created":
       null}, {"username": "linodegotest-listuser", "email": "linodegotest-listuser@example.com",
       "restricted": false, "ssh_keys": [], "tfa_enabled": false, "verified_phone_number":
-      null}], "page": 1, "pages": 1, "results": 2}'
+      null, "password_created": null}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -92,7 +91,7 @@ interactions:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "476"
+      - "419"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:


### PR DESCRIPTION
## 📝 Description

The account_users it outdated comparing to the API doc: https://www.linode.com/docs/api/account/#user-view

Added `PasswordCreated`, `VerifiedPhoneNumber`. Tested `ListUsers` and `GetUser`.

## ✔️ How to Test

`make ARGS="-run TestUsers_List” fixtures`
`make ARGS="-run TestUser_Get” fixtures`

`make testunit`
`make testint`
