### PR TITLE
fix: Add null check in eventMatchesSecondary

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -168,7 +168,6 @@ golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98y
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
-golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=
@@ -192,6 +191,8 @@ golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/go.work.sum
+++ b/go.work.sum
@@ -168,6 +168,7 @@ golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98y
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
 golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72g=
+golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=
@@ -191,8 +192,6 @@ golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/test/integration/fixtures/TestEventPoller_Secondary.yaml
+++ b/test/integration/fixtures/TestEventPoller_Secondary.yaml
@@ -222,7 +222,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:05:32 GMT
+      - Wed, 20 Dec 2023 22:08:04 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -260,15 +260,15 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 53282692, "label": "go-ins-poll-test", "group": "", "status": "provisioning",
+    body: '{"id": 53282734, "label": "go-ins-poll-test", "group": "", "status": "provisioning",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type":
-      "g6-nanode-1", "ipv4": ["45.79.123.5"], "ipv6": "1234::5678/128",
+      "g6-nanode-1", "ipv4": ["45.79.123.17"], "ipv6": "1234::5678/128",
       "image": null, "region": "ap-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
       false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
       null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
-      "c60d6982c4937a81828438a49510043deeb0a9cb", "has_user_data": false}'
+      "926f6f61bf1247b3667bd94b88cd5ac7c8d33901", "has_user_data": false}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -285,13 +285,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "719"
+      - "720"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:05:32 GMT
+      - Wed, 20 Dec 2023 22:08:04 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -325,15 +325,15 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":53282692,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":53282734,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 615700307, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
-      "duration": null, "action": "linode_create", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}], "page": 1,
+    body: '{"data": [{"id": 615701235, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      14.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282734, "type": "linode", "url": "/v4/linode/instances/53282734"},
+      "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
       "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -351,13 +351,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "442"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:05:48 GMT
+      - Wed, 20 Dec 2023 22:08:19 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -391,77 +391,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/615700307
+    url: https://api.linode.com/v4beta/account/events/615701235
     method: GET
   response:
-    body: '{"id": 615700307, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 22:05:48 GMT
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/615700307
-    method: GET
-  response:
-    body: '{"id": 615700307, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 615701235, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      19.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      14.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282734, "type": "linode", "url": "/v4/linode/instances/53282734"},
       "status": "finished", "secondary_entity": null, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -485,7 +421,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:03 GMT
+      - Wed, 20 Dec 2023 22:08:19 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -519,10 +455,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks
     method: POST
   response:
-    body: '{"id": 105632975, "status": "not ready", "label": "deleteEvent-0", "created":
+    body: '{"id": 105633086, "status": "not ready", "label": "deleteEvent-0", "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
       "size": 512}'
     headers:
@@ -547,7 +483,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:03 GMT
+      - Wed, 20 Dec 2023 22:08:19 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -580,7 +516,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -598,7 +534,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:03 GMT
+      - Wed, 20 Dec 2023 22:08:20 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -622,7 +558,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -640,7 +576,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:06 GMT
+      - Wed, 20 Dec 2023 22:08:23 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -664,10 +600,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks
     method: POST
   response:
-    body: '{"id": 105632981, "status": "not ready", "label": "deleteEvent-1", "created":
+    body: '{"id": 105633090, "status": "not ready", "label": "deleteEvent-1", "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
       "size": 512}'
     headers:
@@ -692,7 +628,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:12 GMT
+      - Wed, 20 Dec 2023 22:08:27 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -726,7 +662,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282734,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -753,7 +689,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:12 GMT
+      - Wed, 20 Dec 2023 22:08:27 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -788,7 +724,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282734,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -815,7 +751,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:12 GMT
+      - Wed, 20 Dec 2023 22:08:27 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -849,7 +785,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632975
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633086
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -869,7 +805,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:12 GMT
+      - Wed, 20 Dec 2023 22:08:27 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -893,7 +829,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632975
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633086
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -913,7 +849,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:15 GMT
+      - Wed, 20 Dec 2023 22:08:30 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -937,7 +873,51 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632975
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633086
+    method: DELETE
+  response:
+    body: '{"errors": [{"reason": "Linode busy."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "40"
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 22:08:34 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 400 Bad Request
+    code: 400
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633086
     method: DELETE
   response:
     body: '{}'
@@ -963,7 +943,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:19 GMT
+      - Wed, 20 Dec 2023 22:08:41 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -996,7 +976,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633090
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -1016,7 +996,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:19 GMT
+      - Wed, 20 Dec 2023 22:08:41 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -1040,7 +1020,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633090
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -1060,7 +1040,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:22 GMT
+      - Wed, 20 Dec 2023 22:08:44 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -1084,7 +1064,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633090
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -1104,7 +1084,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:26 GMT
+      - Wed, 20 Dec 2023 22:08:49 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -1128,7 +1108,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
+    url: https://api.linode.com/v4beta/linode/instances/53282734/disks/105633090
     method: DELETE
   response:
     body: '{}'
@@ -1154,7 +1134,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:36 GMT
+      - Wed, 20 Dec 2023 22:08:59 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1188,22 +1168,22 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282734,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 615700715, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 615701642, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      9.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "finished", "secondary_entity": {"id": 105632981, "type": "disk",
-      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282692/disks/105632981"},
-      "message": ""}, {"id": 615700608, "created": "2018-01-02T03:04:05", "seen":
+      12.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282734, "type": "linode", "url": "/v4/linode/instances/53282734"},
+      "status": "finished", "secondary_entity": {"id": 105633090, "type": "disk",
+      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282734/disks/105633090"},
+      "message": ""}, {"id": 615701539, "created": "2018-01-02T03:04:05", "seen":
       false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
-      null, "duration": 7.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "finished", "secondary_entity": {"id": 105632975, "type": "disk",
-      "label": "deleteEvent-0", "url": "/v4/linode/instances/53282692/disks/105632975"},
+      null, "duration": 13.0, "action": "disk_delete", "username": "lgarber-dev",
+      "entity": {"label": "go-ins-poll-test", "id": 53282734, "type": "linode", "url":
+      "/v4/linode/instances/53282734"}, "status": "finished", "secondary_entity":
+      {"id": 105633086, "type": "disk", "label": "deleteEvent-0", "url": "/v4/linode/instances/53282734/disks/105633086"},
       "message": ""}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
