### PR TITLE
fix: [BREAKING] Support ID field for nodes in NodeBalancerConfigRebuildOptions

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,8 +1,10 @@
 cloud.google.com/go v0.81.0 h1:at8Tk2zUz63cLPR0JPWm5vp77pEZmzxEQBEfRKn1VV8=
 cloud.google.com/go/bigquery v1.8.0 h1:PQcPefKFdaIzjQFbiyOgAqyx8q5djaE7x9Sqe712DPA=
+cloud.google.com/go/compute v1.20.1 h1:6aKEtlUiwEpJzM001l0yFkpXmUVXaN8W+fbkb2AZNbg=
 cloud.google.com/go/compute v1.20.1/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
 cloud.google.com/go/compute/metadata v0.2.0 h1:nBbNSZyDpkNlo3DepaaLKVuO7ClyifSAmNloSCZrHnQ=
 cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
+cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/datastore v1.1.0 h1:/May9ojXjRkPBNVrq+oWLqmWCkr4OU5uRY29bu0mRyQ=
 cloud.google.com/go/pubsub v1.3.1 h1:ukjixP1wl0LpnZ6LWtZJ0mX5tBmjp1f8Sqer8Z2OMUU=
@@ -117,6 +119,7 @@ github.com/linode/linodego v0.20.1/go.mod h1:XOWXRHjqeU2uPS84tKLgfWIfTlv3TYzCS0i
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72ysdyKe7Dyogw70=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
@@ -174,6 +177,7 @@ golang.org/x/crypto v0.15.0/go.mod h1:4ChreQoLWfG3xLDer1WdlH5NdlQ3+mwnQq1YTKY+72
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
+golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=
@@ -197,8 +201,6 @@ golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/nodebalancer_configs.go
+++ b/nodebalancer_configs.go
@@ -120,22 +120,30 @@ type NodeBalancerConfigCreateOptions struct {
 
 // NodeBalancerConfigRebuildOptions used by RebuildNodeBalancerConfig
 type NodeBalancerConfigRebuildOptions struct {
-	Port          int                             `json:"port"`
-	Protocol      ConfigProtocol                  `json:"protocol,omitempty"`
-	ProxyProtocol ConfigProxyProtocol             `json:"proxy_protocol,omitempty"`
-	Algorithm     ConfigAlgorithm                 `json:"algorithm,omitempty"`
-	Stickiness    ConfigStickiness                `json:"stickiness,omitempty"`
-	Check         ConfigCheck                     `json:"check,omitempty"`
-	CheckInterval int                             `json:"check_interval,omitempty"`
-	CheckAttempts int                             `json:"check_attempts,omitempty"`
-	CheckPath     string                          `json:"check_path,omitempty"`
-	CheckBody     string                          `json:"check_body,omitempty"`
-	CheckPassive  *bool                           `json:"check_passive,omitempty"`
-	CheckTimeout  int                             `json:"check_timeout,omitempty"`
-	CipherSuite   ConfigCipher                    `json:"cipher_suite,omitempty"`
-	SSLCert       string                          `json:"ssl_cert,omitempty"`
-	SSLKey        string                          `json:"ssl_key,omitempty"`
-	Nodes         []NodeBalancerNodeCreateOptions `json:"nodes"`
+	Port          int                                    `json:"port"`
+	Protocol      ConfigProtocol                         `json:"protocol,omitempty"`
+	ProxyProtocol ConfigProxyProtocol                    `json:"proxy_protocol,omitempty"`
+	Algorithm     ConfigAlgorithm                        `json:"algorithm,omitempty"`
+	Stickiness    ConfigStickiness                       `json:"stickiness,omitempty"`
+	Check         ConfigCheck                            `json:"check,omitempty"`
+	CheckInterval int                                    `json:"check_interval,omitempty"`
+	CheckAttempts int                                    `json:"check_attempts,omitempty"`
+	CheckPath     string                                 `json:"check_path,omitempty"`
+	CheckBody     string                                 `json:"check_body,omitempty"`
+	CheckPassive  *bool                                  `json:"check_passive,omitempty"`
+	CheckTimeout  int                                    `json:"check_timeout,omitempty"`
+	CipherSuite   ConfigCipher                           `json:"cipher_suite,omitempty"`
+	SSLCert       string                                 `json:"ssl_cert,omitempty"`
+	SSLKey        string                                 `json:"ssl_key,omitempty"`
+	Nodes         []NodeBalancerConfigRebuildNodeOptions `json:"nodes"`
+}
+
+// NodeBalancerConfigRebuildNodeOptions represents a node defined when rebuilding a
+// NodeBalancer config.
+type NodeBalancerConfigRebuildNodeOptions struct {
+	NodeBalancerNodeCreateOptions
+
+	ID int `json:"id,omitempty"`
 }
 
 // NodeBalancerConfigUpdateOptions are permitted by UpdateNodeBalancerConfig
@@ -201,7 +209,7 @@ func (i NodeBalancerConfig) GetRebuildOptions() NodeBalancerConfigRebuildOptions
 		CipherSuite:   i.CipherSuite,
 		SSLCert:       i.SSLCert,
 		SSLKey:        i.SSLKey,
-		Nodes:         make([]NodeBalancerNodeCreateOptions, 0),
+		Nodes:         make([]NodeBalancerConfigRebuildNodeOptions, 0),
 	}
 }
 

--- a/test/integration/fixtures/TestNodeBalancer_Rebuild.yaml
+++ b/test/integration/fixtures/TestNodeBalancer_Rebuild.yaml
@@ -14,13 +14,13 @@ interactions:
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 228215, "label": "linodego-fw-test", "created": "2018-01-02T03:04:05",
+    body: '{"id": 380701, "label": "linodego-fw-test", "created": "2018-01-02T03:04:05",
       "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
       [{"action": "ACCEPT", "label": "go-fwrule-test", "ports": "22", "protocol":
       "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["1234::5678/0"]}}], "inbound_policy":
       "ACCEPT", "outbound": [{"action": "ACCEPT", "label": "go-fwrule-test", "ports":
       "22", "protocol": "TCP", "addresses": {"ipv4": ["0.0.0.0/0"], "ipv6": ["1234::5678/0"]}}],
-      "outbound_policy": "ACCEPT"}, "tags": ["testing"]}'
+      "outbound_policy": "ACCEPT"}, "tags": ["testing"], "entities": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -33,15 +33,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "526"
+      - "542"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:30 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -56,7 +60,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -76,176 +80,216 @@ interactions:
     method: GET
   response:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, IN", "country": "in", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes",
