### PR TITLE
ref: Rename ListVPC(...) to ListVPCs(...)

### DIFF
--- a/test/integration/vpc_test.go
+++ b/test/integration/vpc_test.go
@@ -167,7 +167,7 @@ func TestVPC_List(t *testing.T) {
 	}
 	vpcCheck(vpc, t)
 
-	vpcs, err := client.ListVPC(context.Background(), nil)
+	vpcs, err := client.ListVPCs(context.Background(), nil)
 	if err != nil {
 		t.Error(formatVPCError(err, "listing", nil))
 	}

--- a/vpc.go
+++ b/vpc.go
@@ -119,7 +119,7 @@ func (c *Client) GetVPC(ctx context.Context, vpcID int) (*VPC, error) {
 	return r.Result().(*VPC), nil
 }
 
-func (c *Client) ListVPC(ctx context.Context, opts *ListOptions) ([]VPC, error) {
+func (c *Client) ListVPCs(ctx context.Context, opts *ListOptions) ([]VPC, error) {
 	response := VPCsPagedResponse{}
 	err := c.listHelper(ctx, &response, opts)
 	if err != nil {


### PR DESCRIPTION
## 📝 Description

This change renames the `ListVPC(...)` function to `ListVPCs(...)` to keep naming consistent with other list functions.