@@ -1225,7 +1205,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:51 GMT
+      - Wed, 20 Dec 2023 22:09:14 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1260,15 +1240,15 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/615700608
+    url: https://api.linode.com/v4beta/account/events/615701539
     method: GET
   response:
-    body: '{"id": 615700608, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 615701539, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      7.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "finished", "secondary_entity": {"id": 105632975, "type": "disk",
-      "label": "deleteEvent-0", "url": "/v4/linode/instances/53282692/disks/105632975"},
+      13.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282734, "type": "linode", "url": "/v4/linode/instances/53282734"},
+      "status": "finished", "secondary_entity": {"id": 105633086, "type": "disk",
+      "label": "deleteEvent-0", "url": "/v4/linode/instances/53282734/disks/105633086"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -1286,13 +1266,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "499"
+      - "500"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:06:51 GMT
+      - Wed, 20 Dec 2023 22:09:14 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1327,22 +1307,22 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282734,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 615700715, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 615701642, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      9.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "finished", "secondary_entity": {"id": 105632981, "type": "disk",
-      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282692/disks/105632981"},
-      "message": ""}, {"id": 615700608, "created": "2018-01-02T03:04:05", "seen":
+      12.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282734, "type": "linode", "url": "/v4/linode/instances/53282734"},
+      "status": "finished", "secondary_entity": {"id": 105633090, "type": "disk",
+      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282734/disks/105633090"},
+      "message": ""}, {"id": 615701539, "created": "2018-01-02T03:04:05", "seen":
       false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
-      null, "duration": 7.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "finished", "secondary_entity": {"id": 105632975, "type": "disk",
-      "label": "deleteEvent-0", "url": "/v4/linode/instances/53282692/disks/105632975"},
+      null, "duration": 13.0, "action": "disk_delete", "username": "lgarber-dev",
+      "entity": {"label": "go-ins-poll-test", "id": 53282734, "type": "linode", "url":
+      "/v4/linode/instances/53282734"}, "status": "finished", "secondary_entity":
+      {"id": 105633086, "type": "disk", "label": "deleteEvent-0", "url": "/v4/linode/instances/53282734/disks/105633086"},
       "message": ""}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
@@ -1364,7 +1344,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:07:06 GMT
+      - Wed, 20 Dec 2023 22:09:29 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1399,15 +1379,15 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/615700715
+    url: https://api.linode.com/v4beta/account/events/615701642
     method: GET
   response:
-    body: '{"id": 615700715, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 615701642, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      9.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
-      "status": "finished", "secondary_entity": {"id": 105632981, "type": "disk",
-      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282692/disks/105632981"},
+      12.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282734, "type": "linode", "url": "/v4/linode/instances/53282734"},
+      "status": "finished", "secondary_entity": {"id": 105633090, "type": "disk",
+      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282734/disks/105633090"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -1425,13 +1405,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "499"
+      - "500"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:07:06 GMT
+      - Wed, 20 Dec 2023 22:09:29 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1465,7 +1445,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282692
+    url: https://api.linode.com/v4beta/linode/instances/53282734
     method: DELETE
   response:
     body: '{}'
@@ -1491,7 +1471,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 22:07:07 GMT
+      - Wed, 20 Dec 2023 22:09:29 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/fixtures/TestEventPoller_Secondary.yaml
+++ b/test/integration/fixtures/TestEventPoller_Secondary.yaml
@@ -41,13 +41,13 @@ interactions:
       1234::5678, 1234::5678, 1234::5678"}},
       {"id": "us-iad", "label": "Washington, DC", "country": "us", "capabilities":
       ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Managed Databases", "Metadata", "Premium Plans"],
-      "status": "ok", "resolvers": {"ipv4": "139.144.192.62,   139.144.192.60,   139.144.192.61,   139.144.192.53,   139.144.192.54,   139.144.192.67,   139.144.192.69,    139.144.192.66,   139.144.192.52,   139.144.192.68",
+      "Cloud Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium
+      Plans"], "status": "ok", "resolvers": {"ipv4": "139.144.192.62,   139.144.192.60,   139.144.192.61,   139.144.192.53,   139.144.192.54,   139.144.192.67,   139.144.192.69,    139.144.192.66,   139.144.192.52,   139.144.192.68",
       "ipv6": "1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678"}},
       {"id": "us-ord", "label": "Chicago, IL", "country": "us", "capabilities": ["Linodes",
       "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Managed Databases", "Premium Plans"], "status": "ok", "resolvers":
-      {"ipv4": "172.232.0.17,   172.232.0.16,   172.232.0.21,   172.232.0.13,   172.232.0.22,   172.232.0.9,   172.232.0.19,   172.232.0.20,   172.232.0.15,   172.232.0.18",
+      "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans"], "status":
+      "ok", "resolvers": {"ipv4": "172.232.0.17,   172.232.0.16,   172.232.0.21,   172.232.0.13,   172.232.0.22,   172.232.0.9,   172.232.0.19,   172.232.0.20,   172.232.0.15,   172.232.0.18",
       "ipv6": "1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678"}},
       {"id": "fr-par", "label": "Paris, FR", "country": "fr", "capabilities": ["Linodes",
       "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
@@ -55,63 +55,130 @@ interactions:
       "resolvers": {"ipv4": "172.232.32.21,  172.232.32.23,  172.232.32.17,  172.232.32.18,  172.232.32.16,  172.232.32.22,  172.232.32.20,  172.232.32.14,  172.232.32.11,  172.232.32.12",
       "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
       {"id": "us-sea", "label": "Seattle, WA", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Cloud Firewall", "Vlans", "Managed Databases",
-      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.160.19, 172.232.160.21,
-      172.232.160.17, 172.232.160.15, 172.232.160.18, 172.232.160.8, 172.232.160.12,
-      172.232.160.11, 172.232.160.14, 172.232.160.16", "ipv6": "1234::5678,
+      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
+      "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.160.19, 172.232.160.21, 172.232.160.17, 172.232.160.15, 172.232.160.18,
+      172.232.160.8, 172.232.160.12, 172.232.160.11, 172.232.160.14, 172.232.160.16",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}}, {"id": "br-gru", "label": "Sao Paulo, BR",
+      "country": "br", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
+      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata",
+      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.233.0.4, 172.233.0.9,
+      172.233.0.7, 172.233.0.12, 172.233.0.5, 172.233.0.13, 172.233.0.10, 172.233.0.6,
+      172.233.0.8, 172.233.0.11", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}}, {"id": "nl-ams",
+      "label": "Amsterdam, NL", "country": "nl", "capabilities": ["Linodes", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.233.33.36, 172.233.33.38, 172.233.33.35, 172.233.33.39, 172.233.33.34,
+      172.233.33.33, 172.233.33.31, 172.233.33.30, 172.233.33.37, 172.233.33.32",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}}, {"id": "se-sto", "label": "Stockholm, SE",
+      "country": "se", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
+      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata",
+      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.128.24, 172.232.128.26,
+      172.232.128.20, 172.232.128.22, 172.232.128.25, 172.232.128.19, 172.232.128.23,
+      172.232.128.18, 172.232.128.21, 172.232.128.27", "ipv6": "1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "se-sto", "label": "Stockholm, SE", "country": "se", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Managed Databases", "Premium Plans"], "status":
-      "ok", "resolvers": {"ipv4": "172.232.128.24,  172.232.128.26,  172.232.128.20,  172.232.128.22,  172.232.128.25,  172.232.128.19,  172.232.128.23,  172.232.128.18,  172.232.128.21,  172.232.128.27",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "in-maa", "label": "Chennai, IN", "country": "in", "capabilities": ["Linodes",
+      {"id": "es-mad", "label": "Madrid, ES", "country": "es", "capabilities": ["Linodes",
       "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Managed Databases", "Premium Plans"], "status": "ok", "resolvers":
-      {"ipv4": "172.232.96.17,  172.232.96.26,  172.232.96.19,  172.232.96.20,  172.232.96.25,  172.232.96.21,  172.232.96.18,  172.232.96.22,  172.232.96.23,  172.232.96.24",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "it-mil", "label": "Milan, IT", "country": "it", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Cloud Firewall", "Vlans", "Managed Databases",
-      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.192.19,  172.232.192.18,  172.232.192.16,  172.232.192.20,  172.232.192.24,  172.232.192.21,  172.232.192.22,  172.232.192.17,  172.232.192.15,  172.232.192.23",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "id-cgk", "label": "Jakarta, ID", "country": "id", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Cloud Firewall", "Vlans",
-      "Managed Databases", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
-      "172.232.224.23,  172.232.224.32,  172.232.224.26,  172.232.224.27,  172.232.224.21,  172.232.224.24,  172.232.224.22,  172.232.224.20,  172.232.224.31,  172.232.224.28",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "us-central", "label": "Dallas, TX", "country": "us", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "72.14.179.5, 72.14.188.5, 173.255.199.5, 66.228.53.5, 96.126.122.5,
-      96.126.124.5, 96.126.127.5, 198.58.107.5, 198.58.111.5, 23.239.24.5", "ipv6":
-      "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678"}}, {"id": "us-west",
-      "label": "Fremont, CA", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,
-      173.230.147.5, 173.230.155.5, 173.255.212.5, 173.255.219.5, 173.255.241.5, 173.255.243.5,
-      173.255.244.5, 74.207.241.5, 74.207.242.5", "ipv6": "1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "us-southeast", "label": "Atlanta, GA",
-      "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block
-      Storage Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4":
-      "74.207.231.5, 173.230.128.5, 173.230.129.5, 173.230.136.5, 173.230.140.5, 66.228.59.5,
-      66.228.62.5, 50.116.35.5, 50.116.41.5, 23.239.18.5", "ipv6": "1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}}, {"id": "us-east", "label": "Newark,
-      NJ", "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Bare Metal",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "66.228.42.5, 96.126.106.5, 50.116.53.5, 50.116.58.5, 50.116.61.5,
-      50.116.62.5, 66.175.211.5, 97.107.133.4, 207.192.69.4, 207.192.69.5", "ipv6":
-      "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678"}}, {"id": "eu-west",
-      "label": "London, UK", "country": "gb", "capabilities": ["Linodes", "NodeBalancers",
+      "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "172.233.111.6, 172.233.111.17, 172.233.111.21, 172.233.111.25, 172.233.111.19,
+      172.233.111.12, 172.233.111.26, 172.233.111.16, 172.233.111.18, 172.233.111.9",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}}, {"id": "in-maa", "label": "Chennai, IN",
+      "country": "in", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
+      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata",
+      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.96.17, 172.232.96.26,
+      172.232.96.19, 172.232.96.20, 172.232.96.25, 172.232.96.21, 172.232.96.18, 172.232.96.22,
+      172.232.96.23, 172.232.96.24", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}}, {"id": "jp-osa",
+      "label": "Osaka, JP", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.233.64.44, 172.233.64.43, 172.233.64.37, 172.233.64.40, 172.233.64.46,
+      172.233.64.41, 172.233.64.39, 172.233.64.42, 172.233.64.45, 172.233.64.38",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}}, {"id": "it-mil", "label": "Milan, IT", "country":
+      "it", "capabilities": ["Linodes", "NodeBalancers", "Block Storage", "Object
+      Storage", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium
+      Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.192.19, 172.232.192.18,
+      172.232.192.16, 172.232.192.20, 172.232.192.24, 172.232.192.21, 172.232.192.22,
+      172.232.192.17, 172.232.192.15, 172.232.192.23", "ipv6": "1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678"}},
+      {"id": "us-mia", "label": "Miami, FL", "country": "us", "capabilities": ["Linodes",
+      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
+      "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "172.233.160.34, 172.233.160.27, 172.233.160.30, 172.233.160.29, 172.233.160.32,
+      172.233.160.28, 172.233.160.33, 172.233.160.26, 172.233.160.25, 172.233.160.31",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}}, {"id": "id-cgk", "label": "Jakarta, ID",
+      "country": "id", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
+      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata",
+      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.224.23, 172.232.224.32,
+      172.232.224.26, 172.232.224.27, 172.232.224.21, 172.232.224.24, 172.232.224.22,
+      172.232.224.20, 172.232.224.31, 172.232.224.28", "ipv6": "1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678"}},
+      {"id": "us-lax", "label": "Los Angeles, CA", "country": "us", "capabilities":
+      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok",
+      "resolvers": {"ipv4": "172.233.128.45, 172.233.128.38, 172.233.128.53, 172.233.128.37,
+      172.233.128.34, 172.233.128.36, 172.233.128.33, 172.233.128.39, 172.233.128.43,
+      172.233.128.44", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}}, {"id": "us-central",
+      "label": "Dallas, TX", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
       "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,  176.58.107.5,  176.58.116.5,  176.58.121.5,  151.236.220.5,  212.71.252.5,  212.71.253.5,  109.74.192.20,  109.74.193.20,  109.74.194.20",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5, 72.14.188.5,
+      173.255.199.5, 66.228.53.5, 96.126.122.5, 96.126.124.5, 96.126.127.5, 198.58.107.5,
+      198.58.111.5, 23.239.24.5", "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}}, {"id": "us-west", "label": "Fremont, CA", "country": "us",
+      "capabilities": ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes",
+      "Cloud Firewall", "Block Storage Migrations", "Managed Databases"], "status":
+      "ok", "resolvers": {"ipv4": "173.230.145.5, 173.230.147.5, 173.230.155.5, 173.255.212.5,
+      173.255.219.5, 173.255.241.5, 173.255.243.5, 173.255.244.5, 74.207.241.5, 74.207.242.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}}, {"id":
+      "us-southeast", "label": "Atlanta, GA", "country": "us", "capabilities": ["Linodes",
+      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
+      "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "74.207.231.5, 173.230.128.5, 173.230.129.5,
+      173.230.136.5, 173.230.140.5, 66.228.59.5, 66.228.62.5, 50.116.35.5, 50.116.41.5,
+      23.239.18.5", "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}},
+      {"id": "us-east", "label": "Newark, NJ", "country": "us", "capabilities": ["Linodes",
+      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
+      "Cloud Firewall", "Bare Metal", "Vlans", "Block Storage Migrations", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5, 96.126.106.5,
+      50.116.53.5, 50.116.58.5, 50.116.61.5, 50.116.62.5, 66.175.211.5, 97.107.133.4,
+      207.192.69.4, 207.192.69.5", "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}}, {"id": "eu-west", "label": "London, UK", "country": "gb", "capabilities":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
+      {"ipv4": "178.79.182.5,  176.58.107.5,  176.58.116.5,  176.58.121.5,  151.236.220.5,  212.71.252.5,  212.71.253.5,  109.74.192.20,  109.74.193.20,  109.74.194.20",
       "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
       {"id": "ap-south", "label": "Singapore, SG", "country": "sg", "capabilities":
       ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
@@ -134,7 +201,7 @@ interactions:
       139.162.69.5, 139.162.70.5, 139.162.71.5, 139.162.72.5, 139.162.73.5, 139.162.74.5,
       139.162.75.5", "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}}],
-      "page": 1, "pages": 1, "results": 19}'
+      "page": 1, "pages": 1, "results": 25}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -147,19 +214,23 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=900
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:50:58 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - '*'
       X-Content-Type-Options:
@@ -170,7 +241,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -189,15 +260,15 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 48058285, "label": "go-ins-poll-test", "group": "", "status": "provisioning",
+    body: '{"id": 53282361, "label": "go-ins-poll-test", "group": "", "status": "provisioning",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type":
-      "g6-nanode-1", "ipv4": ["172.105.43.138"], "ipv6": "1234::5678/128",
+      "g6-nanode-1", "ipv4": ["172.105.56.90"], "ipv6": "1234::5678/128",
       "image": null, "region": "ap-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
       false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
       null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
-      "71943b7db55fadab33ab3a638a6626fbcb4583e7"}'
+      "926f6f61bf1247b3667bd94b88cd5ac7c8d33901", "has_user_data": false}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -210,15 +281,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "698"
+      - "721"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:50:58 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -250,15 +325,15 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":48058285,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":53282361,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
-      "duration": null, "action": "linode_create", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}], "page": 1,
+    body: '{"data": [{"id": 615694039, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      14.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
       "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -272,16 +347,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "442"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:13 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -297,7 +375,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -313,6174 +391,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
+    url: https://api.linode.com/v4beta/account/events/615694039
     method: GET
   response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
-      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "393"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 7, "time_remaining": null, "rate": null, "duration":
-      7.454861, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 7, "time_remaining": null, "rate": null, "duration":
-      7.550843, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 7, "time_remaining": null, "rate": null, "duration":
-      7.629794, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 7, "time_remaining": null, "rate": null, "duration":
-      7.770662, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 7, "time_remaining": null, "rate": null, "duration":
-      7.96467, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "394"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.018463, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.072477, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.127755, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.181259, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.230558, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.284226, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.33762, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.393868, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.449046, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.504209, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.56065, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.728876, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.784009, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.83956, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.895015, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 14, "time_remaining": null, "rate": null, "duration":
-      8.954802, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.013011, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.072854, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.128061, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.202519, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.262427, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.315118, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.378273, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.431461, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.489423, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.551267, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.604134, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.671234, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.720224, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.77817, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.837986, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.88878, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "395"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 20, "time_remaining": null, "rate": null, "duration":
-      9.953298, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.005885, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.069542, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.119933, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.172495, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.235155, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.296762, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.38855, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "396"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 26, "time_remaining": null, "rate": null, "duration":
-      10.447171, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "started", "secondary_entity": null, "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "397"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066527
-    method: GET
-  response:
-    body: '{"id": 535066527, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 615694039, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      10.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
+      14.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
       "status": "finished", "secondary_entity": null, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -6494,16 +411,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "391"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:13 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -6519,7 +439,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -6535,11 +455,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
     method: POST
   response:
-    body: '{"id": 95703754, "status": "not ready", "label": "disk-0", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "filesystem": "ext4", "size": 512}'
+    body: '{"id": 105632327, "status": "not ready", "label": "disk-0", "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
+      "size": 512}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -6552,15 +473,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "161"
+      - "162"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:14 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -6575,7 +500,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -6591,7 +516,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -6602,12 +527,16 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:14 GMT
+      Pragma:
+      - no-cache
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
       X-Frame-Options:
@@ -6615,7 +544,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -6629,11 +558,54 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
     method: POST
   response:
-    body: '{"id": 95703765, "status": "not ready", "label": "disk-1", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "filesystem": "ext4", "size": 512}'
+    body: '{"errors": [{"reason": "Linode busy."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "40"
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:51:17 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 400 Bad Request
+    code: 400
+    duration: ""
+- request:
+    body: '{"label":"disk-1","size":512}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    method: POST
+  response:
+    body: '{"id": 105632330, "status": "not ready", "label": "disk-1", "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
+      "size": 512}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -6646,15 +618,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "161"
+      - "162"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:23 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -6669,7 +645,194 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"label":"disk-2","size":512}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Linode busy."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "40"
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:51:23 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 400 Bad Request
+    code: 400
+    duration: ""
+- request:
+    body: '{"label":"disk-2","size":512}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Linode busy."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "40"
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:51:26 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 400 Bad Request
+    code: 400
+    duration: ""
+- request:
+    body: '{"label":"disk-2","size":512}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Linode busy."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "40"
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:51:30 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 400 Bad Request
+    code: 400
+    duration: ""
+- request:
+    body: '{"label":"disk-2","size":512}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    method: POST
+  response:
+    body: '{"id": 105632339, "status": "not ready", "label": "disk-2", "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
+      "size": 512}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "162"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:51:39 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -6686,7 +849,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":48058285,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -6703,16 +866,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "49"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:39 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -6728,7 +894,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -6744,7 +910,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703754
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -6755,12 +921,18 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:39 GMT
+      Pragma:
+      - no-cache
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
       X-Frame-Options:
@@ -6768,7 +940,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -6782,7 +954,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703754
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -6793,12 +965,18 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:42 GMT
+      Pragma:
+      - no-cache
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
       X-Frame-Options:
@@ -6806,7 +984,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -6820,7 +998,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703754
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -6831,12 +1009,18 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:48 GMT
+      Pragma:
+      - no-cache
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
       X-Frame-Options:
@@ -6844,7 +1028,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -6858,7 +1042,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703754
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
     method: DELETE
   response:
     body: '{}'
@@ -6874,15 +1058,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:58 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -6897,7 +1085,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -6913,7 +1101,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703765
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -6924,12 +1112,18 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:51:58 GMT
+      Pragma:
+      - no-cache
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
       X-Frame-Options:
@@ -6937,7 +1131,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -6951,7 +1145,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703765
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -6962,12 +1156,18 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:52:01 GMT
+      Pragma:
+      - no-cache
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
       X-Frame-Options:
@@ -6975,7 +1175,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -6989,7 +1189,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703765
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -7000,12 +1200,18 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "40"
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:52:05 GMT
+      Pragma:
+      - no-cache
       X-Accepted-Oauth-Scopes:
       - linodes:read_write
       X-Frame-Options:
@@ -7013,7 +1219,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
     status: 400 Bad Request
     code: 400
     duration: ""
@@ -7027,7 +1233,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285/disks/95703765
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
     method: DELETE
   response:
     body: '{}'
@@ -7043,15 +1249,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:52:16 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -7066,7 +1276,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -7083,23 +1293,23 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":48058285,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 535066940, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
-      "duration": null, "action": "disk_delete", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "scheduled", "secondary_entity": {"id": 95703765, "type": "disk",
-      "label": "disk-1", "url": "/v4/linode/instances/48058285/disks/95703765"}, "message":
-      ""}, {"id": 535066839, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      12.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "finished", "secondary_entity": {"id": 95703754, "type": "disk", "label":
-      "disk-0", "url": "/v4/linode/instances/48058285/disks/95703754"}, "message":
-      ""}], "page": 1, "pages": 1, "results": 2}'
+    body: '{"data": [{"id": 615694526, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      8.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632330, "type": "disk",
+      "label": "disk-1", "url": "/v4/linode/instances/53282361/disks/105632330"},
+      "message": ""}, {"id": 615694412, "created": "2018-01-02T03:04:05", "seen":
+      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
+      null, "duration": 9.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
+      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
+      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
+      "message": ""}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -7112,19 +1322,23 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:52:31 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - events:read_only
       X-Content-Type-Options:
@@ -7135,7 +1349,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -7151,16 +1365,16 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/535066839
+    url: https://api.linode.com/v4beta/account/events/615694412
     method: GET
   response:
-    body: '{"id": 535066839, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 615694412, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      12.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 48058285, "type": "linode", "url": "/v4/linode/instances/48058285"},
-      "status": "finished", "secondary_entity": {"id": 95703754, "type": "disk", "label":
-      "disk-0", "url": "/v4/linode/instances/48058285/disks/95703754"}, "message":
-      ""}'
+      9.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
+      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
+      "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -7173,16 +1387,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "491"
+      - "492"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:52:31 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -7198,7 +1415,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -7214,7 +1431,80 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/48058285
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 615694526, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      8.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632330, "type": "disk",
+      "label": "disk-1", "url": "/v4/linode/instances/53282361/disks/105632330"},
+      "message": ""}, {"id": 615694412, "created": "2018-01-02T03:04:05", "seen":
+      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
+      null, "duration": 9.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
+      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
+      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
+      "message": ""}], "page": 1, "pages": 1, "results": 2}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:52:32 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632339
     method: DELETE
   response:
     body: '{}'
@@ -7230,15 +1520,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Dec 2023 21:52:32 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -7253,7 +1547,211 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 615694653, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      10.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632339, "type": "disk",
+      "label": "disk-2", "url": "/v4/linode/instances/53282361/disks/105632339"},
+      "message": ""}, {"id": 615694526, "created": "2018-01-02T03:04:05", "seen":
+      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
+      null, "duration": 8.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
+      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632330, "type": "disk",
+      "label": "disk-1", "url": "/v4/linode/instances/53282361/disks/105632330"},
+      "message": ""}, {"id": 615694412, "created": "2018-01-02T03:04:05", "seen":
+      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
+      null, "duration": 9.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
+      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
+      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
+      "message": ""}], "page": 1, "pages": 1, "results": 3}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:52:47 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/615694653
+    method: GET
+  response:
+    body: '{"id": 615694653, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      10.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
+      "status": "finished", "secondary_entity": {"id": 105632339, "type": "disk",
+      "label": "disk-2", "url": "/v4/linode/instances/53282361/disks/105632339"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "493"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:52:47 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282361
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 21:52:47 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestEventPoller_Secondary.yaml
+++ b/test/integration/fixtures/TestEventPoller_Secondary.yaml
@@ -222,7 +222,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:50:58 GMT
+      - Wed, 20 Dec 2023 22:05:32 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -260,15 +260,15 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 53282361, "label": "go-ins-poll-test", "group": "", "status": "provisioning",
+    body: '{"id": 53282692, "label": "go-ins-poll-test", "group": "", "status": "provisioning",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "type":
-      "g6-nanode-1", "ipv4": ["172.105.56.90"], "ipv6": "1234::5678/128",
+      "g6-nanode-1", "ipv4": ["45.79.123.5"], "ipv6": "1234::5678/128",
       "image": null, "region": "ap-west", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
       false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
       null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
-      "926f6f61bf1247b3667bd94b88cd5ac7c8d33901", "has_user_data": false}'
+      "c60d6982c4937a81828438a49510043deeb0a9cb", "has_user_data": false}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -285,13 +285,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "721"
+      - "719"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:50:58 GMT
+      - Wed, 20 Dec 2023 22:05:32 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -325,15 +325,15 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":53282361,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","entity.id":53282692,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 615694039, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      14.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": null, "message": ""}], "page": 1,
+    body: '{"data": [{"id": 615700307, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
+      "duration": null, "action": "linode_create", "username": "lgarber-dev", "entity":
+      {"label": "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "scheduled", "secondary_entity": null, "message": ""}], "page": 1,
       "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -351,13 +351,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "440"
+      - "442"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:13 GMT
+      - Wed, 20 Dec 2023 22:05:48 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -391,14 +391,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/615694039
+    url: https://api.linode.com/v4beta/account/events/615700307
     method: GET
   response:
-    body: '{"id": 615694039, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      14.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": null, "message": ""}'
+    body: '{"id": 615700307, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 0, "time_remaining": null, "rate": null, "duration":
+      null, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "scheduled", "secondary_entity": null, "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -415,13 +415,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "391"
+      - "393"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:13 GMT
+      - Wed, 20 Dec 2023 22:05:48 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -446,7 +446,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"disk-0","size":512}'
+    body: ""
     form: {}
     headers:
       Accept:
@@ -455,10 +455,74 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    url: https://api.linode.com/v4beta/account/events/615700307
+    method: GET
+  response:
+    body: '{"id": 615700307, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      19.0, "action": "linode_create", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "finished", "secondary_entity": null, "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "391"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 22:06:03 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"label":"deleteEvent-0","size":512}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
     method: POST
   response:
-    body: '{"id": 105632327, "status": "not ready", "label": "disk-0", "created":
+    body: '{"id": 105632975, "status": "not ready", "label": "deleteEvent-0", "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
       "size": 512}'
     headers:
@@ -477,13 +541,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "162"
+      - "169"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:14 GMT
+      - Wed, 20 Dec 2023 22:06:03 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -507,7 +571,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"disk-1","size":512}'
+    body: '{"label":"deleteEvent-1","size":512}'
     form: {}
     headers:
       Accept:
@@ -516,7 +580,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -534,7 +598,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:14 GMT
+      - Wed, 20 Dec 2023 22:06:03 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -549,7 +613,7 @@ interactions:
     code: 400
     duration: ""
 - request:
-    body: '{"label":"disk-1","size":512}'
+    body: '{"label":"deleteEvent-1","size":512}'
     form: {}
     headers:
       Accept:
@@ -558,7 +622,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
     method: POST
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -576,7 +640,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:17 GMT
+      - Wed, 20 Dec 2023 22:06:06 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -591,7 +655,7 @@ interactions:
     code: 400
     duration: ""
 - request:
-    body: '{"label":"disk-1","size":512}'
+    body: '{"label":"deleteEvent-1","size":512}'
     form: {}
     headers:
       Accept:
@@ -600,10 +664,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks
     method: POST
   response:
-    body: '{"id": 105632330, "status": "not ready", "label": "disk-1", "created":
+    body: '{"id": 105632981, "status": "not ready", "label": "deleteEvent-1", "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
       "size": 512}'
     headers:
@@ -622,200 +686,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "162"
+      - "169"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:23 GMT
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_write
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"label":"disk-2","size":512}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
-    method: POST
-  response:
-    body: '{"errors": [{"reason": "Linode busy."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Content-Length:
-      - "40"
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:51:23 GMT
-      Pragma:
-      - no-cache
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-    status: 400 Bad Request
-    code: 400
-    duration: ""
-- request:
-    body: '{"label":"disk-2","size":512}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
-    method: POST
-  response:
-    body: '{"errors": [{"reason": "Linode busy."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Content-Length:
-      - "40"
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:51:26 GMT
-      Pragma:
-      - no-cache
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-    status: 400 Bad Request
-    code: 400
-    duration: ""
-- request:
-    body: '{"label":"disk-2","size":512}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
-    method: POST
-  response:
-    body: '{"errors": [{"reason": "Linode busy."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Content-Length:
-      - "40"
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:51:30 GMT
-      Pragma:
-      - no-cache
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-    status: 400 Bad Request
-    code: 400
-    duration: ""
-- request:
-    body: '{"label":"disk-2","size":512}'
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks
-    method: POST
-  response:
-    body: '{"id": 105632339, "status": "not ready", "label": "disk-2", "created":
-      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem": "ext4",
-      "size": 512}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "162"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:51:39 GMT
+      - Wed, 20 Dec 2023 22:06:12 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -849,7 +726,7 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
@@ -876,7 +753,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:39 GMT
+      - Wed, 20 Dec 2023 22:06:12 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -910,7 +787,69 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [], "page": 1, "pages": 1, "results": 0}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "49"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 22:06:12 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632975
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -930,7 +869,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:39 GMT
+      - Wed, 20 Dec 2023 22:06:12 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -954,7 +893,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632975
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -974,7 +913,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:42 GMT
+      - Wed, 20 Dec 2023 22:06:15 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -998,51 +937,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
-    method: DELETE
-  response:
-    body: '{"errors": [{"reason": "Linode busy."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "40"
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:51:48 GMT
-      Pragma:
-      - no-cache
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-    status: 400 Bad Request
-    code: 400
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632327
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632975
     method: DELETE
   response:
     body: '{}'
