### PR TITLE
feature: Add helper functions for working with errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -149,3 +149,34 @@ func NewError(err any) *Error {
 		return &Error{Code: ErrorUnsupported, Message: fmt.Sprintf("Unsupported type to linodego.NewError: %s", reflect.TypeOf(e))}
 	}
 }
+
+// IsNotFound indicates if err indicates a 404 Not Found error from the Linode API.
+func IsNotFound(err error) bool {
+	return ErrHasStatus(err, http.StatusNotFound)
+}
+
+// ErrHasStatus checks if err is an error from the Linode API, and whether it contains the given HTTP status code.
+// More than one status code may be given.
+// If len(code) == 0, err is nil or is not a [Error], ErrHasStatus will return false.
+func ErrHasStatus(err error, code ...int) bool {
+	if err == nil {
+		return false
+	}
+
+	// Short-circuit if the caller did not provide any status codes.
+	if len(code) == 0 {
+		return false
+	}
+
+	var e *Error
+	if !errors.As(err, &e) {
+		return false
+	}
+	ec := e.StatusCode()
+	for _, c := range code {
+		if ec == c {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 📝 Description

This pull request adds two functions to the public API for this package:

* `ErrHasStatus(error, ...int)` attempts to unwrap the provided error to an `*Error` and see if its status code matches any of the status codes provided.
* `IsNotFound` is a thin wrapper over `ErrHasStatus(err, http.StatusNotFound)` for a subjectively-common use case.

Implements #460

## ✔️ How to Test

```
make testunit
```