### PR TITLE
Fix `ipv4` Field of Linode Instance Interface

### DIFF
--- a/instance_config_interfaces.go
+++ b/instance_config_interfaces.go
@@ -20,8 +20,8 @@ type InstanceConfigInterface struct {
 }
 
 type VPCIPv4 struct {
-	VPC     string `json:"vpc"`
-	NAT1To1 string `json:"nat_1_1"`
+	VPC     string `json:"vpc,omitempty"`
+	NAT1To1 string `json:"nat_1_1,omitempty"`
 }
 
 type InstanceConfigInterfaceCreateOptions struct {


### PR DESCRIPTION
## 📝 Description

Omit any empty field during JSON marshaling in IPv4 struct. 

## ✔️ How to Test

Run `make ARGS="-run TestInstance_Config" fixtures` against alpha environment