+      "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "172.105.34.5, 172.105.35.5, 172.105.36.5,
+      172.105.37.5, 172.105.38.5, 172.105.39.5, 172.105.40.5, 172.105.41.5, 172.105.42.5,
+      172.105.43.5", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "ca-central", "label": "Toronto, CA", "country": "ca", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud
       Firewall", "Vlans", "Block Storage Migrations", "Managed Databases"], "status":
-      "ok", "resolvers": {"ipv4": "172.105.34.5, 172.105.35.5, 172.105.36.5, 172.105.37.5,
-      172.105.38.5, 172.105.39.5, 172.105.40.5, 172.105.41.5, 172.105.42.5, 172.105.43.5",
+      "ok", "resolvers": {"ipv4": "172.105.0.5, 172.105.3.5, 172.105.4.5, 172.105.5.5,
+      172.105.6.5, 172.105.7.5, 172.105.8.5, 172.105.9.5, 172.105.10.5, 172.105.11.5",
       "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "ca-central", "label": "Toronto, CA",
-      "country": "ca", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed
-      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5, 172.105.3.5,
-      172.105.4.5, 172.105.5.5, 172.105.6.5, 172.105.7.5, 172.105.8.5, 172.105.9.5,
-      172.105.10.5, 172.105.11.5", "ipv6": "1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "ap-southeast",
+      "label": "Sydney, AU", "country": "au", "capabilities": ["Linodes", "Backups",
+      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      Storage Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4":
+      "172.105.166.5, 172.105.169.5, 172.105.168.5, 172.105.172.5, 172.105.162.5,
+      172.105.170.5, 172.105.167.5, 172.105.171.5, 172.105.181.5, 172.105.161.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "ap-southeast",
-      "label": "Sydney, AU", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,
-      172.105.169.5, 172.105.168.5, 172.105.172.5, 172.105.162.5, 172.105.170.5, 172.105.167.5,
-      172.105.171.5, 172.105.181.5, 172.105.161.5", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-iad", "label":
+      "Washington, DC", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "139.144.192.62, 139.144.192.60, 139.144.192.61, 139.144.192.53, 139.144.192.54,
+      139.144.192.67, 139.144.192.69, 139.144.192.66, 139.144.192.52, 139.144.192.68",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-iad", "label": "Washington, DC", "country": "us", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Managed Databases", "Metadata", "Premium Plans"],
-      "status": "ok", "resolvers": {"ipv4": "139.144.192.62,   139.144.192.60,   139.144.192.61,   139.144.192.53,   139.144.192.54,   139.144.192.67,   139.144.192.69,    139.144.192.66,   139.144.192.52,   139.144.192.68",
-      "ipv6": "1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678"}},
-      {"id": "us-ord", "label": "Chicago, IL", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Managed Databases", "Premium Plans"], "status": "ok", "resolvers":
-      {"ipv4": "172.232.0.17,   172.232.0.16,   172.232.0.21,   172.232.0.13,   172.232.0.22,   172.232.0.9,   172.232.0.19,   172.232.0.20,   172.232.0.15,   172.232.0.18",
-      "ipv6": "1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678"}},
-      {"id": "fr-par", "label": "Paris, FR", "country": "fr", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok",
-      "resolvers": {"ipv4": "172.232.32.21,  172.232.32.23,  172.232.32.17,  172.232.32.18,  172.232.32.16,  172.232.32.22,  172.232.32.20,  172.232.32.14,  172.232.32.11,  172.232.32.12",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "us-sea", "label": "Seattle, WA", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.160.19,
-      172.232.160.21, 172.232.160.17, 172.232.160.15, 172.232.160.18, 172.232.160.8,
-      172.232.160.12, 172.232.160.11, 172.232.160.14, 172.232.160.16", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-ord", "label":
+      "Chicago, IL", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.0.17, 172.232.0.16, 172.232.0.21, 172.232.0.13, 172.232.0.22,
+      172.232.0.9, 172.232.0.19, 172.232.0.20, 172.232.0.15, 172.232.0.18", "ipv6":
+      "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "br-gru", "label": "Sao Paulo, BR", "country": "br", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      1234::5678"}, "site_type": "core"}, {"id": "fr-par", "label":
+      "Paris, FR", "country": "fr", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.32.21, 172.232.32.23, 172.232.32.17, 172.232.32.18, 172.232.32.16,
+      172.232.32.22, 172.232.32.20, 172.232.32.14, 172.232.32.11, 172.232.32.12",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-sea", "label":
+      "Seattle, WA", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.232.160.19, 172.232.160.21, 172.232.160.17, 172.232.160.15, 172.232.160.18,
+      172.232.160.8, 172.232.160.12, 172.232.160.11, 172.232.160.14, 172.232.160.16",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "br-gru", "label":
+      "Sao Paulo, BR", "country": "br", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
       "172.233.0.4, 172.233.0.9, 172.233.0.7, 172.233.0.12, 172.233.0.5, 172.233.0.13,
       172.233.0.10, 172.233.0.6, 172.233.0.8, 172.233.0.11", "ipv6": "1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "nl-ams", "label": "Amsterdam, NL", "country": "nl", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
-      "172.233.33.36, 172.233.33.38, 172.233.33.35, 172.233.33.39, 172.233.33.34,
-      172.233.33.33, 172.233.33.31, 172.233.33.30, 172.233.33.37, 172.233.33.32",
+      1234::5678, 1234::5678, 1234::5678"},
+      "site_type": "core"}, {"id": "nl-ams", "label": "Amsterdam, NL", "country":
+      "nl", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Block Storage",
+      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata",
+      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.233.33.36, 172.233.33.38,
+      172.233.33.35, 172.233.33.39, 172.233.33.34, 172.233.33.33, 172.233.33.31, 172.233.33.30,
+      172.233.33.37, 172.233.33.32", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "se-sto", "label": "Stockholm, SE", "country": "se", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok",
+      "resolvers": {"ipv4": "172.232.128.24, 172.232.128.26, 172.232.128.20, 172.232.128.22,
+      172.232.128.25, 172.232.128.19, 172.232.128.23, 172.232.128.18, 172.232.128.21,
+      172.232.128.27", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "es-mad", "label": "Madrid, ES", "country": "es", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok",
+      "resolvers": {"ipv4": "172.233.111.6, 172.233.111.17, 172.233.111.21, 172.233.111.25,
+      172.233.111.19, 172.233.111.12, 172.233.111.26, 172.233.111.16, 172.233.111.18,
+      172.233.111.9", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "in-maa", "label": "Chennai, IN", "country": "in", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok",
+      "resolvers": {"ipv4": "172.232.96.17, 172.232.96.26, 172.232.96.19, 172.232.96.20,
+      172.232.96.25, 172.232.96.21, 172.232.96.18, 172.232.96.22, 172.232.96.23, 172.232.96.24",
       "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "se-sto", "label": "Stockholm, SE",
-      "country": "se", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Premium Plans"],
-      "status": "ok", "resolvers": {"ipv4": "172.232.128.24, 172.232.128.26, 172.232.128.20,
-      172.232.128.22, 172.232.128.25, 172.232.128.19, 172.232.128.23, 172.232.128.18,
-      172.232.128.21, 172.232.128.27", "ipv6": "1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "in-maa",
-      "label": "Chennai, IN", "country": "in", "capabilities": ["Linodes", "NodeBalancers",
+      1234::5678"}, "site_type": "core"}, {"id": "jp-osa", "label":
+      "Osaka, JP", "country": "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
-      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.96.17,  172.232.96.26,  172.232.96.19,  172.232.96.20,  172.232.96.25,  172.232.96.21,  172.232.96.18,  172.232.96.22,  172.232.96.23,  172.232.96.24",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "jp-osa", "label": "Osaka, JP", "country": "jp", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.233.64.44,
-      172.233.64.43, 172.233.64.37, 172.233.64.40, 172.233.64.46, 172.233.64.41, 172.233.64.39,
-      172.233.64.42, 172.233.64.45, 172.233.64.38", "ipv6": "1234::5678,
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.233.64.44, 172.233.64.43, 172.233.64.37, 172.233.64.40, 172.233.64.46,
+      172.233.64.41, 172.233.64.39, 172.233.64.42, 172.233.64.45, 172.233.64.38",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "it-mil", "label": "Milan, IT", "country": "it", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.192.19,
-      172.232.192.18, 172.232.192.16, 172.232.192.20, 172.232.192.24, 172.232.192.21,
-      172.232.192.22, 172.232.192.17, 172.232.192.15, 172.232.192.23", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "it-mil", "label":
+      "Milan, IT", "country": "it", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.232.192.19, 172.232.192.18, 172.232.192.16, 172.232.192.20, 172.232.192.24,
+      172.232.192.21, 172.232.192.22, 172.232.192.17, 172.232.192.15, 172.232.192.23",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-mia", "label": "Miami, FL", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.233.160.34,
-      172.233.160.27, 172.233.160.30, 172.233.160.29, 172.233.160.32, 172.233.160.28,
-      172.233.160.33, 172.233.160.26, 172.233.160.25, 172.233.160.31", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-mia", "label":
+      "Miami, FL", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.233.160.34, 172.233.160.27, 172.233.160.30, 172.233.160.29, 172.233.160.32,
+      172.233.160.28, 172.233.160.33, 172.233.160.26, 172.233.160.25, 172.233.160.31",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "id-cgk", "label": "Jakarta, ID", "country": "id", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.224.23,
-      172.232.224.32, 172.232.224.26, 172.232.224.27, 172.232.224.21, 172.232.224.24,
-      172.232.224.22, 172.232.224.20, 172.232.224.31, 172.232.224.28", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "id-cgk", "label":
+      "Jakarta, ID", "country": "id", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.232.224.23, 172.232.224.32, 172.232.224.26, 172.232.224.27, 172.232.224.21,
+      172.232.224.24, 172.232.224.22, 172.232.224.20, 172.232.224.31, 172.232.224.28",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-lax", "label": "Los Angeles, CA", "country": "us", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      1234::5678"}, "site_type": "core"}, {"id": "us-lax", "label":
+      "Los Angeles, CA", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
       "172.233.128.45, 172.233.128.38, 172.233.128.53, 172.233.128.37, 172.233.128.34,
       172.233.128.36, 172.233.128.33, 172.233.128.39, 172.233.128.43, 172.233.128.44",
       "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "us-central", "label": "Dallas, TX",
-      "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Kubernetes", "Cloud Firewall", "Block Storage Migrations", "Managed Databases"],
-      "status": "ok", "resolvers": {"ipv4": "72.14.179.5, 72.14.188.5, 173.255.199.5,
-      66.228.53.5, 96.126.122.5, 96.126.124.5, 96.126.127.5, 198.58.107.5, 198.58.111.5,
-      23.239.24.5", "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-west", "label": "Fremont, CA", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage
-      Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,
-      173.230.147.5, 173.230.155.5, 173.255.212.5, 173.255.219.5, 173.255.241.5, 173.255.243.5,
-      173.255.244.5, 74.207.241.5, 74.207.242.5", "ipv6": "1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "us-southeast", "label": "Atlanta, GA",
-      "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      1234::5678"}, "site_type": "core"}, {"id": "us-central",
+      "label": "Dallas, TX", "country": "us", "capabilities": ["Linodes", "Backups",
+      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
       Storage Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4":
-      "74.207.231.5, 173.230.128.5, 173.230.129.5, 173.230.136.5, 173.230.140.5, 66.228.59.5,
-      66.228.62.5, 50.116.35.5, 50.116.41.5, 23.239.18.5", "ipv6": "1234::5678,
+      "72.14.179.5, 72.14.188.5, 173.255.199.5, 66.228.53.5, 96.126.122.5, 96.126.124.5,
+      96.126.127.5, 198.58.107.5, 198.58.111.5, 23.239.24.5", "ipv6": "1234::5678,
       1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}}, {"id": "us-east", "label": "Newark,
-      NJ", "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Bare Metal",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
+      1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"}, {"id": "us-west",
+      "label": "Fremont, CA", "country": "us", "capabilities": ["Linodes", "Backups",
+      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      Storage Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4":
+      "173.230.145.5, 173.230.147.5, 173.230.155.5, 173.255.212.5, 173.255.219.5,
+      173.255.241.5, 173.255.243.5, 173.255.244.5, 74.207.241.5, 74.207.242.5", "ipv6":
+      "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"},
+      {"id": "us-southeast", "label": "Atlanta, GA", "country": "us", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "GPU
+      Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5, 173.230.128.5,
+      173.230.129.5, 173.230.136.5, 173.230.140.5, 66.228.59.5, 66.228.62.5, 50.116.35.5,
+      50.116.41.5, 23.239.18.5", "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Block
+      Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans",
+      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
       {"ipv4": "66.228.42.5, 96.126.106.5, 50.116.53.5, 50.116.58.5, 50.116.61.5,
       50.116.62.5, 66.175.211.5, 97.107.133.4, 207.192.69.4, 207.192.69.5", "ipv6":
       "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678"}}, {"id": "eu-west",
-      "label": "London, UK", "country": "gb", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,  176.58.107.5,  176.58.116.5,  176.58.121.5,  151.236.220.5,  212.71.252.5,  212.71.253.5,  109.74.192.20,  109.74.193.20,  109.74.194.20",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
+      1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"},
+      {"id": "eu-west", "label": "London, UK", "country": "gb", "capabilities": ["Linodes",
+      "Backups", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
+      {"ipv4": "178.79.182.5, 176.58.107.5, 176.58.116.5, 176.58.121.5, 151.236.220.5,
+      212.71.252.5, 212.71.253.5, 109.74.192.20, 109.74.193.20, 109.74.194.20", "ipv6":
+      "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"},
       {"id": "ap-south", "label": "Singapore, SG", "country": "sg", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
-      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed
-      Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5, 139.162.13.5,
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "GPU
+      Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5, 139.162.13.5,
       139.162.14.5, 139.162.15.5, 139.162.16.5, 139.162.21.5, 139.162.27.5, 103.3.60.18,
       103.3.60.19, 103.3.60.20", "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "eu-central", "label": "Frankfurt, DE", "country": "de",
-      "capabilities": ["Linodes", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,
-      139.162.131.5, 139.162.132.5, 139.162.133.5, 139.162.134.5, 139.162.135.5, 139.162.136.5,
-      139.162.137.5, 139.162.138.5, 139.162.139.5", "ipv6": "1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "ap-northeast", "label": "Tokyo, JP",
-      "country": "jp", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Kubernetes", "Cloud Firewall", "Block Storage Migrations", "Managed Databases"],
-      "status": "ok", "resolvers": {"ipv4": "139.162.66.5, 139.162.67.5, 139.162.68.5,
-      139.162.69.5, 139.162.70.5, 139.162.71.5, 139.162.72.5, 139.162.73.5, 139.162.74.5,
-      139.162.75.5", "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}}],
-      "page": 1, "pages": 1, "results": 24}'
+      1234::5678"}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt,
+      DE", "country": "de", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
+      {"ipv4": "139.162.130.5, 139.162.131.5, 139.162.132.5, 139.162.133.5, 139.162.134.5,
+      139.162.135.5, 139.162.136.5, 139.162.137.5, 139.162.138.5, 139.162.139.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "ap-northeast", "label": "Tokyo, JP", "country": "jp", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud
+      Firewall", "Vlans", "Block Storage Migrations", "Managed Databases"], "status":
+      "ok", "resolvers": {"ipv4": "139.162.66.5, 139.162.67.5, 139.162.68.5, 139.162.69.5,
+      139.162.70.5, 139.162.71.5, 139.162.72.5, 139.162.73.5, 139.162.74.5, 139.162.75.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type":
+      "core"}], "page": 1, "pages": 1, "results": 25}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -258,19 +302,23 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=900
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:30 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - '*'
       X-Content-Type-Options:
@@ -281,14 +329,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-def","region":"ap-west","client_conn_throttle":20,"tags":null,"firewall_id":228215}'
+    body: '{"label":"go-test-def","region":"ap-west","client_conn_throttle":20,"tags":null,"firewall_id":380701}'
     form: {}
     headers:
       Accept:
@@ -300,8 +348,8 @@ interactions:
     url: https://api.linode.com/v4beta/nodebalancers
     method: POST
   response:
-    body: '{"id": 441126, "label": "go-test-def", "region": "ap-west", "hostname":
-      "172-232-86-38.ip.linodeusercontent.com", "ipv4": "172.232.86.38", "ipv6": "1234::5678",
+    body: '{"id": 552752, "label": "go-test-def", "region": "ap-west", "hostname":
+      "172-232-87-69.ip.linodeusercontent.com", "ipv4": "172.232.87.69", "ipv6": "1234::5678",
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "client_conn_throttle":
       20, "tags": [], "transfer": {"in": null, "out": null, "total": null}}'
     headers:
@@ -316,15 +364,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "334"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:30 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -339,7 +391,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -355,14 +407,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/nodebalancers/441126/configs
+    url: https://api.linode.com/v4beta/nodebalancers/552752/configs
     method: POST
   response:
-    body: '{"id": 670344, "port": 80, "protocol": "http", "algorithm": "roundrobin",
+    body: '{"id": 869293, "port": 80, "protocol": "http", "algorithm": "roundrobin",
       "stickiness": "none", "check": "none", "check_interval": 60, "check_timeout":
       30, "check_attempts": 3, "check_path": "", "check_body": "", "check_passive":
       true, "proxy_protocol": "none", "cipher_suite": "recommended", "nodebalancer_id":
-      441126, "ssl_commonname": "", "ssl_fingerprint": "", "ssl_cert": null, "ssl_key":
+      552752, "ssl_commonname": "", "ssl_fingerprint": "", "ssl_cert": null, "ssl_key":
       null, "nodes_status": {"up": 0, "down": 0}}'
     headers:
       Access-Control-Allow-Credentials:
@@ -376,15 +428,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "437"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:30 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -399,7 +455,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -415,7 +471,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/nodebalancers/441126/configs/670344
+    url: https://api.linode.com/v4beta/nodebalancers/552752/configs/869293
     method: DELETE
   response:
     body: '{}'
@@ -431,15 +487,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:32 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -454,7 +514,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -470,7 +530,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/nodebalancers/441126
+    url: https://api.linode.com/v4beta/nodebalancers/552752
     method: DELETE
   response:
     body: '{}'
@@ -486,15 +546,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:32 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -509,7 +573,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -525,7 +589,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/228215
+    url: https://api.linode.com/v4beta/networking/firewalls/380701
     method: DELETE
   response:
     body: '{}'
@@ -541,15 +605,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:32 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -564,7 +632,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestNodeBalancer_RebuildInstance.yaml
+++ b/test/integration/fixtures/TestNodeBalancer_RebuildInstance.yaml
@@ -15,176 +15,216 @@ interactions:
     method: GET
   response:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, IN", "country": "in", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes",
+      "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "172.105.34.5, 172.105.35.5, 172.105.36.5,
+      172.105.37.5, 172.105.38.5, 172.105.39.5, 172.105.40.5, 172.105.41.5, 172.105.42.5,
+      172.105.43.5", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "ca-central", "label": "Toronto, CA", "country": "ca", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud
       Firewall", "Vlans", "Block Storage Migrations", "Managed Databases"], "status":
-      "ok", "resolvers": {"ipv4": "172.105.34.5, 172.105.35.5, 172.105.36.5, 172.105.37.5,
-      172.105.38.5, 172.105.39.5, 172.105.40.5, 172.105.41.5, 172.105.42.5, 172.105.43.5",
+      "ok", "resolvers": {"ipv4": "172.105.0.5, 172.105.3.5, 172.105.4.5, 172.105.5.5,
+      172.105.6.5, 172.105.7.5, 172.105.8.5, 172.105.9.5, 172.105.10.5, 172.105.11.5",
       "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "ca-central", "label": "Toronto, CA",
-      "country": "ca", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed
-      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5, 172.105.3.5,
-      172.105.4.5, 172.105.5.5, 172.105.6.5, 172.105.7.5, 172.105.8.5, 172.105.9.5,
-      172.105.10.5, 172.105.11.5", "ipv6": "1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "ap-southeast",
+      "label": "Sydney, AU", "country": "au", "capabilities": ["Linodes", "Backups",
+      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      Storage Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4":
+      "172.105.166.5, 172.105.169.5, 172.105.168.5, 172.105.172.5, 172.105.162.5,
+      172.105.170.5, 172.105.167.5, 172.105.171.5, 172.105.181.5, 172.105.161.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "ap-southeast",
-      "label": "Sydney, AU", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,
-      172.105.169.5, 172.105.168.5, 172.105.172.5, 172.105.162.5, 172.105.170.5, 172.105.167.5,
-      172.105.171.5, 172.105.181.5, 172.105.161.5", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-iad", "label":
+      "Washington, DC", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "139.144.192.62, 139.144.192.60, 139.144.192.61, 139.144.192.53, 139.144.192.54,
+      139.144.192.67, 139.144.192.69, 139.144.192.66, 139.144.192.52, 139.144.192.68",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-iad", "label": "Washington, DC", "country": "us", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Managed Databases", "Metadata", "Premium Plans"],
-      "status": "ok", "resolvers": {"ipv4": "139.144.192.62,   139.144.192.60,   139.144.192.61,   139.144.192.53,   139.144.192.54,   139.144.192.67,   139.144.192.69,    139.144.192.66,   139.144.192.52,   139.144.192.68",
-      "ipv6": "1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678"}},
-      {"id": "us-ord", "label": "Chicago, IL", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Managed Databases", "Premium Plans"], "status": "ok", "resolvers":
-      {"ipv4": "172.232.0.17,   172.232.0.16,   172.232.0.21,   172.232.0.13,   172.232.0.22,   172.232.0.9,   172.232.0.19,   172.232.0.20,   172.232.0.15,   172.232.0.18",
-      "ipv6": "1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678,   1234::5678"}},
-      {"id": "fr-par", "label": "Paris, FR", "country": "fr", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok",
-      "resolvers": {"ipv4": "172.232.32.21,  172.232.32.23,  172.232.32.17,  172.232.32.18,  172.232.32.16,  172.232.32.22,  172.232.32.20,  172.232.32.14,  172.232.32.11,  172.232.32.12",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "us-sea", "label": "Seattle, WA", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.160.19,
-      172.232.160.21, 172.232.160.17, 172.232.160.15, 172.232.160.18, 172.232.160.8,
-      172.232.160.12, 172.232.160.11, 172.232.160.14, 172.232.160.16", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-ord", "label":
+      "Chicago, IL", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.0.17, 172.232.0.16, 172.232.0.21, 172.232.0.13, 172.232.0.22,
+      172.232.0.9, 172.232.0.19, 172.232.0.20, 172.232.0.15, 172.232.0.18", "ipv6":
+      "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "br-gru", "label": "Sao Paulo, BR", "country": "br", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      1234::5678"}, "site_type": "core"}, {"id": "fr-par", "label":
+      "Paris, FR", "country": "fr", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Managed Databases", "Metadata", "Premium Plans"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.32.21, 172.232.32.23, 172.232.32.17, 172.232.32.18, 172.232.32.16,
+      172.232.32.22, 172.232.32.20, 172.232.32.14, 172.232.32.11, 172.232.32.12",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-sea", "label":
+      "Seattle, WA", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.232.160.19, 172.232.160.21, 172.232.160.17, 172.232.160.15, 172.232.160.18,
+      172.232.160.8, 172.232.160.12, 172.232.160.11, 172.232.160.14, 172.232.160.16",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "br-gru", "label":
+      "Sao Paulo, BR", "country": "br", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
       "172.233.0.4, 172.233.0.9, 172.233.0.7, 172.233.0.12, 172.233.0.5, 172.233.0.13,
       172.233.0.10, 172.233.0.6, 172.233.0.8, 172.233.0.11", "ipv6": "1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "nl-ams", "label": "Amsterdam, NL", "country": "nl", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
-      "172.233.33.36, 172.233.33.38, 172.233.33.35, 172.233.33.39, 172.233.33.34,
-      172.233.33.33, 172.233.33.31, 172.233.33.30, 172.233.33.37, 172.233.33.32",
+      1234::5678, 1234::5678, 1234::5678"},
+      "site_type": "core"}, {"id": "nl-ams", "label": "Amsterdam, NL", "country":
+      "nl", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Block Storage",
+      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata",
+      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.233.33.36, 172.233.33.38,
+      172.233.33.35, 172.233.33.39, 172.233.33.34, 172.233.33.33, 172.233.33.31, 172.233.33.30,
+      172.233.33.37, 172.233.33.32", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "se-sto", "label": "Stockholm, SE", "country": "se", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok",
+      "resolvers": {"ipv4": "172.232.128.24, 172.232.128.26, 172.232.128.20, 172.232.128.22,
+      172.232.128.25, 172.232.128.19, 172.232.128.23, 172.232.128.18, 172.232.128.21,
+      172.232.128.27", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "es-mad", "label": "Madrid, ES", "country": "es", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok",
+      "resolvers": {"ipv4": "172.233.111.6, 172.233.111.17, 172.233.111.21, 172.233.111.25,
+      172.233.111.19, 172.233.111.12, 172.233.111.26, 172.233.111.16, 172.233.111.18,
+      172.233.111.9", "ipv6": "1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "in-maa", "label": "Chennai, IN", "country": "in", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans"], "status": "ok",
+      "resolvers": {"ipv4": "172.232.96.17, 172.232.96.26, 172.232.96.19, 172.232.96.20,
+      172.232.96.25, 172.232.96.21, 172.232.96.18, 172.232.96.22, 172.232.96.23, 172.232.96.24",
       "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "se-sto", "label": "Stockholm, SE",
-      "country": "se", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Premium Plans"],
-      "status": "ok", "resolvers": {"ipv4": "172.232.128.24, 172.232.128.26, 172.232.128.20,
-      172.232.128.22, 172.232.128.25, 172.232.128.19, 172.232.128.23, 172.232.128.18,
-      172.232.128.21, 172.232.128.27", "ipv6": "1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "in-maa",
-      "label": "Chennai, IN", "country": "in", "capabilities": ["Linodes", "NodeBalancers",
+      1234::5678"}, "site_type": "core"}, {"id": "jp-osa", "label":
+      "Osaka, JP", "country": "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
-      "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.96.17,  172.232.96.26,  172.232.96.19,  172.232.96.20,  172.232.96.25,  172.232.96.21,  172.232.96.18,  172.232.96.22,  172.232.96.23,  172.232.96.24",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
-      {"id": "jp-osa", "label": "Osaka, JP", "country": "jp", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.233.64.44,
-      172.233.64.43, 172.233.64.37, 172.233.64.40, 172.233.64.46, 172.233.64.41, 172.233.64.39,
-      172.233.64.42, 172.233.64.45, 172.233.64.38", "ipv6": "1234::5678,
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.233.64.44, 172.233.64.43, 172.233.64.37, 172.233.64.40, 172.233.64.46,
+      172.233.64.41, 172.233.64.39, 172.233.64.42, 172.233.64.45, 172.233.64.38",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "it-mil", "label": "Milan, IT", "country": "it", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.192.19,
-      172.232.192.18, 172.232.192.16, 172.232.192.20, 172.232.192.24, 172.232.192.21,
-      172.232.192.22, 172.232.192.17, 172.232.192.15, 172.232.192.23", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "it-mil", "label":
+      "Milan, IT", "country": "it", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.232.192.19, 172.232.192.18, 172.232.192.16, 172.232.192.20, 172.232.192.24,
+      172.232.192.21, 172.232.192.22, 172.232.192.17, 172.232.192.15, 172.232.192.23",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-mia", "label": "Miami, FL", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.233.160.34,
-      172.233.160.27, 172.233.160.30, 172.233.160.29, 172.233.160.32, 172.233.160.28,
-      172.233.160.33, 172.233.160.26, 172.233.160.25, 172.233.160.31", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-mia", "label":
+      "Miami, FL", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.233.160.34, 172.233.160.27, 172.233.160.30, 172.233.160.29, 172.233.160.32,
+      172.233.160.28, 172.233.160.33, 172.233.160.26, 172.233.160.25, 172.233.160.31",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "id-cgk", "label": "Jakarta, ID", "country": "id", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4": "172.232.224.23,
-      172.232.224.32, 172.232.224.26, 172.232.224.27, 172.232.224.21, 172.232.224.24,
-      172.232.224.22, 172.232.224.20, 172.232.224.31, 172.232.224.28", "ipv6": "1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "id-cgk", "label":
+      "Jakarta, ID", "country": "id", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      "172.232.224.23, 172.232.224.32, 172.232.224.26, 172.232.224.27, 172.232.224.21,
+      172.232.224.24, 172.232.224.22, 172.232.224.20, 172.232.224.31, 172.232.224.28",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-lax", "label": "Los Angeles, CA", "country": "us", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
+      1234::5678"}, "site_type": "core"}, {"id": "us-lax", "label":
+      "Los Angeles, CA", "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans"], "status": "ok", "resolvers": {"ipv4":
       "172.233.128.45, 172.233.128.38, 172.233.128.53, 172.233.128.37, 172.233.128.34,
       172.233.128.36, 172.233.128.33, 172.233.128.39, 172.233.128.43, 172.233.128.44",
       "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "us-central", "label": "Dallas, TX",
-      "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Kubernetes", "Cloud Firewall", "Block Storage Migrations", "Managed Databases"],
-      "status": "ok", "resolvers": {"ipv4": "72.14.179.5, 72.14.188.5, 173.255.199.5,
-      66.228.53.5, 96.126.122.5, 96.126.124.5, 96.126.127.5, 198.58.107.5, 198.58.111.5,
-      23.239.24.5", "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}},
-      {"id": "us-west", "label": "Fremont, CA", "country": "us", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage
-      Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,
-      173.230.147.5, 173.230.155.5, 173.255.212.5, 173.255.219.5, 173.255.241.5, 173.255.243.5,
-      173.255.244.5, 74.207.241.5, 74.207.242.5", "ipv6": "1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "us-southeast", "label": "Atlanta, GA",
-      "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      1234::5678"}, "site_type": "core"}, {"id": "us-central",
+      "label": "Dallas, TX", "country": "us", "capabilities": ["Linodes", "Backups",
+      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
       Storage Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4":
-      "74.207.231.5, 173.230.128.5, 173.230.129.5, 173.230.136.5, 173.230.140.5, 66.228.59.5,
-      66.228.62.5, 50.116.35.5, 50.116.41.5, 23.239.18.5", "ipv6": "1234::5678,
+      "72.14.179.5, 72.14.188.5, 173.255.199.5, 66.228.53.5, 96.126.122.5, 96.126.124.5,
+      96.126.127.5, 198.58.107.5, 198.58.111.5, 23.239.24.5", "ipv6": "1234::5678,
       1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678"}}, {"id": "us-east", "label": "Newark,
-      NJ", "country": "us", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Bare Metal",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
+      1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"}, {"id": "us-west",
+      "label": "Fremont, CA", "country": "us", "capabilities": ["Linodes", "Backups",
+      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      Storage Migrations", "Managed Databases"], "status": "ok", "resolvers": {"ipv4":
+      "173.230.145.5, 173.230.147.5, 173.230.155.5, 173.255.212.5, 173.255.219.5,
+      173.255.241.5, 173.255.243.5, 173.255.244.5, 74.207.241.5, 74.207.242.5", "ipv6":
+      "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"},
+      {"id": "us-southeast", "label": "Atlanta, GA", "country": "us", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "GPU
+      Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5, 173.230.128.5,
+      173.230.129.5, 173.230.136.5, 173.230.140.5, 66.228.59.5, 66.228.62.5, 50.116.35.5,
+      50.116.41.5, 23.239.18.5", "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Block
+      Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans",
+      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
       {"ipv4": "66.228.42.5, 96.126.106.5, 50.116.53.5, 50.116.58.5, 50.116.61.5,
       50.116.62.5, 66.175.211.5, 97.107.133.4, 207.192.69.4, 207.192.69.5", "ipv6":
       "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678"}}, {"id": "eu-west",
-      "label": "London, UK", "country": "gb", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,  176.58.107.5,  176.58.116.5,  176.58.121.5,  151.236.220.5,  212.71.252.5,  212.71.253.5,  109.74.192.20,  109.74.193.20,  109.74.194.20",
-      "ipv6": "1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678,  1234::5678"}},
+      1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"},
+      {"id": "eu-west", "label": "London, UK", "country": "gb", "capabilities": ["Linodes",
+      "Backups", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
+      {"ipv4": "178.79.182.5, 176.58.107.5, 176.58.116.5, 176.58.121.5, 151.236.220.5,
+      212.71.252.5, 212.71.253.5, 109.74.192.20, 109.74.193.20, 109.74.194.20", "ipv6":
+      "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type": "core"},
       {"id": "ap-south", "label": "Singapore, SG", "country": "sg", "capabilities":
-      ["Linodes", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
-      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed
-      Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5, 139.162.13.5,
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Object Storage", "GPU
+      Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5, 139.162.13.5,
       139.162.14.5, 139.162.15.5, 139.162.16.5, 139.162.21.5, 139.162.27.5, 103.3.60.18,
       103.3.60.19, 103.3.60.20", "ipv6": "1234::5678, 1234::5678, 1234::5678,
       1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}}, {"id": "eu-central", "label": "Frankfurt, DE", "country": "de",
-      "capabilities": ["Linodes", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,
-      139.162.131.5, 139.162.132.5, 139.162.133.5, 139.162.134.5, 139.162.135.5, 139.162.136.5,
-      139.162.137.5, 139.162.138.5, 139.162.139.5", "ipv6": "1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678"}}, {"id": "ap-northeast", "label": "Tokyo, JP",
-      "country": "jp", "capabilities": ["Linodes", "NodeBalancers", "Block Storage",
-      "Kubernetes", "Cloud Firewall", "Block Storage Migrations", "Managed Databases"],
-      "status": "ok", "resolvers": {"ipv4": "139.162.66.5, 139.162.67.5, 139.162.68.5,
-      139.162.69.5, 139.162.70.5, 139.162.71.5, 139.162.72.5, 139.162.73.5, 139.162.74.5,
-      139.162.75.5", "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}}],
-      "page": 1, "pages": 1, "results": 24}'
+      1234::5678"}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt,
+      DE", "country": "de", "capabilities": ["Linodes", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
+      {"ipv4": "139.162.130.5, 139.162.131.5, 139.162.132.5, 139.162.133.5, 139.162.134.5,
+      139.162.135.5, 139.162.136.5, 139.162.137.5, 139.162.138.5, 139.162.139.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type":
+      "core"}, {"id": "ap-northeast", "label": "Tokyo, JP", "country": "jp", "capabilities":
+      ["Linodes", "Backups", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud
+      Firewall", "Vlans", "Block Storage Migrations", "Managed Databases"], "status":
+      "ok", "resolvers": {"ipv4": "139.162.66.5, 139.162.67.5, 139.162.68.5, 139.162.69.5,
+      139.162.70.5, 139.162.71.5, 139.162.72.5, 139.162.73.5, 139.162.74.5, 139.162.75.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "site_type":
+      "core"}], "page": 1, "pages": 1, "results": 25}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -197,19 +237,23 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=900
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:30 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - '*'
       X-Content-Type-Options:
@@ -220,14 +264,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"ap-west","type":"g6-nanode-1","label":"go-test-ins-qs6jt31631qw","root_pass":"R34lBAdP455LONGLONGLONGLONG","image":"linode/debian9","booted":false}'
+    body: '{"region":"ap-west","type":"g6-nanode-1","label":"go-test-ins-74uq6x25mfw5","root_pass":"2vCt11P\u003cO9UH0r3yJN|z\u0026,6d=eHg\u003e6\\59?2}):tQ[n^Pn0Cwh@D2j|$26pB6FTLd","image":"linode/debian9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -239,15 +283,15 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 49708285, "label": "go-test-ins-qs6jt31631qw", "group": "", "status":
+    body: '{"id": 55899624, "label": "go-test-ins-74uq6x25mfw5", "group": "", "status":
       "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["139.144.4.174"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["192.46.212.26"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "ap-west", "specs": {"disk": 25600, "memory":
       1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
       false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
       null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
-      "6eb83ed887a5cd4920fbeb92ba8047f660ef74f4", "has_user_data": false}'
+      "ddc9b0f1543cd067735eb31792566cb8378c2e9b", "has_user_data": false}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -260,15 +304,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "741"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:31 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -299,12 +347,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/49708285/ips
+    url: https://api.linode.com/v4beta/linode/instances/55899624/ips
     method: POST
   response:
-    body: '{"address": "192.168.159.34", "gateway": null, "subnet_mask": "255.255.128.0",
-      "prefix": 17, "type": "ipv4", "public": false, "rdns": null, "linode_id": 49708285,
-      "region": "ap-west"}'
+    body: '{"address": "192.168.128.97", "gateway": null, "subnet_mask": "255.255.128.0",
+      "prefix": 17, "type": "ipv4", "public": false, "rdns": null, "linode_id": 55899624,
+      "region": "ap-west", "vpc_nat_1_1": null}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -317,15 +365,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "183"
+      - "204"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:31 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -340,14 +392,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"address":"192.168.159.34:8080","label":"go-node-test-def","weight":10,"mode":"accept"}'
+    body: '{"address":"192.168.128.97:8080","label":"go-node-test-def","weight":10,"mode":"accept"}'
     form: {}
     headers:
       Accept:
@@ -356,12 +408,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/nodebalancers/441126/configs/670344/nodes
+    url: https://api.linode.com/v4beta/nodebalancers/552752/configs/869293/nodes
     method: POST
   response:
-    body: '{"id": 516206639, "address": "192.168.159.34:8080", "label": "go-node-test-def",
-      "status": "Unknown", "weight": 10, "mode": "accept", "config_id": 670344, "nodebalancer_id":
-      441126}'
+    body: '{"id": 1943752004, "address": "192.168.128.97:8080", "label": "go-node-test-def",
+      "status": "Unknown", "weight": 10, "mode": "accept", "config_id": 869293, "nodebalancer_id":
+      552752}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -374,15 +426,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "181"
+      - "182"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:31 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -397,14 +453,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"port":80,"protocol":"http","proxy_protocol":"none","algorithm":"roundrobin","stickiness":"none","check":"none","check_interval":60,"check_attempts":3,"check_passive":true,"check_timeout":30,"cipher_suite":"recommended","nodes":[]}'
+    body: '{"port":80,"protocol":"http","proxy_protocol":"none","algorithm":"roundrobin","stickiness":"none","check":"none","check_interval":60,"check_attempts":3,"check_passive":true,"check_timeout":30,"cipher_suite":"recommended","nodes":[{"address":"192.168.128.97:8080","label":"go-node-test-def","weight":10,"mode":"accept","id":1943752004}]}'
     form: {}
     headers:
       Accept:
@@ -413,14 +469,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/nodebalancers/441126/configs/670344/rebuild
+    url: https://api.linode.com/v4beta/nodebalancers/552752/configs/869293/rebuild
     method: POST
   response:
-    body: '{"id": 670344, "port": 80, "protocol": "http", "algorithm": "roundrobin",
+    body: '{"id": 869293, "port": 80, "protocol": "http", "algorithm": "roundrobin",
       "stickiness": "none", "check": "none", "check_interval": 60, "check_timeout":
       30, "check_attempts": 3, "check_path": "", "check_body": "", "check_passive":
       true, "proxy_protocol": "none", "cipher_suite": "recommended", "nodebalancer_id":
-      441126, "ssl_commonname": "", "ssl_fingerprint": "", "ssl_cert": null, "ssl_key":
+      552752, "ssl_commonname": "", "ssl_fingerprint": "", "ssl_cert": null, "ssl_key":
       null, "nodes_status": {"up": 0, "down": 1}}'
     headers:
       Access-Control-Allow-Credentials:
@@ -434,15 +490,19 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "437"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:31 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -457,7 +517,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -473,33 +533,57 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/nodebalancers/441126/configs/670344/nodes/516206639
-    method: DELETE
+    url: https://api.linode.com/v4beta/nodebalancers/552752/configs/869293/nodes
+    method: GET
   response:
-    body: '{"errors": [{"reason": "Not found"}]}'
+    body: '{"data": [{"id": 1943752004, "address": "192.168.128.97:8080", "label":
+      "go-node-test-def", "status": "Unknown", "weight": 10, "mode": "accept", "config_id":
+      869293, "nodebalancer_id": 552752}], "page": 1, "pages": 1, "results": 1}'
     headers:
+      Access-Control-Allow-Credentials:
+      - "true"
       Access-Control-Allow-Headers:
       - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
       Access-Control-Allow-Methods:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
-      - "37"
+      - "231"
+      Content-Security-Policy:
+      - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:31 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
-      - nodebalancers:read_write
+      - nodebalancers:read_only
+      X-Content-Type-Options:
+      - nosniff
       X-Frame-Options:
+      - DENY
       - DENY
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 404 Not Found
-    code: 404
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -511,7 +595,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/49708285
+    url: https://api.linode.com/v4beta/nodebalancers/552752/configs/869293/nodes/1943752004
     method: DELETE
   response:
     body: '{}'
@@ -527,15 +611,78 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Mon, 11 Mar 2024 15:04:32 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - nodebalancers:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/55899624
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Mon, 11 Mar 2024 15:04:33 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -550,7 +697,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK


### PR DESCRIPTION
## 📝 Description

This change resolves an issue that prevented existing nodes from being preserved using the `id` field in the [NodeBalancer Config Rebuild response body](https://www.linode.com/docs/api/nodebalancers/#config-rebuild). This works by creating a new `NodeBalancerConfigRebuildNodeOptions` struct that extends the `NodeBalancerNodeCreateOptions` struct with a new `ID` field.

NOTE: This IS a breaking change but we deemed it low-impact enough to be worth making.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Integration Testing

```
make ARGS="-run TestNodeBalancer_Rebuild" fixtures
```

### Manual Testing

1. In a linodego sandbox environment (e.g. dx-devenv), run the following:

```go
package main

import (
	"context"
	"fmt"
	"github.com/linode/linodego"
	"github.com/sanity-io/litter"
	"log"
	"os"
)

func main() {
	ctx := context.Background()

	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))

	inst, err := client.CreateInstance(
		ctx,
		linodego.InstanceCreateOptions{
			Label:     "test-instance",
			Region:    "us-mia",
			Type:      "g6-nanode-1",
			PrivateIP: true,
		},
	)
	if err != nil {
		log.Fatal(err)
	}

	nbLabel := "test-nb"

	nb, err := client.CreateNodeBalancer(
		ctx,
		linodego.NodeBalancerCreateOptions{
			Label:  &nbLabel,
			Region: "us-mia",
			Configs: []*linodego.NodeBalancerConfigCreateOptions{
				{
					Port: 80,
					Nodes: []linodego.NodeBalancerNodeCreateOptions{
						{
							Address: inst.IPv4[1].String() + ":80",
							Label:   "test-node",
						},
					},
				},
			},
		},
	)
	if err != nil {
		log.Fatal(err)
	}

	configs, err := client.ListNodeBalancerConfigs(ctx, nb.ID, nil)
	if err != nil {
		log.Fatal(err)
	}
	config := configs[0]

	oldNodes, err := client.ListNodeBalancerNodes(ctx, nb.ID, config.ID, nil)
	if err != nil {
		log.Fatal(err)
	}

	oldNode := oldNodes[0]
	fmt.Println("Old node:")
	litter.Dump(oldNode)
	fmt.Println()

	_, err = client.RebuildNodeBalancerConfig(
		ctx,
		nb.ID,
		config.ID,
		linodego.NodeBalancerConfigRebuildOptions{
			Port: 81,
			Nodes: []linodego.NodeBalancerConfigRebuildNodeOptions{
				{
					NodeBalancerNodeCreateOptions: oldNode.GetCreateOptions(),
					ID:                            oldNode.ID,
				},
			},
		},
	)
	if err != nil {
		log.Fatal(err)
	}

	newNodes, err := client.ListNodeBalancerNodes(ctx, nb.ID, config.ID, nil)
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println("Updated node:")
	litter.Dump(newNodes[0])
}
```

2. Ensure the output is similar to the following:

```
Old node:
linodego.NodeBalancerNode{
  ID: 1943768499,
  Address: "192.168.149.92:80",
  Label: "test-node",
  Status: "Unknown",
  Weight: 50,
  Mode: "accept",
  ConfigID: 869351,
  NodeBalancerID: 552780,
}

Updated node:
linodego.NodeBalancerNode{
  ID: 1943768499,
  Address: "192.168.149.92:80",
  Label: "test-node-updated",
  Status: "Unknown",
  Weight: 50,
  Mode: "accept",
  ConfigID: 869351,
  NodeBalancerID: 552780,
}
```

3. Ensure the IDs of both nodes match and the label of the updated node is `test-node-updated`.
