### PR TITLE
Explicitly store (teardown) fixtures in `setupVPCWithSubnetWithInstance`

### DIFF
--- a/test/integration/fixtures/TestInstance_ConfigInterface_Update.yaml
+++ b/test/integration/fixtures/TestInstance_ConfigInterface_Update.yaml
@@ -238,7 +238,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-p67uc1u33z0e","booted":false}'
+    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-94oh76dtq5q9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -250,9 +250,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 51687525, "label": "go-test-ins-wo-disk-p67uc1u33z0e", "group":
+    body: '{"id": 51696212, "label": "go-test-ins-wo-disk-94oh76dtq5q9", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.233.110.106"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.233.111.128"], "ipv6": "1234::5678/128",
       "image": null, "region": "es-mad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -303,7 +303,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-z82rm8eb58k9","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-ahx01xo7709c","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -312,10 +312,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687525/configs
+    url: https://api.linode.com/v4beta/linode/instances/51696212/configs
     method: POST
   response:
-    body: '{"id": 54672869, "label": "go-test-conf-z82rm8eb58k9", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681856, "label": "go-test-conf-ahx01xo7709c", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -366,7 +366,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1699289566596805000","region":"es-mad"}'
+    body: '{"label":"go-test-vpc-1699301187871294000","region":"es-mad"}'
     form: {}
     headers:
       Accept:
@@ -378,7 +378,7 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 7033, "label": "go-test-vpc-1699289566596805000", "description":
+    body: '{"id": 7379, "label": "go-test-vpc-1699301187871294000", "description":
       "", "region": "es-mad", "subnets": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -425,7 +425,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-vpc-test-1699289566861781000","ipv4":"192.168.0.0/25"}'
+    body: '{"label":"linodego-vpc-test-1699301188013974000","ipv4":"192.168.0.0/25"}'
     form: {}
     headers:
       Accept:
@@ -434,10 +434,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/7033/subnets
+    url: https://api.linode.com/v4beta/vpcs/7379/subnets
     method: POST
   response:
-    body: '{"id": 7954, "label": "linodego-vpc-test-1699289566861781000", "ipv4":
+    body: '{"id": 8278, "label": "linodego-vpc-test-1699301188013974000", "ipv4":
       "192.168.0.0/25", "linodes": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -484,7 +484,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"purpose":"vpc","subnet_id":7954}'
+    body: '{"purpose":"vpc","subnet_id":8278}'
     form: {}
     headers:
       Accept:
@@ -493,11 +493,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687525/configs/54672869/interfaces
+    url: https://api.linode.com/v4beta/linode/instances/51696212/configs/54681856/interfaces
     method: POST
   response:
-    body: '{"id": 797897, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7033, "subnet_id": 7954, "ipv4": {"vpc": "192.168.0.2",
+    body: '{"id": 799678, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7379, "subnet_id": 8278, "ipv4": {"vpc": "192.168.0.2",
       "nat_1_1": ""}}'
     headers:
       Access-Control-Allow-Credentials:
@@ -552,11 +552,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687525/configs/54672869/interfaces/797897
+    url: https://api.linode.com/v4beta/linode/instances/51696212/configs/54681856/interfaces/799678
     method: PUT
   response:
-    body: '{"id": 797897, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7033, "subnet_id": 7954, "ipv4": {"vpc": "192.168.0.2",
+    body: '{"id": 799678, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7379, "subnet_id": 8278, "ipv4": {"vpc": "192.168.0.2",
       "nat_1_1": ""}}'
     headers:
       Access-Control-Allow-Credentials:
@@ -611,12 +611,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687525/configs/54672869/interfaces/797897
+    url: https://api.linode.com/v4beta/linode/instances/51696212/configs/54681856/interfaces/799678
     method: PUT
   response:
-    body: '{"id": 797897, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7033, "subnet_id": 7954, "ipv4": {"vpc": "192.168.0.10",
-      "nat_1_1": "172.233.110.106"}}'
+    body: '{"id": 799678, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7379, "subnet_id": 8278, "ipv4": {"vpc": "192.168.0.10",
+      "nat_1_1": "172.233.111.128"}}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -670,7 +670,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687525
+    url: https://api.linode.com/v4beta/linode/instances/51696212
     method: DELETE
   response:
     body: '{}'
