### PR TITLE
Add Updated and EOL Fields to Image

### DIFF
--- a/images.go
+++ b/images.go
@@ -33,8 +33,10 @@ type Image struct {
 	Size         int         `json:"size"`
 	IsPublic     bool        `json:"is_public"`
 	Deprecated   bool        `json:"deprecated"`
+	Updated      *time.Time  `json:"-"`
 	Created      *time.Time  `json:"-"`
 	Expiry       *time.Time  `json:"-"`
+	EOL          *time.Time  `json:"-"`
 }
 
 // ImageCreateOptions fields are those accepted by CreateImage
@@ -80,8 +82,10 @@ func (i *Image) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+		Updated *parseabletime.ParseableTime `json:"updated"`
 		Created *parseabletime.ParseableTime `json:"created"`
 		Expiry  *parseabletime.ParseableTime `json:"expiry"`
+		EOL     *parseabletime.ParseableTime `json:"eol"`
 	}{
 		Mask: (*Mask)(i),
 	}
@@ -90,8 +94,10 @@ func (i *Image) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
+	i.Updated = (*time.Time)(p.Updated)
 	i.Created = (*time.Time)(p.Created)
 	i.Expiry = (*time.Time)(p.Expiry)
+	i.EOL = (*time.Time)(p.EOL)
 
 	return nil
 }

--- a/test/integration/fixtures/TestImage_GetFound.yaml
+++ b/test/integration/fixtures/TestImage_GetFound.yaml
@@ -11,14 +11,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/images/linode%2Fubuntu16.04lts
+    url: https://api.linode.com/v4beta/images/linode%2Fubuntu22.04
     method: GET
   response:
-    body: '{"id": "linode/ubuntu16.04lts", "label": "Ubuntu 16.04 LTS", "deprecated":
-      true, "size": 2700, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+    body: '{"id": "linode/ubuntu22.04", "label": "Ubuntu 22.04 LTS", "deprecated":
+      false, "size": 3500, "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
       "description": "", "created_by": "linode", "type": "manual", "is_public": true,
       "vendor": "Ubuntu", "expiry": null, "eol": "2018-01-02T03:04:05", "status":
-      "available", "capabilities": []}'
+      "available", "capabilities": ["cloud-init"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -35,13 +35,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "351"
+      - "361"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Fri, 16 Feb 2024 17:47:58 GMT
+      - Fri, 15 Mar 2024 18:43:24 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/images_test.go
+++ b/test/integration/images_test.go
@@ -39,11 +39,14 @@ func TestImage_GetFound(t *testing.T) {
 	client, teardown := createTestClient(t, "fixtures/TestImage_GetFound")
 	defer teardown()
 
-	i, err := client.GetImage(context.Background(), "linode/ubuntu16.04lts")
+	i, err := client.GetImage(context.Background(), "linode/ubuntu22.04")
+	if i.Created == nil || i.EOL == nil || i.Updated == nil {
+		t.Errorf("Error parsing time, %v, %v, %v", i.Created, i.EOL, i.Updated)
+	}
 	if err != nil {
 		t.Errorf("Error getting image, expected struct, got %v and error %v", i, err)
 	}
-	if i.ID != "linode/ubuntu16.04lts" {
+	if i.ID != "linode/ubuntu22.04" {
 		t.Errorf("Expected a specific image, but got a different one %v", i)
 	}
 }


### PR DESCRIPTION
## 📝 Description

This is to add missing fields to the Image struct.

## ✔️ How to Test

```bash
make ARGS="-run TestImage_GetFound" fixtures
```

```go
import (
	"context"
	"fmt"
	"os"
	"time"

	"github.com/linode/linodego"
)

func main() {
	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))
	image, err := client.GetImage(context.Background(), "linode/ubuntu22.04")
	if err != nil {
		panic(err)
	}
	
	fmt.Println(image.EOL.Format(time.RFC3339))
	fmt.Println(image.Updated.Format(time.RFC3339))
}
```

