### PR TITLE
Remove `ReadOnly` from disk structs

### DIFF
--- a/instance_disks.go
+++ b/instance_disks.go
@@ -61,15 +61,13 @@ type InstanceDiskCreateOptions struct {
 	Filesystem      string            `json:"filesystem,omitempty"`
 	AuthorizedKeys  []string          `json:"authorized_keys,omitempty"`
 	AuthorizedUsers []string          `json:"authorized_users,omitempty"`
-	ReadOnly        bool              `json:"read_only,omitempty"`
 	StackscriptID   int               `json:"stackscript_id,omitempty"`
 	StackscriptData map[string]string `json:"stackscript_data,omitempty"`
 }
 
 // InstanceDiskUpdateOptions are InstanceDisk settings that can be used in updates
 type InstanceDiskUpdateOptions struct {
-	Label    string `json:"label"`
-	ReadOnly bool   `json:"read_only"`
+	Label string `json:"label"`
 }
 
 // endpoint gets the endpoint URL for InstanceDisks of a given Instance


### PR DESCRIPTION
## 📝 Description

This is no longer a valid attribute of the structs.

## ✔️ How to Test

### Automated Testing
```
make ARGS="-run TestInstance_Disk" fixtures
```

### Manual Testing
```go
package main

import (
	"context"
	"os"

	"github.com/linode/linodego"
)

func main() {
	ctx := context.Background()

	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))

	linodeClient.CreateInstanceDisk(
		context.Background(),
		123456, // your Linode ID
		linodego.InstanceDiskCreateOptions{
			Label: "somedisk",
			Size: 500,
		},
	)
}
```