### PR TITLE
test: change generated test report to acceptable xml for TOD 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,32 +54,14 @@ jobs:
       - name: Run tests and save test report
         run: |
           timestamp=$(date +'%Y%m%d%H%M')
-          report_filename="${timestamp}_linodego_test_report.log"
+          report_filename="${timestamp}_linodego_test_report.xml"
 
-          if ! make ARGS="2>&1" test > "$report_filename"; then
+          if ! make test | go-junit-report -set-exit-code > "$report_filename"; then
             echo "EXIT_STATUS=1" >> $GITHUB_ENV
           fi
           cat "$report_filename"
         env:
           SKIP_LINT: 1
-
-      - name: Convert to XML Report
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: |
-          filename=$(ls | grep -E '^[0-9]{12}_linodego_test_report\.log')
-
-          if [ -f "$filename" ]; then
-            go_junit_report_dir=$(go env GOPATH)/bin
-            export PATH="$PATH:$go_junit_report_dir"
-            xml_filename=$(echo "$filename" | sed 's/\.log/.xml/')
-            go-junit-report -in "$filename" -iocopy -out "$xml_filename"
-            echo "Conversion from log to XML completed successfully."
-          else
-            echo "test report file not found."
-            exit 1
-          fi
-        env:
-          GO111MODULE: on
 
       - name: Add additional information to XML report
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/scripts/test_report_upload_script.py
+++ b/scripts/test_report_upload_script.py
@@ -1,6 +1,7 @@
 import boto3
 import sys
 import os
+import xml.etree.ElementTree as ET
 from botocore.exceptions import NoCredentialsError
 
 ACCESS_KEY = os.environ.get('LINODE_CLI_OBJ_ACCESS_KEY')
@@ -14,6 +15,42 @@ linode_obj_config = {
     "region_name": "us-southeast-1",
 }
 
+def change_xml_report_to_tod_acceptable_version(file_name):
+    # Load the original XML file
+    tree = ET.parse(file_name)
+    root = tree.getroot()
+
+    testsuites_element = root
+
+    # total
+    total_tests = int(testsuites_element.get('tests'))
+    total_failures = int(testsuites_element.get('failures'))
+    total_errors = int(testsuites_element.get('errors'))
+    total_skipped = int(testsuites_element.get('skipped'))
+
+    # Create a new <testsuites> element with aggregated values
+    new_testsuites = ET.Element("testsuites")
+    new_testsuites.set("tests", str(total_tests))
+    new_testsuites.set("failures", str(total_failures))
+    new_testsuites.set("errors", str(total_errors))
+    new_testsuites.set("skipped", str(total_skipped))
+
+    # Create a new <testsuite> element under <testsuites>
+    new_testsuite = ET.SubElement(new_testsuites, "testsuite", attrib=testsuites_element.attrib)
+
+    for testcase in root.findall('.//testcase'):
+        new_testcase = ET.SubElement(new_testsuite, "testcase", attrib=testcase.attrib)
+        for child in testcase:
+            new_testcase.append(child)
+
+    # Save the new XML to a file
+    try:
+        new_tree = ET.ElementTree(new_testsuites)
+        new_tree.write(file_name, encoding="UTF-8", xml_declaration=True)
+        print("XML content successfully over-written to " + file_name)
+
+    except Exception as e:
+        print("Error writing XML content:", str(e))
 
 def upload_to_linode_object_storage(file_name):
     try:


### PR DESCRIPTION
Workaround for this issue - https://jira.linode.com/browse/QE-334

For some context, I had a change in earlier this week improving xml test report to contain more information about the test run. However, this xml report that was generated caused some issue with TOD (issue linked above) due to multiple testsuite parameter in the report.

Fix:

Modified our exsiting test upload script to change the xml report to acceptable one by TOD

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**