### PR TITLE
Add a list VPC IPs function for a specific VPC

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,22 +7,15 @@ linters-settings:
     check-blank: true
 
   govet:
-    check-shadowing: true
-
     enable:
       - atomicalign
-    enable-all: false
-    disable:
       - shadow
+    enable-all: false
     disable-all: false
-  golint:
-    min-confidence: 0.8
   gocyclo:
     min-complexity: 30
   gocognit:
     min-complexity: 30
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 100
 

--- a/test/integration/fixtures/TestVPC_ListAllIPAddresses.yaml
+++ b/test/integration/fixtures/TestVPC_ListAllIPAddresses.yaml
@@ -245,7 +245,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:44 GMT
+      - Fri, 05 Apr 2024 19:23:42 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -271,7 +271,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"us-iad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-0j8oh1xh725p","booted":false}'
+    body: '{"region":"us-iad","type":"g6-nanode-1","label":"go-test-ins-wo-disk-32l2mwivl348","booted":false}'
     form: {}
     headers:
       Accept:
@@ -283,15 +283,15 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 56840097, "label": "go-test-ins-wo-disk-0j8oh1xh725p", "group":
+    body: '{"id": 56840095, "label": "go-test-ins-wo-disk-32l2mwivl348", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["139.144.199.177"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["139.144.221.98"], "ipv6": "1234::5678/128",
       "image": null, "region": "us-iad", "specs": {"disk": 25600, "memory": 1024,
       "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
       false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
       null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
-      "7d976b01d7a02564542f5279df040f3672a62eec", "has_user_data": false}'
+      "4d538cc0e67c9f98073a079b8960199e65fdbe06", "has_user_data": false}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -308,13 +308,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "738"
+      - "737"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:44 GMT
+      - Fri, 05 Apr 2024 19:23:43 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -338,7 +338,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-11w439bzc9vl","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-5j4g24jt0jt0","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -347,10 +347,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/56840097/configs
+    url: https://api.linode.com/v4beta/linode/instances/56840095/configs
     method: POST
   response:
-    body: '{"id": 59991783, "label": "go-test-conf-11w439bzc9vl", "helpers": {"updatedb_disabled":
+    body: '{"id": 59991781, "label": "go-test-conf-5j4g24jt0jt0", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -379,7 +379,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:44 GMT
+      - Fri, 05 Apr 2024 19:23:43 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -403,7 +403,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-vpc-1712345024899989000","region":"us-iad","subnets":[{"label":"linodego-vpc-test-1712345024900060000","ipv4":"192.168.0.0/25"}]}'
+    body: '{"label":"go-test-vpc-1712345023171915000","region":"us-iad","subnets":[{"label":"linodego-vpc-test-1712345023172003000","ipv4":"192.168.0.0/25"}]}'
     form: {}
     headers:
       Accept:
@@ -415,8 +415,8 @@ interactions:
     url: https://api.linode.com/v4beta/vpcs
     method: POST
   response:
-    body: '{"id": 52789, "label": "go-test-vpc-1712345024899989000", "description":
-      "", "region": "us-iad", "subnets": [{"id": 52457, "label": "linodego-vpc-test-1712345024900060000",
+    body: '{"id": 52788, "label": "go-test-vpc-1712345023171915000", "description":
+      "", "region": "us-iad", "subnets": [{"id": 52456, "label": "linodego-vpc-test-1712345023172003000",
       "ipv4": "192.168.0.0/25", "linodes": [], "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05"}], "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05"}'
     headers:
@@ -441,7 +441,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:45 GMT
+      - Fri, 05 Apr 2024 19:23:43 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -465,7 +465,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-11w439bzc9vl","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"vpc","subnet_id":52457,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
+    body: '{"label":"go-test-conf-5j4g24jt0jt0","comments":"","devices":{},"helpers":{"updatedb_disabled":true,"distro":true,"modules_dep":true,"network":true,"devtmpfs_automount":true},"interfaces":[{"purpose":"vpc","subnet_id":52456,"ipv4":{"nat_1_1":"any"}}],"memory_limit":0,"kernel":"linode/latest-64bit","init_rd":null,"root_device":"/dev/sda","run_level":"default","virt_mode":"paravirt"}'
     form: {}
     headers:
       Accept:
@@ -474,18 +474,18 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/56840097/configs/59991783
+    url: https://api.linode.com/v4beta/linode/instances/56840095/configs/59991781
     method: PUT
   response:
-    body: '{"id": 59991783, "label": "go-test-conf-11w439bzc9vl", "helpers": {"updatedb_disabled":
+    body: '{"id": 59991781, "label": "go-test-conf-5j4g24jt0jt0", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
       "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
       "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
-      "virt_mode": "paravirt", "interfaces": [{"id": 1315044, "purpose": "vpc", "primary":
-      false, "active": false, "ipam_address": null, "label": null, "vpc_id": 52789,
-      "subnet_id": 52457, "ipv4": {"vpc": "192.168.0.2", "nat_1_1": "139.144.199.177"},
+      "virt_mode": "paravirt", "interfaces": [{"id": 1315043, "purpose": "vpc", "primary":
+      false, "active": false, "ipam_address": null, "label": null, "vpc_id": 52788,
+      "subnet_id": 52456, "ipv4": {"vpc": "192.168.0.2", "nat_1_1": "139.144.221.98"},
       "ip_ranges": []}]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -503,13 +503,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "760"
+      - "759"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:45 GMT
+      - Fri, 05 Apr 2024 19:23:43 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -543,13 +543,13 @@ interactions:
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
       X-Filter:
-      - '{"linode_id": 56840097}'
-    url: https://api.linode.com/v4beta/vpcs/52789/ips?page=1
+      - '{"linode_id": 56840095}'
+    url: https://api.linode.com/v4beta/vpcs/ips?page=1
     method: GET
   response:
-    body: '{"data": [{"address": "192.168.0.2", "address_range": null, "vpc_id": 52789,
-      "subnet_id": 52457, "region": "us-iad", "linode_id": 56840097, "config_id":
-      59991783, "interface_id": 1315044, "active": false, "nat_1_1": "139.144.199.177",
+    body: '{"data": [{"address": "192.168.0.2", "address_range": null, "vpc_id": 52788,
+      "subnet_id": 52456, "region": "us-iad", "linode_id": 56840095, "config_id":
+      59991781, "interface_id": 1315043, "active": false, "nat_1_1": "139.144.221.98",
       "gateway": "192.168.0.1", "prefix": 25, "subnet_mask": "255.255.255.128"}],
       "page": 1, "pages": 1, "results": 1}'
     headers:
@@ -568,13 +568,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "347"
+      - "346"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:45 GMT
+      - Fri, 05 Apr 2024 19:23:43 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -608,7 +608,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/56840097
+    url: https://api.linode.com/v4beta/linode/instances/56840095
     method: DELETE
   response:
     body: '{}'
@@ -634,7 +634,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:45 GMT
+      - Fri, 05 Apr 2024 19:23:44 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -667,7 +667,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/vpcs/52789
+    url: https://api.linode.com/v4beta/vpcs/52788
     method: DELETE
   response:
     body: '{}'
@@ -693,7 +693,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Fri, 05 Apr 2024 19:23:46 GMT
+      - Fri, 05 Apr 2024 19:23:44 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/vpc_test.go
+++ b/test/integration/vpc_test.go
@@ -230,12 +230,41 @@ func TestVPC_Update_Invalid_data(t *testing.T) {
 	}
 }
 
