### PR TITLE
new: Add Client.UseURL(...) method

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -103,6 +103,34 @@ func TestClient_NewFromEnvToken(t *testing.T) {
 	}
 }
 
+func TestClient_UseURL(t *testing.T) {
+	client := NewClient(nil)
+
+	if _, err := client.UseURL("https://api.test1.linode.com/"); err != nil {
+		t.Fatal(err)
+	}
+
+	if client.baseURL != "api.test1.linode.com" {
+		t.Fatalf("mismatched base url: %s", client.baseURL)
+	}
+
+	if client.apiVersion != "v4" {
+		t.Fatalf("mismatched api version: %s", client.apiVersion)
+	}
+
+	if _, err := client.UseURL("https://api.test2.linode.com/v4beta"); err != nil {
+		t.Fatal(err)
+	}
+
+	if client.baseURL != "api.test2.linode.com" {
+		t.Fatalf("mismatched base url: %s", client.baseURL)
+	}
+
+	if client.apiVersion != "v4beta" {
+		t.Fatalf("mismatched api version: %s", client.apiVersion)
+	}
+}
+
 const configNewFromEnv = `
 [default]
 api_url = api.cool.linode.com


### PR DESCRIPTION
## 📝 Description

This PR adds a new `client.UseURL(...)` method that allows users to configure the scheme, host, and version of a client using a single URL.

For example:

```go
client.UseURL("https://api.test1.linode.com/v4beta")
```

This is implemented in linodego as a convenience feature for projects that previously implemented this functionality manually (e.g. CCM).

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally.

### Unit Testing

```
make testunit
```

### Manual Testing

1. In a linodego sandbox environment (e.g. dx-devenv), run the following:

```go
package main

import (
	"context"
	"github.com/linode/linodego"
	"log"
	"os"
)

func main() {
	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))

	// This is intentionally set to an invalid URL
	if _, err := client.UseURL("https://api.test1.linode.com/v4beta"); err != nil {
		log.Fatal(err)
	}

	if _, err := client.ListInstances(context.Background(), nil); err != nil {
		log.Fatal(err)
	}
}
```

2. Ensure the run fails with an error similar to the following:

```
2024/03/28 13:17:38.300111 WARN RESTY Get "https://api.test1.linode.com/v4beta/linode/instances": dial tcp: lookup api.test1.linode.com: no such host, Attempt 1
2024/03/28 13:17:38.300217 ERROR RESTY Get "https://api.test1.linode.com/v4beta/linode/instances": dial tcp: lookup api.test1.linode.com: no such host
2024/03/28 13:17:38 [002] Get "https://api.test1.linode.com/v4beta/linode/instances": dial tcp: lookup api.test1.linode.com: no such host
```