@@ -703,6 +703,120 @@ interactions:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7379/subnets/8278
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7379
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/test/integration/fixtures/TestInstance_ConfigInterfaces_AppendDelete.yaml
+++ b/test/integration/fixtures/TestInstance_ConfigInterfaces_AppendDelete.yaml
@@ -238,7 +238,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-uh7252u4wk6v","booted":false}'
+    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-15tp0q99gix9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -250,9 +250,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 51687320, "label": "go-test-ins-wo-disk-uh7252u4wk6v", "group":
+    body: '{"id": 51696205, "label": "go-test-ins-wo-disk-15tp0q99gix9", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.233.110.110"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.233.111.125"], "ipv6": "1234::5678/128",
       "image": null, "region": "es-mad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -303,7 +303,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-2e6l8uz0z8n9","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-b3v8n5y46hv8","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -312,10 +312,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687320/configs
+    url: https://api.linode.com/v4beta/linode/instances/51696205/configs
     method: POST
   response:
-    body: '{"id": 54672641, "label": "go-test-conf-2e6l8uz0z8n9", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681848, "label": "go-test-conf-b3v8n5y46hv8", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -366,7 +366,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1699289190376903000","region":"es-mad"}'
+    body: '{"label":"go-test-vpc-1699301175821254000","region":"es-mad"}'
     form: {}
     headers:
       Accept:
@@ -378,7 +378,7 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 7025, "label": "go-test-vpc-1699289190376903000", "description":
+    body: '{"id": 7375, "label": "go-test-vpc-1699301175821254000", "description":
       "", "region": "es-mad", "subnets": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -425,7 +425,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-vpc-test-1699289190516844000","ipv4":"192.168.0.0/25"}'
+    body: '{"label":"linodego-vpc-test-1699301175974513000","ipv4":"192.168.0.0/25"}'
     form: {}
     headers:
       Accept:
@@ -434,10 +434,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/7025/subnets
+    url: https://api.linode.com/v4beta/vpcs/7375/subnets
     method: POST
   response:
-    body: '{"id": 7946, "label": "linodego-vpc-test-1699289190516844000", "ipv4":
+    body: '{"id": 8274, "label": "linodego-vpc-test-1699301175974513000", "ipv4":
       "192.168.0.0/25", "linodes": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -484,7 +484,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"purpose":"vpc","subnet_id":7946}'
+    body: '{"purpose":"vpc","subnet_id":8274}'
     form: {}
     headers:
       Accept:
@@ -493,11 +493,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687320/configs/54672641/interfaces
+    url: https://api.linode.com/v4beta/linode/instances/51696205/configs/54681848/interfaces
     method: POST
   response:
-    body: '{"id": 797819, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7025, "subnet_id": 7946, "ipv4": {"vpc": "192.168.0.2",
+    body: '{"id": 799668, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7375, "subnet_id": 8274, "ipv4": {"vpc": "192.168.0.2",
       "nat_1_1": ""}}'
     headers:
       Access-Control-Allow-Credentials:
@@ -552,11 +552,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687320/configs/54672641/interfaces
+    url: https://api.linode.com/v4beta/linode/instances/51696205/configs/54681848/interfaces
     method: GET
   response:
-    body: '[{"id": 797819, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7025, "subnet_id": 7946, "ipv4": {"vpc": "192.168.0.2",
+    body: '[{"id": 799668, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7375, "subnet_id": 8274, "ipv4": {"vpc": "192.168.0.2",
       "nat_1_1": ""}}]'
     headers:
       Access-Control-Allow-Credentials:
@@ -613,7 +613,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687320/configs/54672641/interfaces/797819
+    url: https://api.linode.com/v4beta/linode/instances/51696205/configs/54681848/interfaces/799668
     method: DELETE
   response:
     body: '{}'
@@ -670,7 +670,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687320/configs/54672641/interfaces
+    url: https://api.linode.com/v4beta/linode/instances/51696205/configs/54681848/interfaces
     method: GET
   response:
     body: '[]'