+func TestVPC_ListAllIPAddresses(t *testing.T) {
+	client, _, _, instance, config, teardown := setupInstanceWithVPCAndNATOneToOne(
+		t, "fixtures/TestVPC_ListAllIPAddresses",
+	)
+	defer teardown()
+
+	vpcIPs, err := client.ListAllVPCIPAddresses(
+		context.Background(),
+		linodego.NewListOptions(1, fmt.Sprintf("{\"linode_id\": %d}", instance.ID)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vpcIPs) == 0 {
+		t.Fatal("expecting 1 VPC IP address, but got 0")
+	}
+
+	if *vpcIPs[0].Address != config.Interfaces[0].IPv4.VPC {
+		t.Fatalf(
+			"expecting VPC IP address on Linode %d to be %q, but got %q",
+			instance.ID, *vpcIPs[0].Address, config.Interfaces[0].IPv4.VPC,
+		)
+	}
+}
+
 func TestVPC_ListIPAddresses(t *testing.T) {
-	client, _, _, instance, config, teardown := setupInstanceWithVPCAndNATOneToOne(t, "fixtures/TestVPC_ListIPAddresses")
+	client, vpc, _, instance, config, teardown := setupInstanceWithVPCAndNATOneToOne(
+		t, "fixtures/TestVPC_ListIPAddresses",
+	)
 	defer teardown()
 
 	vpcIPs, err := client.ListVPCIPAddresses(
 		context.Background(),
+		vpc.ID,
 		linodego.NewListOptions(1, fmt.Sprintf("{\"linode_id\": %d}", instance.ID)),
 	)
 	if err != nil {

--- a/vpc_ips.go
+++ b/vpc_ips.go
@@ -2,9 +2,19 @@ package linodego
 
 import (
 	"context"
+	"fmt"
 )
 
-// ListVPCIPAddresses gets the list of all IP addresses of all VPCs in the Linode account.
-func (c *Client) ListVPCIPAddresses(ctx context.Context, opts *ListOptions) ([]VPCIP, error) {
+// ListAllVPCIPAddresses gets the list of all IP addresses of all VPCs in the Linode account.
+func (c *Client) ListAllVPCIPAddresses(
+	ctx context.Context, opts *ListOptions,
+) ([]VPCIP, error) {
 	return getPaginatedResults[VPCIP](ctx, c, "vpcs/ips", opts)
+}
+
+// ListVPCIPAddresses gets the list of all IP addresses of a specific VPC.
+func (c *Client) ListVPCIPAddresses(
+	ctx context.Context, vpcID int, opts *ListOptions,
+) ([]VPCIP, error) {
+	return getPaginatedResults[VPCIP](ctx, c, fmt.Sprintf("vpcs/%d/ips", vpcID), opts)
 }


### PR DESCRIPTION
## 📝 Description

closes #483

- Rename existing `ListVPCIPAddresses` function to `ListAllVPCIPAddresses`.
- Create a new `ListVPCIPAddresses` function to call `/v4/vpcs/:id/ips` API endpoint.
- Remove deprecated linters and update linter config

## ✔️ How to Test
```bash
make ARGS="-run TestVPC_List" fixtures
```

```go
import (
	"context"
	"encoding/json"
	"fmt"
	"os"

	"github.com/linode/linodego"
)

func main() {
	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))
	ctx := context.Background()
	region := "us-mia"
	vpc, err := client.CreateVPC(
		ctx, linodego.VPCCreateOptions{
			Label:  "test-vpc-ips",
			Region: region,
			Subnets: []linodego.VPCSubnetCreateOptions{
				{
					Label: "test-vpc-ips-subnet",
					IPv4:  "10.0.0.0/24",
				},
			},
		},
	)
	if err != nil {
		panic(err)
	}

	anyNAT11 := "any"
	instance, err := client.CreateInstance(
		ctx, linodego.InstanceCreateOptions{
			Region:   region,
			Image:    "linode/ubuntu22.04",
			Type:     "g6-nanode-1",
			RootPass: "this-is-an-UNSAFE-password",
			Interfaces: []linodego.InstanceConfigInterfaceCreateOptions{
				{
					Purpose:  linodego.InterfacePurposeVPC,
					SubnetID: &vpc.Subnets[0].ID,
					IPv4: &linodego.VPCIPv4{
						NAT1To1: &anyNAT11,
					},
				},
			},
		},
	)
	if err != nil {
		panic(err)
	}

	VPCAllIPs, err := client.ListAllVPCIPAddresses(ctx, linodego.NewListOptions(0, ""))
	if err != nil {
		panic(err)
	}

	VPCIPs, err := client.ListVPCIPAddresses(ctx, vpc.ID, linodego.NewListOptions(0, ""))
	if err != nil {
		panic(err)
	}

	VPCAllIPsJson, err := json.Marshal(VPCAllIPs)
	if err != nil {
		panic(err)
	}

	VPCIPsJson, err := json.Marshal(VPCIPs)
	if err != nil {
		panic(err)
	}

	fmt.Println(string(VPCAllIPsJson))
	fmt.Println(string(VPCIPsJson))

	client.DeleteInstance(ctx, instance.ID)
	client.DeleteVPC(ctx, vpc.ID)
}

```
