### PR TITLE
Fix instance create opts

### DIFF
--- a/instances.go
+++ b/instances.go
@@ -107,23 +107,23 @@ type InstanceMetadataOptions struct {
 
 // InstanceCreateOptions require only Region and Type
 type InstanceCreateOptions struct {
-	Region          string                    `json:"region"`
-	Type            string                    `json:"type"`
-	Label           string                    `json:"label,omitempty"`
-	Group           string                    `json:"group,omitempty"`
-	RootPass        string                    `json:"root_pass,omitempty"`
-	AuthorizedKeys  []string                  `json:"authorized_keys,omitempty"`
-	AuthorizedUsers []string                  `json:"authorized_users,omitempty"`
-	StackScriptID   int                       `json:"stackscript_id,omitempty"`
-	StackScriptData map[string]string         `json:"stackscript_data,omitempty"`
-	BackupID        int                       `json:"backup_id,omitempty"`
-	Image           string                    `json:"image,omitempty"`
-	Interfaces      []InstanceConfigInterface `json:"interfaces,omitempty"`
-	BackupsEnabled  bool                      `json:"backups_enabled,omitempty"`
-	PrivateIP       bool                      `json:"private_ip,omitempty"`
-	Tags            []string                  `json:"tags,omitempty"`
-	Metadata        *InstanceMetadataOptions  `json:"metadata,omitempty"`
-	FirewallID      int                       `json:"firewall_id,omitempty"`
+	Region          string                                 `json:"region"`
+	Type            string                                 `json:"type"`
+	Label           string                                 `json:"label,omitempty"`
+	Group           string                                 `json:"group,omitempty"`
+	RootPass        string                                 `json:"root_pass,omitempty"`
+	AuthorizedKeys  []string                               `json:"authorized_keys,omitempty"`
+	AuthorizedUsers []string                               `json:"authorized_users,omitempty"`
+	StackScriptID   int                                    `json:"stackscript_id,omitempty"`
+	StackScriptData map[string]string                      `json:"stackscript_data,omitempty"`
+	BackupID        int                                    `json:"backup_id,omitempty"`
+	Image           string                                 `json:"image,omitempty"`
+	Interfaces      []InstanceConfigInterfaceCreateOptions `json:"interfaces,omitempty"`
+	BackupsEnabled  bool                                   `json:"backups_enabled,omitempty"`
+	PrivateIP       bool                                   `json:"private_ip,omitempty"`
+	Tags            []string                               `json:"tags,omitempty"`
+	Metadata        *InstanceMetadataOptions               `json:"metadata,omitempty"`
+	FirewallID      int                                    `json:"firewall_id,omitempty"`
 
 	// Creation fields that need to be set explicitly false, "", or 0 use pointers
 	SwapSize *int  `json:"swap_size,omitempty"`

--- a/test/integration/instance_config_test.go
+++ b/test/integration/instance_config_test.go
@@ -37,8 +37,6 @@ func setupVPCWithSubnetWithInstance(
 	vpc, vpcSubnet, vpcWithSubnetTeardown, err := createVPCWithSubnet(t, client)
 	if err != nil {
 		t.Error(err)
-		instanceTeardown()
-		vpcWithSubnetTeardown()
 	}
 
 	teardownAll := func() {

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -508,7 +508,7 @@ func createInstanceWithoutDisks(
 	instance, err := client.CreateInstance(context.Background(), createOpts)
 	if err != nil {
 		t.Errorf("Error creating test Instance: %s", err)
-		return nil, nil, func(){}, err
+		return nil, nil, func() {}, err
 	}
 	configOpts := linodego.InstanceConfigCreateOptions{
 		Label: "go-test-conf-" + randLabel(),
@@ -516,7 +516,7 @@ func createInstanceWithoutDisks(
 	config, err := client.CreateInstanceConfig(context.Background(), instance.ID, configOpts)
 	if err != nil {
 		t.Errorf("Error creating config: %s", err)
-		return nil, nil, func(){}, err
+		return nil, nil, func() {}, err
 	}
 
 	teardown := func() {

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -533,9 +533,6 @@ func setupInstanceWithoutDisks(t *testing.T, fixturesYaml string, modifiers ...i
 	instance, config, instanceTeardown, err := createInstanceWithoutDisks(t, client)
 
 	teardown := func() {
-		if terr := client.DeleteInstance(context.Background(), instance.ID); terr != nil {
-			t.Errorf("Error deleting test Instance: %s", terr)
-		}
 		instanceTeardown()
 		fixtureTeardown()
 	}

--- a/test/integration/vlans_test.go
+++ b/test/integration/vlans_test.go
@@ -86,7 +86,7 @@ func createVLANInstance(t *testing.T, client *linodego.Client, instanceName, vla
 	trueBool := true
 
 	instance, err := createInstance(t, client, func(client *linodego.Client, opts *linodego.InstanceCreateOptions) {
-		opts.Interfaces = []linodego.InstanceConfigInterface{
+		opts.Interfaces = []linodego.InstanceConfigInterfaceCreateOptions{
 			{
 				Label:       vlanName,
 				Purpose:     linodego.InterfacePurposeVLAN,

--- a/test/integration/vpc_test.go
+++ b/test/integration/vpc_test.go
@@ -157,7 +157,7 @@ func TestVPC_List(t *testing.T) {
 			found = true
 		}
 	}
-	
+
 	if !found {
 		t.Errorf("vpc %v not found in list", vpc.ID)
 	}


### PR DESCRIPTION
Instance creation options should now use `InstanceConfigInterfaceCreateOptions` for the interfaces.

Also fixed a test issue.

Special thanks to @yec-akamai for discovering this issue!