### PR TITLE
fix: [BREAKING] Treat ip_ranges as a pointer in config interface update options

### DIFF
--- a/instance_config_interfaces.go
+++ b/instance_config_interfaces.go
@@ -41,6 +41,27 @@ type InstanceConfigInterfaceUpdateOptions struct {
 	IPRanges []string `json:"ip_ranges,omitempty"`
 }
 
+// MarshalJSON implements the JSON marshal interface method for the interface update options.
+// This is a workaround for #462, allowing users to explicitly clear the ip_ranges field.
+func (opts InstanceConfigInterfaceUpdateOptions) MarshalJSON() ([]byte, error) {
+	type Mask InstanceConfigInterfaceUpdateOptions
+
+	// If IP ranges is nil, return the default
+	if opts.IPRanges == nil {
+		return json.Marshal(opts)
+	}
+
+	maskedOpts := &struct {
+		Mask
+		IPRanges []string `json:"ip_ranges"`
+	}{
+		Mask:     (Mask)(opts),
+		IPRanges: opts.IPRanges,
+	}
+
+	return json.Marshal(maskedOpts)
+}
+
 type InstanceConfigInterfacesReorderOptions struct {
 	IDs []int `json:"ids"`
 }

--- a/test/integration/fixtures/TestInstance_ConfigInterface_Update.yaml
+++ b/test/integration/fixtures/TestInstance_ConfigInterface_Update.yaml
@@ -228,7 +228,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:14 GMT
+      - Mon, 04 Mar 2024 20:22:16 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -254,7 +254,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"us-iad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-73be3u8uqn82","booted":false}'
+    body: '{"region":"us-iad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-o27gv95tu35t","booted":false}'
     form: {}
     headers:
       Accept:
@@ -266,15 +266,15 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 54933555, "label": "go-test-ins-wo-disk-73be3u8uqn82", "group":
+    body: '{"id": 55633797, "label": "go-test-ins-wo-disk-o27gv95tu35t", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["139.144.202.63"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.233.196.252"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-iad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
       false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
       null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
-      "069a01c443a4c034edaff10aeecdf8fb95ec66ba", "has_user_data": false}'
+      "bf7a891314cca054680070d406f60283ad2477aa", "has_user_data": false}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -291,13 +291,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "737"
+      - "738"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:15 GMT
+      - Mon, 04 Mar 2024 20:22:16 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -321,7 +321,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-9iut07dbo832","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-tes2d3k1745m","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -330,10 +330,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/54933555/configs
+    url: https://api.linode.com/v4beta/linode/instances/55633797/configs
     method: POST
   response:
-    body: '{"id": 58037972, "label": "go-test-conf-9iut07dbo832", "helpers": {"updatedb_disabled":
+    body: '{"id": 58758984, "label": "go-test-conf-tes2d3k1745m", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -362,7 +362,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:15 GMT
+      - Mon, 04 Mar 2024 20:22:16 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -386,7 +386,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1707934155274221000","region":"us-iad","subnets":[{"label":"linodego-vpc-test-1707934155274261000","ipv4":"192.168.0.0/25"}]}'
+    body: '{"label":"go-test-vpc-1709583736746076000","region":"us-iad","subnets":[{"label":"linodego-vpc-test-1709583736746145000","ipv4":"192.168.0.0/25"}]}'
     form: {}
     headers:
       Accept:
@@ -398,8 +398,8 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 22685, "label": "go-test-vpc-1707934155274221000", "description":
-      "", "region": "us-iad", "subnets": [{"id": 23564, "label": "linodego-vpc-test-1707934155274261000",
+    body: '{"id": 26498, "label": "go-test-vpc-1709583736746076000", "description":
+      "", "region": "us-iad", "subnets": [{"id": 26749, "label": "linodego-vpc-test-1709583736746145000",
       "ipv4": "192.168.0.0/25", "ipv6": null, "linodes": [], "created": "2018-01-02T03:04:05",
       "updated": "2018-01-02T03:04:05"}], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}'
@@ -425,7 +425,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:15 GMT
+      - Mon, 04 Mar 2024 20:22:17 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -449,7 +449,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"purpose":"vpc","subnet_id":23564}'
+    body: '{"purpose":"vpc","subnet_id":26749,"ip_ranges":["192.168.0.5/32"]}'
     form: {}
     headers:
       Accept:
@@ -458,12 +458,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/54933555/configs/58037972/interfaces
+    url: https://api.linode.com/v4beta/linode/instances/55633797/configs/58758984/interfaces
     method: POST
   response:
