### PR TITLE
updating errors coverage to 100%

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -13,10 +13,39 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-type tstringer string
+type testStringer string
 
-func (t tstringer) String() string {
+func (t testStringer) String() string {
 	return string(t)
+}
+
+type testError string
+
+func (e testError) Error() string {
+	return string(e)
+}
+
+func restyError(reason, field string) *resty.Response {
+	var reasons []APIErrorReason
+
+	// allow for an empty reasons
+	if reason != "" && field != "" {
+		reasons = append(reasons, APIErrorReason{
+			Reason: reason,
+			Field:  field,
+		})
+	}
+
+	return &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: 500,
+		},
+		Request: &resty.Request{
+			Error: &APIError{
+				Errors: reasons,
+			},
+		},
+	}
 }
 
 func TestNewError(t *testing.T) {
@@ -26,33 +55,27 @@ func TestNewError(t *testing.T) {
 	if NewError(struct{}{}).Code != ErrorUnsupported {
 		t.Error("empty struct should return unsupported error type")
 	}
+
 	err := errors.New("test")
-	newErr := NewError(&err)
-	if newErr.Message == err.Error() && newErr.Code == ErrorFromError {
-		t.Error("nil error should return nil")
+	newErr := NewError(err)
+
+	if newErr.Message != err.Error() && newErr.Code != ErrorFromError {
+		t.Error("error should return ErrorFromError")
+	}
+
+	if newErr.Error() != "[002] test" {
+		t.Error("Error should support Error() formatter with code")
+	}
+
+	if NewError(newErr) != newErr {
+		t.Error("Error should be itself")
 	}
 
 	if err := NewError(&resty.Response{Request: &resty.Request{}}); err.Message != "Unexpected Resty Error Response, no error" {
 		t.Error("Unexpected Resty Error Response, no error")
 	}
 
-	rerr := &resty.Response{
-		RawResponse: &http.Response{
-			StatusCode: 500,
-		},
-		Request: &resty.Request{
-			Error: &APIError{
-				[]APIErrorReason{
-					{
-						Reason: "testreason",
-						Field:  "testfield",
-					},
-				},
-			},
-		},
-	}
-
-	if err := NewError(rerr); err.Message != "[testfield] testreason" {
+	if err := NewError(restyError("testreason", "testfield")); err.Message != "[testfield] testreason" {
 		t.Error("rest response error should should be set")
 	}
 
@@ -60,8 +83,12 @@ func TestNewError(t *testing.T) {
 		t.Errorf("string error should be set")
 	}
 
-	if err := NewError(tstringer("teststringer")); err.Message != "teststringer" || err.Code != ErrorFromStringer {
-		t.Errorf("stringer error should be set")
+	if err := NewError(testStringer("teststringer")); err.Message != "teststringer" || err.Code != ErrorFromStringer {
+		t.Errorf("error should be set for a stringer interface")
+	}
+
+	if err := NewError(testError("testerror")); err.Message != "testerror" || err.Code != ErrorFromError {
+		t.Errorf("error should be set for an error interface")
 	}
 }
 
@@ -82,59 +109,94 @@ func createTestServer(method, route, contentType, body string, statusCode int) (
 	return ts, &client
 }
 
-func TestCoupleAPIErrors_genericHtmlError(t *testing.T) {
-	rawResponse := `<html>
+func TestCoupleAPIErrors(t *testing.T) {
+	t.Run("not nil error generates error", func(t *testing.T) {
+		err := errors.New("test")
+		if _, err := coupleAPIErrors(nil, err); !cmp.Equal(err, NewError(err)) {
+			t.Errorf("expect a not nil error to be returned as an Error")
+		}
+	})
+
+	t.Run("resty 500 response error with reasons", func(t *testing.T) {
+		if _, err := coupleAPIErrors(restyError("testreason", "testfield"), nil); err.Error() != "[500] [testfield] testreason" {
+			t.Error("resty error should return with proper format [code] [field] reason")
+		}
+	})
+
+	t.Run("resty 500 response error without reasons", func(t *testing.T) {
+		if _, err := coupleAPIErrors(restyError("", ""), nil); err != nil {
+			t.Error("resty error with no reasons should return no error")
+		}
+	})
+
+	t.Run("resty response with nil error", func(t *testing.T) {
+		emptyErr := &resty.Response{
+			RawResponse: &http.Response{
+				StatusCode: 500,
+			},
+			Request: &resty.Request{
+				Error: nil,
+			},
+		}
+		if _, err := coupleAPIErrors(emptyErr, nil); err != nil {
+			t.Error("resty error with no reasons should return no error")
+		}
+	})
+
+	t.Run("generic html error", func(t *testing.T) {
+		rawResponse := `<html>
 <head><title>500 Internal Server Error</title></head>
 <body bgcolor="white">
 <center><h1>500 Internal Server Error</h1></center>
 <hr><center>nginx</center>
 </body>
 </html>`
-	route := "/v4/linode/instances/123"
-	ts, client := createTestServer(http.MethodGet, route, "text/html", rawResponse, http.StatusInternalServerError)
-	client.SetDebug(true)
-	defer ts.Close()
+		route := "/v4/linode/instances/123"
+		ts, client := createTestServer(http.MethodGet, route, "text/html", rawResponse, http.StatusInternalServerError)
+		// client.SetDebug(true)
+		defer ts.Close()
 
-	expectedError := Error{
-		Code:    http.StatusInternalServerError,
-		Message: "Unexpected Content-Type: Expected: application/json, Received: text/html\nResponse body: " + rawResponse,
-	}
+		expectedError := Error{
+			Code:    http.StatusInternalServerError,
+			Message: "Unexpected Content-Type: Expected: application/json, Received: text/html\nResponse body: " + rawResponse,
+		}
 
-	_, err := coupleAPIErrors(client.R(context.Background()).SetResult(&Instance{}).Get(ts.URL + route))
-	if diff := cmp.Diff(expectedError, err); diff != "" {
-		t.Errorf("expected error to match but got diff:\n%s", diff)
-	}
-}
+		_, err := coupleAPIErrors(client.R(context.Background()).SetResult(&Instance{}).Get(ts.URL + route))
+		if diff := cmp.Diff(expectedError, err); diff != "" {
+			t.Errorf("expected error to match but got diff:\n%s", diff)
+		}
+	})
 
-func TestCoupleAPIErrors_badGatewayError(t *testing.T) {
-	rawResponse := []byte(`<html>
+	t.Run("bad gateway error", func(t *testing.T) {
+		rawResponse := []byte(`<html>
 <head><title>502 Bad Gateway</title></head>
 <body bgcolor="white">
 <center><h1>502 Bad Gateway</h1></center>
 <hr><center>nginx</center>
 </body>
 </html>`)
-	buf := io.NopCloser(bytes.NewBuffer(rawResponse))
+		buf := io.NopCloser(bytes.NewBuffer(rawResponse))
 
-	resp := &resty.Response{
-		Request: &resty.Request{
-			Error: errors.New("Bad Gateway"),
-		},
-		RawResponse: &http.Response{
-			Header: http.Header{
-				"Content-Type": []string{"text/html"},
+		resp := &resty.Response{
+			Request: &resty.Request{
+				Error: errors.New("Bad Gateway"),
 			},
-			StatusCode: http.StatusBadGateway,
-			Body:       buf,
-		},
-	}
+			RawResponse: &http.Response{
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
+				StatusCode: http.StatusBadGateway,
+				Body:       buf,
+			},
+		}
 
-	expectedError := Error{
-		Code:    http.StatusBadGateway,
-		Message: http.StatusText(http.StatusBadGateway),
-	}
+		expectedError := Error{
+			Code:    http.StatusBadGateway,
+			Message: http.StatusText(http.StatusBadGateway),
+		}
 
-	if _, err := coupleAPIErrors(resp, nil); !cmp.Equal(err, expectedError) {
-		t.Errorf("expected error %#v to match error %#v", err, expectedError)
-	}
+		if _, err := coupleAPIErrors(resp, nil); !cmp.Equal(err, expectedError) {
+			t.Errorf("expected error %#v to match error %#v", err, expectedError)
+		}
+	})
 }


### PR DESCRIPTION
## 📝 Description
There was a type error in my last test with `*error` vs. `error` which I missed so I fixed that and added tests for the rest of the file. Note to reviewer... 
* I changed the logic in `coupleAPIErrors` to return earlier instead of putting all the coupling logic inside an if block, spiritually the same but easier to follow.
* I commented the `client.SetDebug(true)` in generic html error because it wasn't really benefiting anything and making the test output spammy. if you want it back, I'll happily uncomment it

**What does this PR do and why is this change necessary?**
Rewrites the errors tests to give 100% coverage, because... tests.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**
`make testunit`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**