### PR TITLE
new: Expose client-level `SetHeader(...)` function 

### DIFF
--- a/client.go
+++ b/client.go
@@ -354,6 +354,13 @@ func (c *Client) GetPollDelay() time.Duration {
 	return c.millisecondsPerPoll
 }
 
+// SetHeader sets a custom header to be used in all API requests made with the current
+// client.
+// NOTE: Some headers may be overridden by the individual request functions.
+func (c *Client) SetHeader(name, value string) {
+	c.resty.SetHeader(name, value)
+}
+
 // NewClient factory to create new Client struct
 func NewClient(hc *http.Client) (client Client) {
 	if hc != nil {


### PR DESCRIPTION
## 📝 Description

This change introduces a wrapper for the `resty.SetHeader(...)` function, allowing users to set custom headers globally for their current client.

NOTE: Per-request custom headers are not currently supported in the interest of maintaining backward compatibility.
