### PR TITLE
fix: password_created type in account_users

### DIFF
--- a/test/integration/account_users_test.go
+++ b/test/integration/account_users_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/linode/linodego"
 	. "github.com/linode/linodego"
 )
 
 const usernamePrefix = "linodegotest-"
+
+var ignoreUserTimestampes = cmpopts.IgnoreFields(linodego.User{}, "PasswordCreated")
 
 type userModifier func(*linodego.UserCreateOptions)
 
@@ -60,9 +63,6 @@ func TestUser_Get(t *testing.T) {
 	}
 	if user.TFAEnabled {
 		t.Error("expected TFA is disabled")
-	}
-	if user.PasswordCreated != "" {
-		t.Error("expected password is not set")
 	}
 	if user.VerifiedPhoneNumber != "" {
 		t.Error("expected phone number is not set")
@@ -146,9 +146,6 @@ func TestUsers_List(t *testing.T) {
 	}
 	if newUser.TFAEnabled {
 		t.Error("expected TFA is disabled")
-	}
-	if newUser.PasswordCreated != "" {
-		t.Error("expected password is not set")
 	}
 	if newUser.VerifiedPhoneNumber != "" {
 		t.Error("expected phone number is not set")


### PR DESCRIPTION
## 📝 Description

A small fix to the `password_created` type. Use the `Time` type instead. 