@@ -729,7 +729,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687320
+    url: https://api.linode.com/v4beta/linode/instances/51696205
     method: DELETE
   response:
     body: '{}'
@@ -762,6 +762,120 @@ interactions:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7375/subnets/8274
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7375
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/test/integration/fixtures/TestInstance_ConfigInterfaces_List.yaml
+++ b/test/integration/fixtures/TestInstance_ConfigInterfaces_List.yaml
@@ -238,7 +238,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-q8k472gyih02","booted":false}'
+    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-orw13b4e44f8","booted":false}'
     form: {}
     headers:
       Accept:
@@ -250,9 +250,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 51687322, "label": "go-test-ins-wo-disk-q8k472gyih02", "group":
+    body: '{"id": 51696208, "label": "go-test-ins-wo-disk-orw13b4e44f8", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.233.110.112"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.233.111.127"], "ipv6": "1234::5678/128",
       "image": null, "region": "es-mad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -303,7 +303,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-kz9e6m4o68q0","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-4yg384mci23h","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -312,10 +312,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687322/configs
+    url: https://api.linode.com/v4beta/linode/instances/51696208/configs
     method: POST
   response:
-    body: '{"id": 54672644, "label": "go-test-conf-kz9e6m4o68q0", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681852, "label": "go-test-conf-4yg384mci23h", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -366,7 +366,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1699289196770332000","region":"es-mad"}'
+    body: '{"label":"go-test-vpc-1699301180721667000","region":"es-mad"}'
     form: {}
     headers:
       Accept:
@@ -378,7 +378,7 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 7027, "label": "go-test-vpc-1699289196770332000", "description":
+    body: '{"id": 7377, "label": "go-test-vpc-1699301180721667000", "description":
       "", "region": "es-mad", "subnets": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -425,7 +425,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-vpc-test-1699289197649277000","ipv4":"192.168.0.0/25"}'
+    body: '{"label":"linodego-vpc-test-1699301181590276000","ipv4":"192.168.0.0/25"}'
     form: {}
     headers:
       Accept:
@@ -434,10 +434,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/7027/subnets
+    url: https://api.linode.com/v4beta/vpcs/7377/subnets
     method: POST
   response:
-    body: '{"id": 7948, "label": "linodego-vpc-test-1699289197649277000", "ipv4":
+    body: '{"id": 8276, "label": "linodego-vpc-test-1699301181590276000", "ipv4":
       "192.168.0.0/25", "linodes": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -484,7 +484,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-kz9e6m4o68q0","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":7948,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
+    body: '{"label":"go-test-conf-4yg384mci23h","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":8276,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
     form: {}
     headers:
       Accept:
@@ -493,23 +493,23 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687322/configs/54672644
+    url: https://api.linode.com/v4beta/linode/instances/51696208/configs/54681852
     method: PUT
   response:
-    body: '{"id": 54672644, "label": "go-test-conf-kz9e6m4o68q0", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681852, "label": "go-test-conf-4yg384mci23h", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 797825, "purpose": "public",
+      "virt_mode": "paravirt", "interfaces": [{"id": 799672, "purpose": "public",
       "primary": false, "active": false, "ipam_address": null, "label": null, "vpc_id":
-      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 797826,
+      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799673,
       "purpose": "vlan", "primary": false, "active": false, "ipam_address": "", "label":
       "testvlan", "vpc_id": null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1":
-      ""}}, {"id": 797827, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7027, "subnet_id": 7948, "ipv4": {"vpc": "192.168.0.2",
-      "nat_1_1": "172.233.110.112"}}]}'
+      ""}}, {"id": 799674, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7377, "subnet_id": 8276, "ipv4": {"vpc": "192.168.0.2",
+      "nat_1_1": "172.233.111.127"}}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -561,16 +561,16 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687322/configs/54672644/interfaces
+    url: https://api.linode.com/v4beta/linode/instances/51696208/configs/54681852/interfaces
     method: GET
   response:
-    body: '[{"id": 797825, "purpose": "public", "primary": false, "active": false,
+    body: '[{"id": 799672, "purpose": "public", "primary": false, "active": false,
       "ipam_address": null, "label": null, "vpc_id": null, "subnet_id": null, "ipv4":
-      {"vpc": "", "nat_1_1": ""}}, {"id": 797826, "purpose": "vlan", "primary": false,
+      {"vpc": "", "nat_1_1": ""}}, {"id": 799673, "purpose": "vlan", "primary": false,
       "active": false, "ipam_address": "", "label": "testvlan", "vpc_id": null, "subnet_id":
-      null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 797827, "purpose": "vpc",
+      null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799674, "purpose": "vpc",
       "primary": false, "active": false, "ipam_address": null, "label": null, "vpc_id":
-      7027, "subnet_id": 7948, "ipv4": {"vpc": "192.168.0.2", "nat_1_1": "172.233.110.112"}}]'
+      7377, "subnet_id": 8276, "ipv4": {"vpc": "192.168.0.2", "nat_1_1": "172.233.111.127"}}]'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -626,7 +626,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687322
+    url: https://api.linode.com/v4beta/linode/instances/51696208
     method: DELETE
   response:
     body: '{}'
@@ -659,6 +659,120 @@ interactions:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7377/subnets/8276
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7377
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/test/integration/fixtures/TestInstance_ConfigInterfaces_Reorder.yaml
+++ b/test/integration/fixtures/TestInstance_ConfigInterfaces_Reorder.yaml
@@ -238,7 +238,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-i7i01rubi233","booted":false}'
+    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-a626be47j9bs","booted":false}'
     form: {}
     headers:
       Accept:
@@ -250,9 +250,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 51687321, "label": "go-test-ins-wo-disk-i7i01rubi233", "group":
+    body: '{"id": 51696207, "label": "go-test-ins-wo-disk-a626be47j9bs", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.233.110.111"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.233.111.126"], "ipv6": "1234::5678/128",
       "image": null, "region": "es-mad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -303,7 +303,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-c3ul745e0g8m","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-a2li369h62rb","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -312,10 +312,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687321/configs
+    url: https://api.linode.com/v4beta/linode/instances/51696207/configs
     method: POST
   response:
-    body: '{"id": 54672643, "label": "go-test-conf-c3ul745e0g8m", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681850, "label": "go-test-conf-a2li369h62rb", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -366,7 +366,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1699289193773583000","region":"es-mad"}'
+    body: '{"label":"go-test-vpc-1699301178430667000","region":"es-mad"}'
     form: {}
     headers:
       Accept:
@@ -378,7 +378,7 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 7026, "label": "go-test-vpc-1699289193773583000", "description":
+    body: '{"id": 7376, "label": "go-test-vpc-1699301178430667000", "description":
       "", "region": "es-mad", "subnets": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -425,7 +425,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-vpc-test-1699289193918539000","ipv4":"192.168.0.0/25"}'
+    body: '{"label":"linodego-vpc-test-1699301178582840000","ipv4":"192.168.0.0/25"}'
     form: {}
     headers:
       Accept:
@@ -434,10 +434,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/7026/subnets
+    url: https://api.linode.com/v4beta/vpcs/7376/subnets
     method: POST
   response:
-    body: '{"id": 7947, "label": "linodego-vpc-test-1699289193918539000", "ipv4":
+    body: '{"id": 8275, "label": "linodego-vpc-test-1699301178582840000", "ipv4":
       "192.168.0.0/25", "linodes": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -484,7 +484,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-c3ul745e0g8m","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":7947,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
+    body: '{"label":"go-test-conf-a2li369h62rb","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":8275,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
     form: {}
     headers:
       Accept:
@@ -493,23 +493,23 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687321/configs/54672643
+    url: https://api.linode.com/v4beta/linode/instances/51696207/configs/54681850
     method: PUT
   response:
-    body: '{"id": 54672643, "label": "go-test-conf-c3ul745e0g8m", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681850, "label": "go-test-conf-a2li369h62rb", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 797822, "purpose": "public",
+      "virt_mode": "paravirt", "interfaces": [{"id": 799669, "purpose": "public",
       "primary": false, "active": false, "ipam_address": null, "label": null, "vpc_id":
-      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 797823,
+      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799670,
       "purpose": "vlan", "primary": false, "active": false, "ipam_address": "", "label":
       "testvlan", "vpc_id": null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1":
-      ""}}, {"id": 797824, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7026, "subnet_id": 7947, "ipv4": {"vpc": "192.168.0.2",
-      "nat_1_1": "172.233.110.111"}}]}'
+      ""}}, {"id": 799671, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7376, "subnet_id": 8275, "ipv4": {"vpc": "192.168.0.2",
+      "nat_1_1": "172.233.111.126"}}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -552,7 +552,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"ids":[797823,797822,797824]}'
+    body: '{"ids":[799670,799669,799671]}'
     form: {}
     headers:
       Accept:
@@ -561,7 +561,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687321/configs/54672643/interfaces/order
+    url: https://api.linode.com/v4beta/linode/instances/51696207/configs/54681850/interfaces/order
     method: POST
   response:
     body: '{}'
@@ -618,23 +618,23 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687321/configs/54672643
+    url: https://api.linode.com/v4beta/linode/instances/51696207/configs/54681850
     method: GET
   response:
-    body: '{"id": 54672643, "label": "go-test-conf-c3ul745e0g8m", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681850, "label": "go-test-conf-a2li369h62rb", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 797823, "purpose": "vlan", "primary":
+      "virt_mode": "paravirt", "interfaces": [{"id": 799670, "purpose": "vlan", "primary":
       false, "active": false, "ipam_address": "", "label": "testvlan", "vpc_id": null,
-      "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 797822, "purpose":
+      "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799669, "purpose":
       "public", "primary": false, "active": false, "ipam_address": null, "label":
       null, "vpc_id": null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}},
-      {"id": 797824, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7026, "subnet_id": 7947, "ipv4": {"vpc": "192.168.0.2",
-      "nat_1_1": "172.233.110.111"}}]}'
+      {"id": 799671, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7376, "subnet_id": 8275, "ipv4": {"vpc": "192.168.0.2",
+      "nat_1_1": "172.233.111.126"}}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -688,7 +688,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51687321
+    url: https://api.linode.com/v4beta/linode/instances/51696207
     method: DELETE
   response:
     body: '{}'
@@ -721,6 +721,120 @@ interactions:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7376/subnets/8275
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7376
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/test/integration/fixtures/TestInstance_ConfigInterfaces_Update.yaml
+++ b/test/integration/fixtures/TestInstance_ConfigInterfaces_Update.yaml
@@ -238,7 +238,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-4be66072uqxc","booted":false}'
+    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-5cy6yk67gb29","booted":false}'
     form: {}
     headers:
       Accept:
@@ -250,9 +250,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 51689661, "label": "go-test-ins-wo-disk-4be66072uqxc", "group":
+    body: '{"id": 51696210, "label": "go-test-ins-wo-disk-5cy6yk67gb29", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.233.111.127"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.233.111.111"], "ipv6": "1234::5678/128",
       "image": null, "region": "es-mad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -303,7 +303,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-x03wt9rpg533","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-f1cm29s3r89f","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -312,10 +312,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51689661/configs
+    url: https://api.linode.com/v4beta/linode/instances/51696210/configs
     method: POST
   response:
-    body: '{"id": 54675061, "label": "go-test-conf-x03wt9rpg533", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681854, "label": "go-test-conf-f1cm29s3r89f", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -366,7 +366,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1699292058226124000","region":"es-mad"}'
+    body: '{"label":"go-test-vpc-1699301184654464000","region":"es-mad"}'
     form: {}
     headers:
       Accept:
@@ -378,7 +378,7 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 7073, "label": "go-test-vpc-1699292058226124000", "description":
+    body: '{"id": 7378, "label": "go-test-vpc-1699301184654464000", "description":
       "", "region": "es-mad", "subnets": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -425,7 +425,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-vpc-test-1699292058391243000","ipv4":"192.168.0.0/25"}'