-    body: '{"id": 1041200, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 22685, "subnet_id": 23564, "ipv4": {"vpc": "192.168.0.2",
-      "nat_1_1": null}, "ipv6": null, "ip_ranges": []}'
+    body: '{"id": 1149865, "purpose": "vpc", "primary": false, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 26498, "subnet_id": 26749, "ipv4": {"vpc": "192.168.0.2",
+      "nat_1_1": null}, "ipv6": null, "ip_ranges": ["192.168.0.5/32"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -480,13 +480,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "222"
+      - "238"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:15 GMT
+      - Mon, 04 Mar 2024 20:22:17 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -510,7 +510,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"primary":true,"ipv4":{"vpc":"192.168.0.2"}}'
+    body: '{"primary":true,"ipv4":{"vpc":"192.168.0.2"},"ip_ranges":["192.168.0.5/32"]}'
     form: {}
     headers:
       Accept:
@@ -519,12 +519,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/54933555/configs/58037972/interfaces/1041200
+    url: https://api.linode.com/v4beta/linode/instances/55633797/configs/58758984/interfaces/1149865
     method: PUT
   response:
-    body: '{"id": 1041200, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 22685, "subnet_id": 23564, "ipv4": {"vpc": "192.168.0.2",
-      "nat_1_1": null}, "ipv6": null, "ip_ranges": []}'
+    body: '{"id": 1149865, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 26498, "subnet_id": 26749, "ipv4": {"vpc": "192.168.0.2",
+      "nat_1_1": null}, "ipv6": null, "ip_ranges": ["192.168.0.5/32"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -541,13 +541,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "221"
+      - "237"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:15 GMT
+      - Mon, 04 Mar 2024 20:22:17 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -571,7 +571,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"primary":true,"ipv4":{"vpc":"192.168.0.10","nat_1_1":"any"}}'
+    body: '{"primary":true,"ipv4":{"vpc":"192.168.0.10","nat_1_1":"any"},"ip_ranges":[]}'
     form: {}
     headers:
       Accept:
@@ -580,12 +580,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/54933555/configs/58037972/interfaces/1041200
+    url: https://api.linode.com/v4beta/linode/instances/55633797/configs/58758984/interfaces/1149865
     method: PUT
   response:
-    body: '{"id": 1041200, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
-      null, "label": null, "vpc_id": 22685, "subnet_id": 23564, "ipv4": {"vpc": "192.168.0.10",
-      "nat_1_1": "139.144.202.63"}, "ipv6": null, "ip_ranges": []}'
+    body: '{"id": 1149865, "purpose": "vpc", "primary": true, "active": false, "ipam_address":
+      null, "label": null, "vpc_id": 26498, "subnet_id": 26749, "ipv4": {"vpc": "192.168.0.10",
+      "nat_1_1": "172.233.196.252"}, "ipv6": null, "ip_ranges": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -602,13 +602,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "234"
+      - "235"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:16 GMT
+      - Mon, 04 Mar 2024 20:22:17 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -641,7 +641,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/54933555
+    url: https://api.linode.com/v4beta/linode/instances/55633797
     method: DELETE
   response:
     body: '{}'
@@ -667,7 +667,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:16 GMT
+      - Mon, 04 Mar 2024 20:22:18 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -700,7 +700,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/22685
+    url: https://api.linode.com/v4beta/vpcs/26498
     method: DELETE
   response:
     body: '{}'
