### PR TITLE
new: Implement `GetAccountTransfer` and add DC-specific pricing fields

### DIFF
--- a/account_transfer.go
+++ b/account_transfer.go
@@ -1,0 +1,33 @@
+package linodego
+
+import "context"
+
+// AccountTransfer represents an Account's network utilization for the current month.
+type AccountTransfer struct {
+	Billable int `json:"billable"`
+	Quota    int `json:"quota"`
+	Used     int `json:"used"`
+
+	RegionTransfers []AccountTransferRegion `json:"region_transfers"`
+}
+
+// AccountTransferRegion represents an Account's network utilization for the current month
+// in a given region.
+type AccountTransferRegion struct {
+	ID       string `json:"id"`
+	Billable int    `json:"billable"`
+	Quota    int    `json:"quota"`
+	Used     int    `json:"used"`
+}
+
+// GetAccountTransfer gets current Account's network utilization for the current month.
+func (c *Client) GetAccountTransfer(ctx context.Context) (*AccountTransfer, error) {
+	req := c.R(ctx).SetResult(&AccountTransfer{})
+	e := "account/transfer"
+	r, err := coupleAPIErrors(req.Get(e))
+	if err != nil {
+		return nil, err
+	}
+
+	return r.Result().(*AccountTransfer), nil
+}

--- a/test/integration/account_transfer_test.go
+++ b/test/integration/account_transfer_test.go
@@ -1,0 +1,41 @@
+package integration
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jarcoal/httpmock"
+	"github.com/linode/linodego"
+)
+
+func TestAccount_getTransfer(t *testing.T) {
+	client := createMockClient(t)
+
+	desiredResponse := linodego.AccountTransfer{
+		Billable: 123,
+		Quota:    456,
+		Used:     789,
+		RegionTransfers: []linodego.AccountTransferRegion{
+			{
+				ID:       "us-southeast",
+				Billable: 987,
+				Quota:    654,
+				Used:     3211,
+			},
+		},
+	}
+
+	httpmock.RegisterRegexpResponder("GET", mockRequestURL(t, "/account/transfer"),
+		httpmock.NewJsonResponderOrPanic(200, &desiredResponse))
+
+	questions, err := client.GetAccountTransfer(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(*questions, desiredResponse) {
+		t.Fatalf("actual response does not equal desired response: %s", cmp.Diff(questions, desiredResponse))
+	}
+}


### PR DESCRIPTION
## 📝 Description

This change adds the missing `GetAccountTransfer` function and includes the `region_transfers` in the response.

NOTE: Tests are expected to be failing until this feature is released in the API.

## ✔️ How to Test

```
make ARGS="-run TestAccount_getTransfer" fixtures
```