### PR TITLE
fix: cached requests 

### DIFF
--- a/client.go
+++ b/client.go
@@ -521,12 +521,12 @@ func copyTime(tPtr *time.Time) *time.Time {
 
 func generateListCacheURL(endpoint string, opts *ListOptions) (string, error) {
 	if opts == nil {
-		return "", nil
+		return endpoint, nil
 	}
 
 	hashedOpts, err := opts.Hash()
 	if err != nil {
-		return "", err
+		return endpoint, err
 	}
 
 	return fmt.Sprintf("%s:%s", endpoint, hashedOpts), nil


### PR DESCRIPTION
## 📝 Description

Currently, when `generateListCacheURL` is called _without options_, the cache key is an empty string. 

This causes a runtime panic if e.g. `listTypes` is called after `listRegions`, because the wrong endpoint is called and the type casting fails: 

```bash
panic: interface conversion: interface {} is []linodego.Region, not []linodego.LinodeType
```

This PR fixes that bug by having `generateListCacheURL` simply return the endpoint itself to be used as a cache key.


## ✔️ How to Test
Previously failing code:

```go
linodeClient.ListRegions(context.Background(), nil)
linodeClient.ListTypes(context.Background(), nil)
```