@@ -1068,7 +963,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:58 GMT
+      - Wed, 20 Dec 2023 22:06:19 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1101,7 +996,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -1121,7 +1016,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:51:58 GMT
+      - Wed, 20 Dec 2023 22:06:19 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -1145,7 +1040,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -1165,7 +1060,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:52:01 GMT
+      - Wed, 20 Dec 2023 22:06:22 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -1189,7 +1084,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
     method: DELETE
   response:
     body: '{"errors": [{"reason": "Linode busy."}]}'
@@ -1209,7 +1104,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:52:05 GMT
+      - Wed, 20 Dec 2023 22:06:26 GMT
       Pragma:
       - no-cache
       X-Accepted-Oauth-Scopes:
@@ -1233,7 +1128,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632330
+    url: https://api.linode.com/v4beta/linode/instances/53282692/disks/105632981
     method: DELETE
   response:
     body: '{}'
@@ -1259,7 +1154,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:52:16 GMT
+      - Wed, 20 Dec 2023 22:06:36 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1293,22 +1188,22 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
     url: https://api.linode.com/v4beta/account/events?page=1
     method: GET
   response:
-    body: '{"data": [{"id": 615694526, "created": "2018-01-02T03:04:05", "seen": false,
+    body: '{"data": [{"id": 615700715, "created": "2018-01-02T03:04:05", "seen": false,
       "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      8.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632330, "type": "disk",
