### PR TITLE
fix: Exclude request body in POST and PUT helpers when options are unspecified

### DIFF
--- a/instances.go
+++ b/instances.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/url"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -450,8 +449,10 @@ func (c *Client) MigrateInstance(ctx context.Context, linodeID int, opts Instanc
 // simpleInstanceAction is a helper for Instance actions that take no parameters
 // and return empty responses `{}` unless they return a standard error
 func (c *Client) simpleInstanceAction(ctx context.Context, action string, linodeID int) error {
-	action = url.PathEscape(action)
-	e := fmt.Sprintf("linode/instances/%d/%s", linodeID, action)
-	_, err := coupleAPIErrors(c.R(ctx).Post(e))
+	_, err := doPOSTRequest[any, any](
+		ctx,
+		c,
+		fmt.Sprintf("linode/instances/%d/%s", linodeID, action),
+	)
 	return err
 }

--- a/internal/testutil/mock.go
+++ b/internal/testutil/mock.go
@@ -21,7 +21,7 @@ func MockRequestURL(path string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf("/[a-zA-Z0-9]+/%s", strings.TrimPrefix(path, "/")))
 }
 
-func MockRequestBodyValidate(t *testing.T, expected interface{}, response interface{}) httpmock.Responder {
+func MockRequestBodyValidate(t *testing.T, expected any, response any) httpmock.Responder {
 	t.Helper()
 
 	return func(request *http.Request) (*http.Response, error) {
@@ -48,6 +48,18 @@ func MockRequestBodyValidate(t *testing.T, expected interface{}, response interf
 
 		if !reflect.DeepEqual(expected, resultValue) {
 			t.Fatalf("request body does not match request options: %s", cmp.Diff(expected, resultValue))
+		}
+
+		return httpmock.NewJsonResponse(200, response)
+	}
+}
+
+func MockRequestBodyValidateNoBody(t *testing.T, response any) httpmock.Responder {
+	t.Helper()
+
+	return func(request *http.Request) (*http.Response, error) {
+		if request.Body != nil {
+			t.Fatal("got request body when no request body was expected")
 		}
 
 		return httpmock.NewJsonResponse(200, response)

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -118,16 +118,27 @@ func doPOSTRequest[T, O any](
 	ctx context.Context,
 	client *Client,
 	endpoint string,
-	options O,
+	options ...O,
 ) (*T, error) {
 	var resultType T
 
-	body, err := json.Marshal(options)
-	if err != nil {
-		return nil, err
+	numOpts := len(options)
+
+	if numOpts > 1 {
+		return nil, fmt.Errorf("invalid number of options: %d", len(options))
 	}
 
-	req := client.R(ctx).SetResult(&resultType).SetBody(string(body))
+	req := client.R(ctx).SetResult(&resultType)
+
+	if numOpts > 0 {
+		body, err := json.Marshal(options[0])
+		if err != nil {
+			return nil, err
+		}
+
+		req.SetBody(string(body))
+	}
+
 	r, err := coupleAPIErrors(req.Post(endpoint))
 	if err != nil {
 		return nil, err
@@ -142,16 +153,27 @@ func doPUTRequest[T, O any](
 	ctx context.Context,
 	client *Client,
 	endpoint string,
-	options O,
+	options ...O,
 ) (*T, error) {
 	var resultType T
 
-	body, err := json.Marshal(options)
-	if err != nil {
-		return nil, err
+	numOpts := len(options)
+
+	if numOpts > 1 {
+		return nil, fmt.Errorf("invalid number of options: %d", len(options))
 	}
 
-	req := client.R(ctx).SetResult(&resultType).SetBody(string(body))
+	req := client.R(ctx).SetResult(&resultType)
+
+	if numOpts > 0 {
+		body, err := json.Marshal(options[0])
+		if err != nil {
+			return nil, err
+		}
+
+		req.SetBody(string(body))
+	}
+
 	r, err := coupleAPIErrors(req.Put(endpoint))
 	if err != nil {
 		return nil, err

--- a/request_helpers_test.go
+++ b/request_helpers_test.go
@@ -75,6 +75,29 @@ func TestRequestHelpers_post(t *testing.T) {
 	}
 }
 
+func TestRequestHelpers_postNoOptions(t *testing.T) {
+	client := testutil.CreateMockClient(t, NewClient)
+
+	httpmock.RegisterRegexpResponder(
+		"POST",
+		testutil.MockRequestURL("/foo/bar"),
+		testutil.MockRequestBodyValidateNoBody(t, testResponse),
+	)
+
+	result, err := doPOSTRequest[testResultType, any](
+		context.Background(),
+		client,
+		"/foo/bar",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(*result, testResponse) {
+		t.Fatalf("actual response does not equal desired response: %s", cmp.Diff(result, testResponse))
+	}
+}
+
 func TestRequestHelpers_put(t *testing.T) {
 	client := testutil.CreateMockClient(t, NewClient)
 
@@ -86,6 +109,29 @@ func TestRequestHelpers_put(t *testing.T) {
 		client,
 		"/foo/bar",
 		testResponse,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(*result, testResponse) {
+		t.Fatalf("actual response does not equal desired response: %s", cmp.Diff(result, testResponse))
+	}
+}
+
+func TestRequestHelpers_putNoOptions(t *testing.T) {
+	client := testutil.CreateMockClient(t, NewClient)
+
+	httpmock.RegisterRegexpResponder(
+		"PUT",
+		testutil.MockRequestURL("/foo/bar"),
+		testutil.MockRequestBodyValidateNoBody(t, testResponse),
+	)
+
+	result, err := doPUTRequest[testResultType, any](
+		context.Background(),
+		client,
+		"/foo/bar",
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## 📝 Description

This change fixes a small issue that made the POST and PUT request helpers encode empty bodies as `null`, which is rejected by the API. This works by making the options argument variadic and only calling `r.SetBody(...)` if the argument is specified.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make testunit
```

### Integration Testing

NOTE: This test calls out to the `client.ShutdownInstance(...)` function, which consumes this helper and does not accept a request body.

```
make ARGS="-run TestEventPoller_InstancePower" fixtures
```

### Manual Testing

1. In a linodego sandbox environment (e.g. dx-devenv), run the following:

```go
package main

import (
	"context"
	"log"
	"os"

	"github.com/linode/linodego"
)

func main() {
	ctx := context.Background()

	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))

	inst, err := client.CreateInstance(ctx, linodego.InstanceCreateOptions{
		Region:   "us-mia",
		Type:     "g6-nanode-1",
		Label:    "test-instance",
		Image:    "linode/ubuntu22.04",
		RootPass: "v3rys3cur3t3stp4ssw0rd!!!!",
	})
	if err != nil {
		log.Fatal(err)
	}

	inst, err = client.WaitForInstanceStatus(ctx, inst.ID, linodego.InstanceRunning, 180)
	if err != nil {
		log.Fatal(err)
	}

	// Attempt to shutdown the instance
	// This calls the request helper with no options internally
	if err := client.ShutdownInstance(ctx, inst.ID); err != nil {
		log.Fatal(err)
	}
}
```
2. Ensure no errors are raised.