+    body: '{"label":"linodego-vpc-test-1699301184970841000","ipv4":"192.168.0.0/25"}'
     form: {}
     headers:
       Accept:
@@ -434,10 +434,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/7073/subnets
+    url: https://api.linode.com/v4beta/vpcs/7378/subnets
     method: POST
   response:
-    body: '{"id": 7984, "label": "linodego-vpc-test-1699292058391243000", "ipv4":
+    body: '{"id": 8277, "label": "linodego-vpc-test-1699301184970841000", "ipv4":
       "192.168.0.0/25", "linodes": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -484,7 +484,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-x03wt9rpg533","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":7984}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
+    body: '{"label":"go-test-conf-f1cm29s3r89f","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":8277}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
     form: {}
     headers:
       Accept:
@@ -493,22 +493,22 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51689661/configs/54675061
+    url: https://api.linode.com/v4beta/linode/instances/51696210/configs/54681854
     method: PUT
   response:
-    body: '{"id": 54675061, "label": "go-test-conf-x03wt9rpg533", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681854, "label": "go-test-conf-f1cm29s3r89f", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 798081, "purpose": "public",
+      "virt_mode": "paravirt", "interfaces": [{"id": 799675, "purpose": "public",
       "primary": false, "active": false, "ipam_address": null, "label": null, "vpc_id":
-      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 798082,
+      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799676,
       "purpose": "vlan", "primary": false, "active": false, "ipam_address": "", "label":
       "testvlan", "vpc_id": null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1":
-      ""}}, {"id": 798083, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7073, "subnet_id": 7984, "ipv4": {"vpc": "192.168.0.2",
+      ""}}, {"id": 799677, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7378, "subnet_id": 8277, "ipv4": {"vpc": "192.168.0.2",
       "nat_1_1": ""}}]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -561,22 +561,22 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51689661/configs/54675061
+    url: https://api.linode.com/v4beta/linode/instances/51696210/configs/54681854
     method: GET
   response:
-    body: '{"id": 54675061, "label": "go-test-conf-x03wt9rpg533", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681854, "label": "go-test-conf-f1cm29s3r89f", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 798081, "purpose": "public",
+      "virt_mode": "paravirt", "interfaces": [{"id": 799675, "purpose": "public",
       "primary": false, "active": false, "ipam_address": null, "label": null, "vpc_id":
-      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 798082,
+      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799676,
       "purpose": "vlan", "primary": false, "active": false, "ipam_address": "", "label":
       "testvlan", "vpc_id": null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1":
-      ""}}, {"id": 798083, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7073, "subnet_id": 7984, "ipv4": {"vpc": "192.168.0.2",
+      ""}}, {"id": 799677, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7378, "subnet_id": 8277, "ipv4": {"vpc": "192.168.0.2",
       "nat_1_1": ""}}]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -631,22 +631,22 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51689661/configs/54675061
+    url: https://api.linode.com/v4beta/linode/instances/51696210/configs/54681854
     method: PUT
   response:
-    body: '{"id": 54675061, "label": "go-test-conf-x03wt9rpg533", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681854, "label": "go-test-conf-f1cm29s3r89f", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 798081, "purpose": "public",
+      "virt_mode": "paravirt", "interfaces": [{"id": 799675, "purpose": "public",
       "primary": false, "active": false, "ipam_address": null, "label": null, "vpc_id":
-      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 798082,
+      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799676,
       "purpose": "vlan", "primary": false, "active": false, "ipam_address": "", "label":
       "testvlan", "vpc_id": null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1":
-      ""}}, {"id": 798083, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7073, "subnet_id": 7984, "ipv4": {"vpc": "192.168.0.2",
+      ""}}, {"id": 799677, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7378, "subnet_id": 8277, "ipv4": {"vpc": "192.168.0.2",
       "nat_1_1": ""}}]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -699,7 +699,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51689661
+    url: https://api.linode.com/v4beta/linode/instances/51696210
     method: DELETE
   response:
     body: '{}'
