### PR TITLE
fix: `verified_phone_number` type in account_users

### DIFF
--- a/account_users.go
+++ b/account_users.go
@@ -18,7 +18,7 @@ type User struct {
 	TFAEnabled          bool       `json:"tfa_enabled"`
 	SSHKeys             []string   `json:"ssh_keys"`
 	PasswordCreated     *time.Time `json:"-"`
-	VerifiedPhoneNumber string     `json:"verified_phone_number"`
+	VerifiedPhoneNumber *string    `json:"verified_phone_number"`
 }
 
 // UserCreateOptions fields are those accepted by CreateUser

--- a/test/integration/account_users_test.go
+++ b/test/integration/account_users_test.go
@@ -64,7 +64,7 @@ func TestUser_Get(t *testing.T) {
 	if user.TFAEnabled {
 		t.Error("expected TFA is disabled")
 	}
-	if user.VerifiedPhoneNumber != "" {
+	if user.VerifiedPhoneNumber != nil {
 		t.Error("expected phone number is not set")
 	}
 }
@@ -147,7 +147,7 @@ func TestUsers_List(t *testing.T) {
 	if newUser.TFAEnabled {
 		t.Error("expected TFA is disabled")
 	}
-	if newUser.VerifiedPhoneNumber != "" {
+	if newUser.VerifiedPhoneNumber != nil {
 		t.Error("expected phone number is not set")
 	}
 }


### PR DESCRIPTION
## 📝 Description

`verified_phone_number` is a nullable string from API. We build nullable fields as pointers to tell apart null value from zero/empty value explicitly. 

## ✔️ How to Test

```
make testunit
make testint
```