-      "label": "disk-1", "url": "/v4/linode/instances/53282361/disks/105632330"},
-      "message": ""}, {"id": 615694412, "created": "2018-01-02T03:04:05", "seen":
+      9.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "finished", "secondary_entity": {"id": 105632981, "type": "disk",
+      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282692/disks/105632981"},
+      "message": ""}, {"id": 615700608, "created": "2018-01-02T03:04:05", "seen":
       false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
-      null, "duration": 9.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
-      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
+      null, "duration": 7.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
+      {"label": "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "finished", "secondary_entity": {"id": 105632975, "type": "disk",
+      "label": "deleteEvent-0", "url": "/v4/linode/instances/53282692/disks/105632975"},
       "message": ""}], "page": 1, "pages": 1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
@@ -1330,7 +1225,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:52:31 GMT
+      - Wed, 20 Dec 2023 22:06:51 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1365,15 +1260,154 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/615694412
+    url: https://api.linode.com/v4beta/account/events/615700608
     method: GET
   response:
-    body: '{"id": 615694412, "created": "2018-01-02T03:04:05", "seen": false, "read":
+    body: '{"id": 615700608, "created": "2018-01-02T03:04:05", "seen": false, "read":
+      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      7.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "finished", "secondary_entity": {"id": 105632975, "type": "disk",
+      "label": "deleteEvent-0", "url": "/v4/linode/instances/53282692/disks/105632975"},
+      "message": ""}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "499"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 22:06:51 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282692,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 615700715, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      9.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
+      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "finished", "secondary_entity": {"id": 105632981, "type": "disk",
+      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282692/disks/105632981"},
+      "message": ""}, {"id": 615700608, "created": "2018-01-02T03:04:05", "seen":
+      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
+      null, "duration": 7.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
+      {"label": "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "finished", "secondary_entity": {"id": 105632975, "type": "disk",
+      "label": "deleteEvent-0", "url": "/v4/linode/instances/53282692/disks/105632975"},
+      "message": ""}], "page": 1, "pages": 1, "results": 2}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Dec 2023 22:07:06 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/account/events/615700715
+    method: GET
+  response:
+    body: '{"id": 615700715, "created": "2018-01-02T03:04:05", "seen": false, "read":
       false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
       9.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
-      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
+      "go-ins-poll-test", "id": 53282692, "type": "linode", "url": "/v4/linode/instances/53282692"},
+      "status": "finished", "secondary_entity": {"id": 105632981, "type": "disk",
+      "label": "deleteEvent-1", "url": "/v4/linode/instances/53282692/disks/105632981"},
       "message": ""}'
     headers:
       Access-Control-Allow-Credentials:
@@ -1391,13 +1425,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "492"
+      - "499"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:52:31 GMT
+      - Wed, 20 Dec 2023 22:07:06 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -1431,80 +1465,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 615694526, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      8.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632330, "type": "disk",
-      "label": "disk-1", "url": "/v4/linode/instances/53282361/disks/105632330"},
-      "message": ""}, {"id": 615694412, "created": "2018-01-02T03:04:05", "seen":
-      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
-      null, "duration": 9.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
-      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
-      "message": ""}], "page": 1, "pages": 1, "results": 2}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:52:32 GMT
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361/disks/105632339
+    url: https://api.linode.com/v4beta/linode/instances/53282692
     method: DELETE
   response:
     body: '{}'