@@ -732,6 +732,120 @@ interactions:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7378/subnets/8277
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7378
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/test/integration/fixtures/TestVPC_Subnet_WithInstance.yaml
+++ b/test/integration/fixtures/TestVPC_Subnet_WithInstance.yaml
@@ -238,7 +238,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-2jyr37gon559","booted":false}'
+    body: '{"region":"es-mad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-9upq91w9ma40","booted":false}'
     form: {}
     headers:
       Accept:
@@ -250,9 +250,9 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 51693566, "label": "go-test-ins-wo-disk-2jyr37gon559", "group":
+    body: '{"id": 51696129, "label": "go-test-ins-wo-disk-9upq91w9ma40", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["172.233.111.111"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.233.111.119"], "ipv6": "1234::5678/128",
       "image": null, "region": "es-mad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
@@ -303,7 +303,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-ql94a57ne12p","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-kut154l3d0e5","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -312,10 +312,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51693566/configs
+    url: https://api.linode.com/v4beta/linode/instances/51696129/configs
     method: POST
   response:
-    body: '{"id": 54679087, "label": "go-test-conf-ql94a57ne12p", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681781, "label": "go-test-conf-kut154l3d0e5", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -366,7 +366,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1699297309404116000","region":"es-mad"}'
+    body: '{"label":"go-test-vpc-1699301061507635000","region":"es-mad"}'
     form: {}
     headers:
       Accept:
@@ -378,7 +378,7 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 7304, "label": "go-test-vpc-1699297309404116000", "description":
+    body: '{"id": 7374, "label": "go-test-vpc-1699301061507635000", "description":
       "", "region": "es-mad", "subnets": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -425,7 +425,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-vpc-test-1699297311041808000","ipv4":"192.168.0.0/25"}'
+    body: '{"label":"linodego-vpc-test-1699301061876079000","ipv4":"192.168.0.0/25"}'
     form: {}
     headers:
       Accept:
@@ -434,10 +434,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/7304/subnets
+    url: https://api.linode.com/v4beta/vpcs/7374/subnets
     method: POST
   response:
-    body: '{"id": 8197, "label": "linodego-vpc-test-1699297311041808000", "ipv4":
+    body: '{"id": 8273, "label": "linodego-vpc-test-1699301061876079000", "ipv4":
       "192.168.0.0/25", "linodes": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
     headers:
@@ -484,7 +484,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-ql94a57ne12p","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":8197,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
+    body: '{"label":"go-test-conf-kut154l3d0e5","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"public"},{"label":"testvlan","purpose":"vlan"},{"purpose":"vpc","subnet_id":8273,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
     form: {}
     headers:
       Accept:
@@ -493,23 +493,23 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51693566/configs/54679087
+    url: https://api.linode.com/v4beta/linode/instances/51696129/configs/54681781
     method: PUT
   response:
-    body: '{"id": 54679087, "label": "go-test-conf-ql94a57ne12p", "helpers": {"updatedb_disabled":
+    body: '{"id": 54681781, "label": "go-test-conf-kut154l3d0e5", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 798625, "purpose": "public",
+      "virt_mode": "paravirt", "interfaces": [{"id": 799665, "purpose": "public",
       "primary": false, "active": false, "ipam_address": null, "label": null, "vpc_id":
-      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 798626,
+      null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1": ""}}, {"id": 799666,
       "purpose": "vlan", "primary": false, "active": false, "ipam_address": "", "label":
       "testvlan", "vpc_id": null, "subnet_id": null, "ipv4": {"vpc": "", "nat_1_1":
-      ""}}, {"id": 798627, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 7304, "subnet_id": 8197, "ipv4": {"vpc": "192.168.0.2",
-      "nat_1_1": "172.233.111.111"}}]}'
+      ""}}, {"id": 799667, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 7374, "subnet_id": 8273, "ipv4": {"vpc": "192.168.0.2",
+      "nat_1_1": "172.233.111.119"}}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -561,11 +561,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/7304/subnets/8197
+    url: https://api.linode.com/v4beta/vpcs/7374/subnets/8273
     method: GET
   response:
