### PR TITLE
test: add test coverage for vpc 

### DIFF
--- a/test/integration/vpc_subnet_test.go
+++ b/test/integration/vpc_subnet_test.go
@@ -240,8 +240,7 @@ func TestVPC_Subnet_Update_Invalid_data(t *testing.T) {
 	vpcSubnetUpdateOptionsCheck(&opts, vpcSubnet, t)
 
 	opts.Label = "invalid_label"
-	opts.
-		_, err = client.UpdateVPCSubnet(
+	_, err = client.UpdateVPCSubnet(
 		context.Background(),
 		vpc.ID,
 		vpcSubnet.ID,

--- a/test/integration/vpc_subnet_test.go
+++ b/test/integration/vpc_subnet_test.go
@@ -107,7 +107,7 @@ func createVPCWithSubnet(t *testing.T, client *linodego.Client) (
 	return vpc, vpcSubnet, teardown, err
 }
 
-func createVPCWithSubnetInvaidLabel(t *testing.T, client *linodego.Client) error {
+func createVPCWithSubnetInvalidLabel(t *testing.T, client *linodego.Client) error {
 	t.Helper()
 	vpc, vpcTeardown, err := createVPC(t, client)
 	if err != nil {
@@ -215,7 +215,7 @@ func TestVPC_Subnet_List(t *testing.T) {
 func TestVPC_Subnet_Create_Invalid_data(t *testing.T) {
 	client, _ := createTestClient(t, "fixtures/TestVPC_Subnet_Create_Invalid_Label")
 
-	err := createVPCWithSubnetInvaidLabel(t, client)
+	err := createVPCWithSubnetInvalidLabel(t, client)
 
 	e, _ := err.(*Error)
 

--- a/test/integration/vpc_subnet_test.go
+++ b/test/integration/vpc_subnet_test.go
@@ -3,9 +3,11 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/linode/linodego"
+	. "github.com/linode/linodego"
 )
 
 const (
@@ -105,6 +107,24 @@ func createVPCWithSubnet(t *testing.T, client *linodego.Client) (
 	return vpc, vpcSubnet, teardown, err
 }
 
+func createVPCWithSubnetInvaidLabel(t *testing.T, client *linodego.Client) error {
+	t.Helper()
+	vpc, vpcTeardown, err := createVPC(t, client)
+	if err != nil {
+		if vpcTeardown != nil {
+			vpcTeardown()
+		}
+		t.Fatal(err)
+	}
+	createOpts := linodego.VPCSubnetCreateOptions{
+		Label: "linodego-vpc-test_invalid_label" + getUniqueText(),
+		IPv4:  TestSubnet,
+	}
+	_, err = client.CreateVPCSubnet(context.Background(), createOpts, vpc.ID)
+
+	return err
+}
+
 func setupVPCWithSubnet(
 	t *testing.T,
 	fixturesYaml string,
@@ -189,5 +209,52 @@ func TestVPC_Subnet_List(t *testing.T) {
 
 	if !found {
 		t.Errorf("the VPC %v subnet %v not found in list", vpc.ID, vpcSubnet.ID)
+	}
+}
+
+func TestVPC_Subnet_Create_Invalid_data(t *testing.T) {
+	client, _ := createTestClient(t, "fixtures/TestVPC_Subnet_Create_Invalid_Label")
+
+	err := createVPCWithSubnetInvaidLabel(t, client)
+
+	e, _ := err.(*Error)
+
+	if e.Code != 400 {
+		t.Errorf("should have received a 400 Code with invalid label, got %v", e.Code)
+	}
+	expectedErrorMessage := "Label must include only ASCII letters, numbers, and dashes"
+	if !strings.Contains(e.Message, expectedErrorMessage) {
+		t.Errorf("Wrong error message displayed should have contained, %s", expectedErrorMessage)
+	}
+}
+
+func TestVPC_Subnet_Update_Invalid_data(t *testing.T) {
+	client, vpc, vpcSubnet, teardown, err := setupVPCWithSubnet(t, "fixtures/TestVPC_Subnet_Update_Invalid_Label")
+	defer teardown()
+	if err != nil {
+		t.Error(formatVPCSubnetError(err, "setting up", nil, nil))
+	}
+	vpcSubnetCheck(vpcSubnet, t)
+
+	opts := vpcSubnet.GetUpdateOptions()
+	vpcSubnetUpdateOptionsCheck(&opts, vpcSubnet, t)
+
+	opts.Label = "invalid_label"
+	opts.
+		_, err = client.UpdateVPCSubnet(
+		context.Background(),
+		vpc.ID,
+		vpcSubnet.ID,
+		opts,
+	)
+
+	e, _ := err.(*Error)
+
+	if e.Code != 400 {
+		t.Errorf("should have received a 400 Code with invalid label, got %v", e.Code)
+	}
+	expectedErrorMessage := "Label must include only ASCII letters, numbers, and dashes"
+	if !strings.Contains(e.Message, expectedErrorMessage) {
+		t.Errorf("Wrong error message displayed should have contained, %s", expectedErrorMessage)
 	}
 }


### PR DESCRIPTION
## 📝 Description

Not much to add as most of endpoints has been covered. Just adding few negative test cases in vpc and vpc_subnet

## ✔️ How to Test

navigate to test directory and `go test -v -run=TestVPC_Subnet_Create_Invalid_data ./integration`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**