### PR TITLE
Skip `TestBetaProgram_Get` When No Beta Program is Available

### DIFF
--- a/test/integration/betas_test.go
+++ b/test/integration/betas_test.go
@@ -26,8 +26,15 @@ func TestBetaPrograms_List(t *testing.T) {
 func TestBetaProgram_Get(t *testing.T) {
 	client, teardown := createTestClient(t, "fixtures/TestBetaProgram_Get")
 	defer teardown()
+	betaPrograms, err := client.ListBetaPrograms(context.Background(), linodego.NewListOptions(0, ""))
+	if err != nil {
+		t.Fatalf("error listing Beta program, %v", err)
+	}
+	if len(betaPrograms) == 0 {
+		t.Skip("no beta program is available, skipping getting beta program test.")
+	}
 
-	betaID := "active_closed"
+	betaID := betaPrograms[0].ID
 	beta, err := client.GetBetaProgram(context.Background(), betaID)
 	if err != nil {
 		t.Errorf("Error getting Beta program, expected struct, got error %v", err)

--- a/test/integration/fixtures/TestBetaProgram_Get.yaml
+++ b/test/integration/fixtures/TestBetaProgram_Get.yaml
@@ -11,12 +11,23 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/betas/active_closed
+    url: https://api.linode.com/v4beta/betas
     method: GET
   response:
-    body: '{"id": "active_closed", "label": "active closed beta", "description": "An
-      active closed beta", "started": "2018-01-02T03:04:05", "ended": null, "greenlight_only":
-      true, "more_info": "a link with even more info"}'
+    body: '{"data": [{"id": "global_load_balancer_beta", "label": "Akamai Global Load
+      Balancer Pre-Registration", "description": "The Akamai Global Load Balancer
+      (AGLB) is a layer 4 and 7 load balancer that distributes traffic based on performance,
+      weight, and content (HTTP headers, query strings, etc.). The AGLB is a multi-region,
+      multicloud, independent of Akamai Delivery, and built for East-West and North-South
+      traffic. Key features include multi-region load balancing and method selection.
+      Beta for this product is coming soon\u2013 sign up to be contacted first when
+      AGLB is available.\r\n\r\nPlease note: Akamai Global Load Balancer is not currently
+      available in beta testing. By signing up to participate in this beta when it
+      becomes available, you consent to be subscribed to receive emails from Akamai
+      cloud computing services marketing and be contacted via email when the beta
+      period begins.", "started": "2018-01-02T03:04:05", "ended": null, "greenlight_only":
+      false, "more_info": "https://www.linode.com/green-light/"}], "page": 1, "pages":
+      1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -29,21 +40,23 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Content-Length:
-      - "211"
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Wed, 20 Mar 2024 20:58:58 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - '*'
       X-Content-Type-Options:
@@ -54,7 +67,78 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1200"
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/betas/global_load_balancer_beta
+    method: GET
+  response:
+    body: '{"id": "global_load_balancer_beta", "label": "Akamai Global Load Balancer
+      Pre-Registration", "description": "The Akamai Global Load Balancer (AGLB) is
+      a layer 4 and 7 load balancer that distributes traffic based on performance,
+      weight, and content (HTTP headers, query strings, etc.). The AGLB is a multi-region,
+      multicloud, independent of Akamai Delivery, and built for East-West and North-South
+      traffic. Key features include multi-region load balancing and method selection.
+      Beta for this product is coming soon\u2013 sign up to be contacted first when
+      AGLB is available.\r\n\r\nPlease note: Akamai Global Load Balancer is not currently
+      available in beta testing. By signing up to participate in this beta when it
+      becomes available, you consent to be subscribed to receive emails from Akamai
+      cloud computing services marketing and be contacted via email when the beta
+      period begins.", "started": "2018-01-02T03:04:05", "ended": null, "greenlight_only":
+      false, "more_info": "https://www.linode.com/green-light/"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Wed, 20 Mar 2024 20:58:59 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK


### PR DESCRIPTION
## 📝 Description

This is to fix `TestBetaProgram_Get` test case when there is not a beta program available.

## ✔️ How to Test
```bash
make ARGS="-run TestBetaProgram_Get" fixtures
```