### PR TITLE
fix: incorrect xml format and add gha fields to test report

### DIFF
--- a/scripts/test_report_upload_script.py
+++ b/scripts/test_report_upload_script.py
@@ -47,6 +47,12 @@ def change_xml_report_to_tod_acceptable_version(file_name):
     try:
         new_tree = ET.ElementTree(new_testsuites)
         new_tree.write(file_name, encoding="UTF-8", xml_declaration=True)
+        new_root = new_tree.getroot()
+        new_root.append(root.get('branch_name'))
+        new_root.append(root.get('gha_run_id'))
+        new_root.append(root.get('gha_run_number'))
+        new_root.append(root.get('release_tag'))
+
         print("XML content successfully over-written to " + file_name)
 
     except Exception as e:
@@ -75,4 +81,5 @@ if __name__ == '__main__':
         print('Error: The provided file name is empty or invalid.')
         sys.exit(1)
 
+    change_xml_report_to_tod_acceptable_version(file_name)
     upload_to_linode_object_storage(file_name)


### PR DESCRIPTION
## 📝 Description

TOD has been rejecting linodego test results due to incorrect xml format, this PR addresses that issue
Forgot to add these fields in xml when uploading from GHA

- test: add release info to xml file before uploading to obj storage #437

## ✔️ How to Test

Will update the ticket with result once everything merged to dev

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**