@@ -726,7 +726,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 14 Feb 2024 18:09:17 GMT
+      - Mon, 04 Mar 2024 20:22:18 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/instance_config_test.go
+++ b/test/integration/instance_config_test.go
@@ -349,6 +349,7 @@ func TestInstance_ConfigInterface_Update(t *testing.T) {
 		InstanceConfigInterfaceCreateOptions{
 			Purpose:  InterfacePurposeVPC,
 			SubnetID: &vpcSubnet.ID,
+			IPRanges: []string{"192.168.0.5/32"},
 		},
 	)
 	if err != nil {
@@ -371,11 +372,17 @@ func TestInstance_ConfigInterface_Update(t *testing.T) {
 	if !(updatedIntfc.Primary == updateOpts.Primary) {
 		t.Errorf("updating interface %v didn't succeed", intfc.ID)
 	}
+
+	if updatedIntfc.IPRanges[0] != "192.168.0.5/32" {
+		t.Errorf("unexpected value for IPRanges: %s", updatedIntfc.IPRanges[0])
+	}
+
 	NAT1To1Any := "any"
 	updateOpts.IPv4 = &VPCIPv4{
 		VPC:     "192.168.0.10",
 		NAT1To1: &NAT1To1Any,
 	}
+	updateOpts.IPRanges = make([]string, 0)
 
 	updatedIntfc, err = client.UpdateInstanceConfigInterface(
 		context.Background(),
@@ -384,7 +391,6 @@ func TestInstance_ConfigInterface_Update(t *testing.T) {
 		intfc.ID,
 		updateOpts,
 	)
-
 	if err != nil {
 		t.Errorf("an error occurs when updating an interface in config %v", config.ID)
 	}
@@ -392,6 +398,10 @@ func TestInstance_ConfigInterface_Update(t *testing.T) {
 	if !(updatedIntfc.Primary == updateOpts.Primary &&
 		updateOpts.IPv4.VPC == updatedIntfc.IPv4.VPC) {
 		t.Errorf("updating interface %v didn't succeed", intfc.ID)
+	}
+
+	if len(updatedIntfc.IPRanges) > 0 {
+		t.Errorf("expected IPRanges to be empty, got %d entries", len(updatedIntfc.IPRanges))
 	}
 }
 

--- a/test/integration/instance_config_test.go
+++ b/test/integration/instance_config_test.go
@@ -382,7 +382,8 @@ func TestInstance_ConfigInterface_Update(t *testing.T) {
 		VPC:     "192.168.0.10",
 		NAT1To1: &NAT1To1Any,
 	}
-	updateOpts.IPRanges = make([]string, 0)
+	newIPRanges := make([]string, 0)
+	updateOpts.IPRanges = &newIPRanges
 
 	updatedIntfc, err = client.UpdateInstanceConfigInterface(
 		context.Background(),


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that prevented users from updating the interface `ip_ranges` field with an explicitly empty list. This works by treating `ip_ranges` as a pointer so it will be only omitted if the pointer is nil, as opposed to if the slice is nil OR the slice is empty. 

Resolves #462 

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make ARGS="-run TestInstance_ConfigInterface_Update" fixtures
```

### Manual Testing

1. In a linodego sandbox environment (e.g. dx-devenv), run the following:

```go
package main

import (
	"context"
	"fmt"
	"github.com/linode/linodego"
	"log"
	"os"
)

func main() {
	ctx := context.Background()

	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))

	vpc, err := client.CreateVPC(ctx, linodego.VPCCreateOptions{
		Label:  "test-vpc",
		Region: "us-mia",
		Subnets: []linodego.VPCSubnetCreateOptions{
			{
				Label: "test-subnet",
				IPv4:  "10.0.0.0/24",
			},
		},
	})
	if err != nil {
		log.Fatal(err)
	}

	defer func() {
		client.DeleteVPC(ctx, vpc.ID)
	}()

	inst, err := client.CreateInstance(
		ctx,
		linodego.InstanceCreateOptions{
			Region: "us-mia",
			Label:  "test-inst",
			Type:   "g6-nanode-1",
		},
	)
	if err != nil {
		log.Fatal(err)
	}
	defer func() {
		client.DeleteInstance(ctx, inst.ID)
	}()

	cfg, err := client.CreateInstanceConfig(
		ctx,
		inst.ID,
		linodego.InstanceConfigCreateOptions{
			Label:   "test-config",
			Devices: linodego.InstanceConfigDeviceMap{},
			Interfaces: []linodego.InstanceConfigInterfaceCreateOptions{
				{
					Purpose:  linodego.InterfacePurposeVPC,
					SubnetID: &vpc.Subnets[0].ID,
					IPRanges: []string{"10.0.0.5/32"},
				},
			},
		},
	)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println("ip_ranges before update:", cfg.Interfaces[0].IPRanges)

	updatedIPRanges := make([]string, 0)

	iface, err := client.UpdateInstanceConfigInterface(
		ctx,
		inst.ID,
		cfg.ID,
		cfg.Interfaces[0].ID,
		linodego.InstanceConfigInterfaceUpdateOptions{
			IPRanges: &updatedIPRanges,
		},
	)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println("ip_ranges after update: ", iface.IPRanges)
}
```

2. Ensure no errors are raised and the output looks similar to the following:

```
ip_ranges before update: [10.0.0.5/32]
ip_ranges after update:  []
```