@@ -1530,211 +1491,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 20 Dec 2023 21:52:32 GMT
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_write
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"+order":"desc","+order_by":"created","action":"disk_delete","entity.id":53282361,"entity.type":"linode"}'
-    url: https://api.linode.com/v4beta/account/events?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 615694653, "created": "2018-01-02T03:04:05", "seen": false,
-      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      10.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632339, "type": "disk",
-      "label": "disk-2", "url": "/v4/linode/instances/53282361/disks/105632339"},
-      "message": ""}, {"id": 615694526, "created": "2018-01-02T03:04:05", "seen":
-      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
-      null, "duration": 8.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632330, "type": "disk",
-      "label": "disk-1", "url": "/v4/linode/instances/53282361/disks/105632330"},
-      "message": ""}, {"id": 615694412, "created": "2018-01-02T03:04:05", "seen":
-      false, "read": false, "percent_complete": 100, "time_remaining": 0, "rate":
-      null, "duration": 9.0, "action": "disk_delete", "username": "lgarber-dev", "entity":
-      {"label": "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632327, "type": "disk",
-      "label": "disk-0", "url": "/v4/linode/instances/53282361/disks/105632327"},
-      "message": ""}], "page": 1, "pages": 1, "results": 3}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:52:47 GMT
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/account/events/615694653
-    method: GET
-  response:
-    body: '{"id": 615694653, "created": "2018-01-02T03:04:05", "seen": false, "read":
-      false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
-      10.0, "action": "disk_delete", "username": "lgarber-dev", "entity": {"label":
-      "go-ins-poll-test", "id": 53282361, "type": "linode", "url": "/v4/linode/instances/53282361"},
-      "status": "finished", "secondary_entity": {"id": 105632339, "type": "disk",
-      "label": "disk-2", "url": "/v4/linode/instances/53282361/disks/105632339"},
-      "message": ""}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "493"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:52:47 GMT
-      Pragma:
-      - no-cache
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - events:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/53282361
-    method: DELETE
-  response:
-    body: '{}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "2"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Expires:
-      - Wed, 20 Dec 2023 21:52:47 GMT
+      - Wed, 20 Dec 2023 22:07:07 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -171,7 +171,7 @@ func TestEventPoller_Secondary(t *testing.T) {
 	}
 
 	// Create two instance disks
-	disks := make([]*linodego.InstanceDisk, 2)
+	disks := make([]*linodego.InstanceDisk, 3)
 
 	for i := 0; i < 3; i++ {
 		disk, err := client.CreateInstanceDisk(context.Background(), instance.ID, linodego.InstanceDiskCreateOptions{

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -174,17 +174,17 @@ func TestEventPoller_Secondary(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		disk, err := client.CreateInstanceDisk(context.Background(), instance.ID, linodego.InstanceDiskCreateOptions{
-			Label: fmt.Sprintf("deleteEvent-%d", i),
+			Label: fmt.Sprintf("test-disk-%d", i),
 			Size:  512,
 		})
 		if err != nil {
-			t.Fatalf("failed to create instance deleteEvent: %s", err)
+			t.Fatalf("failed to create instance disk: %s", err)
 		}
 
 		disks[i] = disk
 	}
 
-	// Poll for the first deleteEvent to be deleted
+	// Poll for the first disk to be deleted
 	diskPoller, err := client.NewEventPollerWithSecondary(
 		context.Background(),
 		instance.ID,
@@ -195,7 +195,7 @@ func TestEventPoller_Secondary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Poll for the second deleteEvent to be deleted
+	// Poll for the second disk to be deleted
 	diskPoller2, err := client.NewEventPollerWithSecondary(
 		context.Background(),
 		instance.ID,
@@ -213,7 +213,7 @@ func TestEventPoller_Secondary(t *testing.T) {
 		}
 	}
 
-	// Wait for the first deleteEvent to be deleted
+	// Wait for the first disk to be deleted
 	deleteEvent, err := diskPoller.WaitForFinished(context.Background(), 60)
 	if err != nil {
 		t.Fatal(err)

--- a/waitfor.go
+++ b/waitfor.go
@@ -787,6 +787,12 @@ func eventMatchesSecondary(configuredID any, e Event) bool {
 		return true
 	}
 
+	// We should return false if the event has no secondary entity.
+	// e.g. A previous disk deletion has completed.
+	if e.SecondaryEntity == nil {
+		return false
+	}
+
 	secondaryID := e.SecondaryEntity.ID
 
 	// Evil hack to correct IDs parsed as floats

--- a/waitfor.go
+++ b/waitfor.go
@@ -669,7 +669,7 @@ func (p *EventPoller) WaitForLatestUnknownEvent(ctx context.Context) (*Event, er
 			}
 
 			for _, event := range events {
-				if !eventMatchesSecondary(p.SecondaryEntityID, event) {
+				if p.SecondaryEntityID != nil && !eventMatchesSecondary(p.SecondaryEntityID, event) {
 					continue
 				}
 
@@ -781,12 +781,6 @@ func (client Client) WaitForResourceFree(
 // matches the configured secondary ID.
 // This logic has been broken out to improve readability.
 func eventMatchesSecondary(configuredID any, e Event) bool {
-	// Always return true if the user is not filtering
-	// on a secondary ID.
-	if configuredID == nil {
-		return true
-	}
-
 	// We should return false if the event has no secondary entity.
 	// e.g. A previous disk deletion has completed.
 	if e.SecondaryEntity == nil {


### PR DESCRIPTION
## 📝 Description

This change adds a nil check in the `eventMatchesSecondary(...)` function to handle an edge case where the `SecondaryEntity` field is nil (e.g. completed disk deletion event). 

Related to https://github.com/linode/terraform-provider-linode/issues/1212

## ✔️ How to Test

E2E Testing:

```
make ARGS="-run TestEventPoller_Secondary" fixtures
```

Manual Testing: 

**TODO**