-    body: '{"id": 8197, "label": "linodego-vpc-test-1699297311041808000", "ipv4":
-      "192.168.0.0/25", "linodes": [{"id": 51693566, "interfaces": [{"id": 798627,
+    body: '{"id": 8273, "label": "linodego-vpc-test-1699301061876079000", "ipv4":
+      "192.168.0.0/25", "linodes": [{"id": 51696129, "interfaces": [{"id": 799667,
       "active": false}]}], "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05"}'
     headers:
       Access-Control-Allow-Credentials:
@@ -622,19 +622,19 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51693566/ips
+    url: https://api.linode.com/v4beta/linode/instances/51696129/ips
     method: GET
   response:
-    body: '{"ipv4": {"public": [{"address": "172.233.111.111", "gateway": "172.233.111.1",
+    body: '{"ipv4": {"public": [{"address": "172.233.111.119", "gateway": "172.233.111.1",
       "subnet_mask": "255.255.255.0", "prefix": 24, "type": "ipv4", "public": true,
-      "rdns": "172-233-111-111.ip.linodeusercontent.com", "linode_id": 51693566, "region":
-      "es-mad", "vpc_nat_1_1": {"vpc_id": 7304, "subnet_id": 8197, "address": "192.168.0.2"}}],
+      "rdns": "172-233-111-119.ip.linodeusercontent.com", "linode_id": 51696129, "region":
+      "es-mad", "vpc_nat_1_1": {"vpc_id": 7374, "subnet_id": 8273, "address": "192.168.0.2"}}],
       "private": [], "shared": [], "reserved": []}, "ipv6": {"slaac": {"address":
       "1234::5678", "gateway": "1234::5678", "subnet_mask": "1234::5678",
-      "prefix": 64, "type": "ipv6", "rdns": null, "linode_id": 51693566, "region":
+      "prefix": 64, "type": "ipv6", "rdns": null, "linode_id": 51696129, "region":
       "es-mad", "public": true}, "link_local": {"address": "1234::5678",
       "gateway": "1234::5678", "subnet_mask": "1234::5678", "prefix": 64,
-      "type": "ipv6", "rdns": null, "linode_id": 51693566, "region": "es-mad", "public":
+      "type": "ipv6", "rdns": null, "linode_id": 51696129, "region": "es-mad", "public":
       false}, "global": []}}'
     headers:
       Access-Control-Allow-Credentials:
@@ -691,7 +691,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/51693566
+    url: https://api.linode.com/v4beta/linode/instances/51696129
     method: DELETE
   response:
     body: '{}'
@@ -724,6 +724,120 @@ interactions:
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7374/subnets/8273
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/vpcs/7374
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - vpc:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:

--- a/test/integration/instance_config_test.go
+++ b/test/integration/instance_config_test.go
@@ -22,9 +22,10 @@ func setupVPCWithSubnetWithInstance(
 	error,
 ) {
 	t.Helper()
-	client, instance, instanceConfig, instanceTeardown, err := setupInstanceWithoutDisks(
+	client, fixtureTeardown := createTestClient(t, fixturesYaml)
+	instance, instanceConfig, instanceTeardown, err := createInstanceWithoutDisks(
 		t,
-		fixturesYaml,
+		client,
 		modifiers...,
 	)
 	if err != nil {
@@ -46,8 +47,9 @@ func setupVPCWithSubnetWithInstance(
 	}
 
 	teardownAll := func() {
-		vpcWithSubnetTeardown()
 		instanceTeardown()
+		vpcWithSubnetTeardown()		
+		fixtureTeardown()
 	}
 	return client, vpc, vpcSubnet, instance, instanceConfig, teardownAll, err
 }


### PR DESCRIPTION
## 📝 Description

Explicitly call fixture teardown function in the VPC setup function, to avoid confusion and errors that caused by API calls after fixtures teardown were not recorded.

## ✔️ How to Test 
`make fixtures ARGS="-run TestInstance_ConfigInterface"`
`make test SKIP_LINT=1 ARGS="-run TestInstance_ConfigInterface"`

`make fixtures ARGS="-run TestVPC"`
`make test SKIP_LINT=1 ARGS="-run TestVPC"`