### PR TITLE
fix: Resolve issue that would cause inaccurate poll intervals in polling functions

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,7 +52,7 @@ type Client struct {
 	debug             bool
 	retryConditionals []RetryConditional
 
-	millisecondsPerPoll time.Duration
+	pollInterval time.Duration
 
 	baseURL         string
 	apiVersion      string
@@ -344,14 +344,14 @@ func (c *Client) SetRetryCount(count int) *Client {
 // SetPollDelay sets the number of milliseconds to wait between events or status polls.
 // Affects all WaitFor* functions and retries.
 func (c *Client) SetPollDelay(delay time.Duration) *Client {
-	c.millisecondsPerPoll = delay
+	c.pollInterval = delay
 	return c
 }
 
 // GetPollDelay gets the number of milliseconds to wait between events or status polls.
 // Affects all WaitFor* functions and retries.
 func (c *Client) GetPollDelay() time.Duration {
-	return c.millisecondsPerPoll
+	return c.pollInterval
 }
 
 // SetHeader sets a custom header to be used in all API requests made with the current

--- a/client.go
+++ b/client.go
@@ -405,7 +405,7 @@ func NewClient(hc *http.Client) (client Client) {
 
 	client.
 		SetRetryWaitTime((1000 * APISecondsPerPoll) * time.Millisecond).
-		SetPollDelay(1000 * APISecondsPerPoll).
+		SetPollDelay(APISecondsPerPoll * time.Second).
 		SetRetries().
 		SetDebug(envDebug)
 

--- a/waitfor.go
+++ b/waitfor.go
@@ -25,7 +25,7 @@ func (client Client) WaitForInstanceStatus(ctx context.Context, instanceID int, 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -52,7 +52,7 @@ func (client Client) WaitForInstanceDiskStatus(ctx context.Context, instanceID i
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -88,7 +88,7 @@ func (client Client) WaitForVolumeStatus(ctx context.Context, volumeID int, stat
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -115,7 +115,7 @@ func (client Client) WaitForSnapshotStatus(ctx context.Context, instanceID int, 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -144,7 +144,7 @@ func (client Client) WaitForVolumeLinodeID(ctx context.Context, volumeID int, li
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -175,7 +175,7 @@ func (client Client) WaitForLKEClusterStatus(ctx context.Context, clusterID int,
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -237,7 +237,7 @@ func (client Client) WaitForLKEClusterConditions(
 		return fmt.Errorf("failed to get Kubeconfig for LKE cluster %d: %w", clusterID, err)
 	}
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	conditionOptions := ClusterConditionOptions{LKEClusterKubeconfig: lkeKubeConfig, TransportWrapper: options.TransportWrapper}
@@ -270,7 +270,7 @@ func (client Client) WaitForLKEClusterConditions(
 // WaitForEventFinished waits for an entity action to reach the 'finished' state
 // before returning. It will timeout with an error after timeoutSeconds.
 // If the event indicates a failure both the failed event and the error will be returned.
-//nolint
+// nolint
 func (client Client) WaitForEventFinished(
 	ctx context.Context,
 	id any,
@@ -313,7 +313,7 @@ func (client Client) WaitForEventFinished(
 		log.Printf("[INFO] Waiting %d seconds for %s events since %v for %s %v", int(duration.Seconds()), action, minStart, titledEntityType, id)
 	}
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 
 	// avoid repeating log messages
 	nextLog := ""
@@ -412,7 +412,7 @@ func (client Client) WaitForImageStatus(ctx context.Context, imageID string, sta
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -438,7 +438,7 @@ func (client Client) WaitForMySQLDatabaseBackup(ctx context.Context, dbID int, l
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -465,7 +465,7 @@ func (client Client) WaitForPostgresDatabaseBackup(ctx context.Context, dbID int
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -515,7 +515,7 @@ func (client Client) WaitForDatabaseStatus(
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -615,7 +615,7 @@ func (p *EventPoller) PreTask(ctx context.Context) error {
 }
 
 func (p *EventPoller) WaitForLatestUnknownEvent(ctx context.Context) (*Event, error) {
-	ticker := time.NewTicker(p.client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(p.client.pollInterval)
 	defer ticker.Stop()
 
 	f := Filter{
@@ -666,7 +666,7 @@ func (p *EventPoller) WaitForFinished(
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(p.client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(p.client.pollInterval)
 	defer ticker.Stop()
 
 	event, err := p.WaitForLatestUnknownEvent(ctx)
@@ -715,7 +715,7 @@ func (client Client) WaitForResourceFree(
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
 	defer cancel()
 
-	ticker := time.NewTicker(client.millisecondsPerPoll * time.Millisecond)
+	ticker := time.NewTicker(client.pollInterval)
 	defer ticker.Stop()
 
 	// A helper function to determine whether a resource is busy

--- a/waitfor.go
+++ b/waitfor.go
@@ -270,7 +270,7 @@ func (client Client) WaitForLKEClusterConditions(
 // WaitForEventFinished waits for an entity action to reach the 'finished' state
 // before returning. It will timeout with an error after timeoutSeconds.
 // If the event indicates a failure both the failed event and the error will be returned.
-// nolint
+//nolint
 func (client Client) WaitForEventFinished(
 	ctx context.Context,
 	id any,


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that would cause properly defined `SetPollDelay` durations to be multiplied by `1000000`, leading to polling operations that never run. 

Blocks https://github.com/linode/terraform-provider-linode/pull/912
