### PR TITLE
test: add checks for test result fields in upload script for TOD

### DIFF
--- a/scripts/test_report_upload_script.py
+++ b/scripts/test_report_upload_script.py
@@ -23,10 +23,10 @@ def change_xml_report_to_tod_acceptable_version(file_name):
     testsuites_element = root
 
     # total
-    total_tests = int(testsuites_element.get('tests'))
-    total_failures = int(testsuites_element.get('failures'))
-    total_errors = int(testsuites_element.get('errors'))
-    total_skipped = int(testsuites_element.get('skipped'))
+    total_tests = int(testsuites_element.get('tests')) if testsuites_element.get('tests') is not None else 0
+    total_failures = int(testsuites_element.get('failures')) if testsuites_element.get('failures') is not None else 0
+    total_errors = int(testsuites_element.get('errors')) if testsuites_element.get('errors') is not None else 0
+    total_skipped = int(testsuites_element.get('skipped')) if testsuites_element.get('skipped') is not None else 0
 
     # Create a new <testsuites> element with aggregated values
     new_testsuites = ET.Element("testsuites")


### PR DESCRIPTION
## 📝 Description
There is an issue on TOD side when taking xml reports generated from our Go repositories.

Cause of the issue is that TOD is only expecting 1 testsuite variable under testsuites but the current xmls have multiple instances of testsuite.

This PR is to add some checks for fields related to test result before processing and uploading xml to TOD

## ✔️ How to Test

Need to monitor TOD side if results got uploaded successfully

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**