### PR TITLE
new: Add support for VM Placement

### DIFF
--- a/instances.go
+++ b/instances.go
@@ -43,25 +43,26 @@ const (
 
 // Instance represents a linode object
 type Instance struct {
-	ID              int             `json:"id"`
-	Created         *time.Time      `json:"-"`
-	Updated         *time.Time      `json:"-"`
-	Region          string          `json:"region"`
-	Alerts          *InstanceAlert  `json:"alerts"`
-	Backups         *InstanceBackup `json:"backups"`
-	Image           string          `json:"image"`
-	Group           string          `json:"group"`
-	IPv4            []*net.IP       `json:"ipv4"`
-	IPv6            string          `json:"ipv6"`
-	Label           string          `json:"label"`
-	Type            string          `json:"type"`
-	Status          InstanceStatus  `json:"status"`
-	HasUserData     bool            `json:"has_user_data"`
-	Hypervisor      string          `json:"hypervisor"`
-	HostUUID        string          `json:"host_uuid"`
-	Specs           *InstanceSpec   `json:"specs"`
-	WatchdogEnabled bool            `json:"watchdog_enabled"`
-	Tags            []string        `json:"tags"`
+	ID              int                     `json:"id"`
+	Created         *time.Time              `json:"-"`
+	Updated         *time.Time              `json:"-"`
+	Region          string                  `json:"region"`
+	Alerts          *InstanceAlert          `json:"alerts"`
+	Backups         *InstanceBackup         `json:"backups"`
+	Image           string                  `json:"image"`
+	Group           string                  `json:"group"`
+	IPv4            []*net.IP               `json:"ipv4"`
+	IPv6            string                  `json:"ipv6"`
+	Label           string                  `json:"label"`
+	Type            string                  `json:"type"`
+	Status          InstanceStatus          `json:"status"`
+	HasUserData     bool                    `json:"has_user_data"`
+	Hypervisor      string                  `json:"hypervisor"`
+	HostUUID        string                  `json:"host_uuid"`
+	Specs           *InstanceSpec           `json:"specs"`
+	WatchdogEnabled bool                    `json:"watchdog_enabled"`
+	Tags            []string                `json:"tags"`
+	PlacementGroup  *InstancePlacementGroup `json:"placement_group"`
 }
 
 // InstanceSpec represents a linode spec
@@ -104,6 +105,15 @@ type InstanceTransfer struct {
 	Quota int `json:"quota"`
 }
 
+// InstancePlacementGroup represents information about the placement group
+// this Linode is a part of.
+type InstancePlacementGroup struct {
+	ID           int                        `json:"id"`
+	Label        string                     `json:"label"`
+	AffinityType PlacementGroupAffinityType `json:"affinity_type"`
+	IsStrict     bool                       `json:"is_strict"`
+}
+
 // InstanceMetadataOptions specifies various Instance creation fields
 // that relate to the Linode Metadata service.
 type InstanceMetadataOptions struct {
@@ -129,6 +139,7 @@ type InstanceCreateOptions struct {
 	Tags            []string                               `json:"tags,omitempty"`
 	Metadata        *InstanceMetadataOptions               `json:"metadata,omitempty"`
 	FirewallID      int                                    `json:"firewall_id,omitempty"`
+	PlacementGroup  *InstanceCreatePlacementGroupOptions   `json:"placement_group,omitempty"`
 
 	// Creation fields that need to be set explicitly false, "", or 0 use pointers
 	SwapSize *int  `json:"swap_size,omitempty"`
@@ -136,6 +147,13 @@ type InstanceCreateOptions struct {
 
 	// Deprecated: group is a deprecated property denoting a group label for the Linode.
 	Group string `json:"group,omitempty"`
+}
+
+// InstanceCreatePlacementGroupOptions represents the placement group
+// to create this Linode under.
+type InstanceCreatePlacementGroupOptions struct {
+	ID            int   `json:"id"`
+	CompliantOnly *bool `json:"compliant_only,omitempty"`
 }
 
 // InstanceUpdateOptions is an options struct used when Updating an Instance
@@ -190,13 +208,14 @@ type InstanceCloneOptions struct {
 	Type   string `json:"type,omitempty"`
 
 	// LinodeID is an optional existing instance to use as the target of the clone
-	LinodeID       int                      `json:"linode_id,omitempty"`
-	Label          string                   `json:"label,omitempty"`
-	BackupsEnabled bool                     `json:"backups_enabled"`
-	Disks          []int                    `json:"disks,omitempty"`
-	Configs        []int                    `json:"configs,omitempty"`
-	PrivateIP      bool                     `json:"private_ip,omitempty"`
-	Metadata       *InstanceMetadataOptions `json:"metadata,omitempty"`
+	LinodeID       int                                  `json:"linode_id,omitempty"`
+	Label          string                               `json:"label,omitempty"`
+	BackupsEnabled bool                                 `json:"backups_enabled"`
+	Disks          []int                                `json:"disks,omitempty"`
+	Configs        []int                                `json:"configs,omitempty"`
+	PrivateIP      bool                                 `json:"private_ip,omitempty"`
+	Metadata       *InstanceMetadataOptions             `json:"metadata,omitempty"`
+	PlacementGroup *InstanceCreatePlacementGroupOptions `json:"placement_group,omitempty"`
 
 	// Deprecated: group is a deprecated property denoting a group label for the Linode.
 	Group string `json:"group,omitempty"`
@@ -211,10 +230,12 @@ type InstanceResizeOptions struct {
 	AllowAutoDiskResize *bool `json:"allow_auto_disk_resize,omitempty"`
 }
 
-// InstanceResizeOptions is an options struct used when resizing an instance
+// InstanceMigrateOptions is an options struct used when migrating an instance
 type InstanceMigrateOptions struct {
 	Type   InstanceMigrationType `json:"type,omitempty"`
 	Region string                `json:"region,omitempty"`
+
+	PlacementGroup *InstanceCreatePlacementGroupOptions `json:"placement_group,omitempty"`
 }
 
 // InstancesPagedResponse represents a linode API response for listing

--- a/placement_groups.go
+++ b/placement_groups.go
@@ -25,6 +25,7 @@ type PlacementGroup struct {
 	AffinityType PlacementGroupAffinityType `json:"affinity_type"`
 	IsCompliant  bool                       `json:"is_compliant"`
 	IsStrict     bool                       `json:"is_strict"`
+	Members      []PlacementGroupMember     `json:"members"`
 }
 
 // PlacementGroupCreateOptions represents the options to use
@@ -133,7 +134,7 @@ func (c *Client) UnAssignPlacementGroupLinodes(
 	return doPOSTRequest[PlacementGroup](
 		ctx,
 		c,
-		formatAPIPath("placement/groups/%d/assign", id),
+		formatAPIPath("placement/groups/%d/unassign", id),
 		options,
 	)
 }

--- a/placement_groups.go
+++ b/placement_groups.go
@@ -1,0 +1,151 @@
+package linodego
+
+import "context"
+
+// PlacementGroupAffinityType is an enum that determines the affinity policy
+// for Linodes in a placement group.
+type PlacementGroupAffinityType string
+
+const (
+	AffinityTypeAntiAffinityLocal PlacementGroupAffinityType = "anti_affinity:local"
+)
+
+// PlacementGroupMember represents a single Linode assigned to a
+// placement group.
+type PlacementGroupMember struct {
+	LinodeID    int  `json:"linode_id"`
+	IsCompliant bool `json:"is_compliant"`
+}
+
+// PlacementGroup represents a Linode placement group.
+type PlacementGroup struct {
+	ID           int                        `json:"id"`
+	Label        string                     `json:"label"`
+	Region       string                     `json:"region"`
+	AffinityType PlacementGroupAffinityType `json:"affinity_type"`
+	IsCompliant  bool                       `json:"is_compliant"`
+	IsStrict     bool                       `json:"is_strict"`
+}
+
+// PlacementGroupCreateOptions represents the options to use
+// when creating a placement group.
+type PlacementGroupCreateOptions struct {
+	Label        string                     `json:"label"`
+	Region       string                     `json:"region"`
+	AffinityType PlacementGroupAffinityType `json:"affinity_type"`
+	IsStrict     bool                       `json:"is_strict"`
+}
+
+// PlacementGroupUpdateOptions represents the options to use
+// when updating a placement group.
+type PlacementGroupUpdateOptions struct {
+	Label string `json:"label,omitempty"`
+}
+
+// PlacementGroupAssignOptions represents options used when
+// assigning Linodes to a placement group.
+type PlacementGroupAssignOptions struct {
+	Linodes       []int `json:"linodes"`
+	CompliantOnly bool  `json:"compliant_only,omitempty"`
+}
+
+// PlacementGroupUnAssignOptions represents options used when
+// unassigning Linodes from a placement group.
+type PlacementGroupUnAssignOptions struct {
+	Linodes []int `json:"linodes"`
+}
+
+// ListPlacementGroups lists placement groups under the current account
+// matching the given list options.
+func (c *Client) ListPlacementGroups(
+	ctx context.Context,
+	options *ListOptions,
+) ([]PlacementGroup, error) {
+	return getPaginatedResults[PlacementGroup](
+		ctx,
+		c,
+		"placement/groups",
+		options,
+	)
+}
+
+// GetPlacementGroup gets a placement group with the specified ID.
+func (c *Client) GetPlacementGroup(
+	ctx context.Context,
+	id int,
+) (*PlacementGroup, error) {
+	return doGETRequest[PlacementGroup](
+		ctx,
+		c,
+		formatAPIPath("placement/groups/%d", id),
+	)
+}
+
+// CreatePlacementGroup creates a placement group with the specified options.
+func (c *Client) CreatePlacementGroup(
+	ctx context.Context,
+	options PlacementGroupCreateOptions,
+) (*PlacementGroup, error) {
+	return doPOSTRequest[PlacementGroup](
+		ctx,
+		c,
+		"placement/groups",
+		options,
+	)
+}
+
+// UpdatePlacementGroup updates a placement group with the specified ID using the provided options.
+func (c *Client) UpdatePlacementGroup(
+	ctx context.Context,
+	id int,
+	options PlacementGroupUpdateOptions,
+) (*PlacementGroup, error) {
+	return doPUTRequest[PlacementGroup](
+		ctx,
+		c,
+		formatAPIPath("placement/groups/%d", id),
+		options,
+	)
+}
+
+// AssignPlacementGroupLinodes assigns the specified Linodes to the given
+// placement group.
+func (c *Client) AssignPlacementGroupLinodes(
+	ctx context.Context,
+	id int,
+	options PlacementGroupAssignOptions,
+) (*PlacementGroup, error) {
+	return doPOSTRequest[PlacementGroup](
+		ctx,
+		c,
+		formatAPIPath("placement/groups/%d/assign", id),
+		options,
+	)
+}
+
+// UnAssignPlacementGroupLinodes un-assigns the specified Linodes from the given
+// placement group.
+func (c *Client) UnAssignPlacementGroupLinodes(
+	ctx context.Context,
+	id int,
+	options PlacementGroupUnAssignOptions,
+) (*PlacementGroup, error) {
+	return doPOSTRequest[PlacementGroup](
+		ctx,
+		c,
+		formatAPIPath("placement/groups/%d/assign", id),
+		options,
+	)
+}
+
+// DeletePlacementGroup deletes a placement group with the specified ID.
+func (c *Client) DeletePlacementGroup(
+	ctx context.Context,
+	id int,
+) error {
+	return doDELETERequest(
+		ctx,
+		c,
+		formatAPIPath("placement/groups/%d", id),
+	)
+}

--- a/placement_groups.go
+++ b/placement_groups.go
@@ -46,7 +46,7 @@ type PlacementGroupUpdateOptions struct {
 // assigning Linodes to a placement group.
 type PlacementGroupAssignOptions struct {
 	Linodes       []int `json:"linodes"`
-	CompliantOnly bool  `json:"compliant_only,omitempty"`
+	CompliantOnly *bool `json:"compliant_only,omitempty"`
 }
 
 // PlacementGroupUnAssignOptions represents options used when

--- a/regions.go
+++ b/regions.go
@@ -15,19 +15,28 @@ var cacheExpiryTime = time.Minute
 
 // Region represents a linode region object
 type Region struct {
-	ID           string          `json:"id"`
-	Country      string          `json:"country"`
-	Capabilities []string        `json:"capabilities"`
-	Status       string          `json:"status"`
-	Resolvers    RegionResolvers `json:"resolvers"`
-	Label        string          `json:"label"`
-	SiteType     string          `json:"site_type"`
+	ID           string   `json:"id"`
+	Country      string   `json:"country"`
+	Capabilities []string `json:"capabilities"`
+	Status       string   `json:"status"`
+	Label        string   `json:"label"`
+	SiteType     string   `json:"site_type"`
+
+	Resolvers            RegionResolvers            `json:"resolvers"`
+	PlacementGroupLimits RegionPlacementGroupLimits `json:"placement_group_limits"`
 }
 
 // RegionResolvers contains the DNS resolvers of a region
 type RegionResolvers struct {
 	IPv4 string `json:"ipv4"`
 	IPv6 string `json:"ipv6"`
+}
+
+// RegionPlacementGroupLimits contains information about the
+// placement group limits for the current user in the current region.
+type RegionPlacementGroupLimits struct {
+	MaximumPGsPerCustomer int `json:"maximum_pgs_per_customer"`
+	MaximumLinodesPerPG   int `json:"maximum_linodes_per_pg"`
 }
 
 // RegionsPagedResponse represents a linode API response for listing

--- a/regions.go
+++ b/regions.go
@@ -22,8 +22,8 @@ type Region struct {
 	Label        string   `json:"label"`
 	SiteType     string   `json:"site_type"`
 
-	Resolvers            RegionResolvers            `json:"resolvers"`
-	PlacementGroupLimits RegionPlacementGroupLimits `json:"placement_group_limits"`
+	Resolvers            RegionResolvers             `json:"resolvers"`
+	PlacementGroupLimits *RegionPlacementGroupLimits `json:"placement_group_limits"`
 }
 
 // RegionResolvers contains the DNS resolvers of a region

--- a/test/go.mod
+++ b/test/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/linode/linodego v1.30.0
 	github.com/linode/linodego/k8s v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/net v0.24.0
 	golang.org/x/oauth2 v0.19.0
 	k8s.io/client-go v0.28.8
@@ -31,6 +32,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 	golang.org/x/term v0.19.0 // indirect

--- a/test/integration/fixtures/TestInstance_withPG.yaml
+++ b/test/integration/fixtures/TestInstance_withPG.yaml
@@ -119,7 +119,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-1712862362503240000","region":"eu-west","affinity_type":"anti_affinity:local","is_strict":false}'
+    body: '{"label":"linodego-test-1712862693761548000","region":"eu-west","affinity_type":"anti_affinity:local","is_strict":false}'
     form: {}
     headers:
       Accept:
@@ -131,7 +131,7 @@ interactions:
     url: https://api.linode.com/v4beta/placement/groups
     method: POST
   response:
-    body: '{"id": 351, "label": "linodego-test-1712862362503240000", "region": "eu-west",
+    body: '{"id": 356, "label": "linodego-test-1712862693761548000", "region": "eu-west",
       "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
       true, "members": []}'
     headers:
@@ -178,7 +178,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-1712862362503240000-updated"}'
+    body: '{"region":"eu-west","type":"g6-nanode-1","label":"go-test-ins-g14gx0ib8h49","root_pass":"h4#|k51Ic\u003cdoX\u00262W59A!fF8N.|}n:5}Yt=s\u003e0yJ\\D/6M8gc/~6PHGYG09nEd4kh5","image":"linode/debian9","placement_group":{"id":356},"booted":false}'
     form: {}
     headers:
       Accept:
@@ -187,12 +187,20 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/placement/groups/351
-    method: PUT
+    url: https://api.linode.com/v4beta/linode/instances
+    method: POST
   response:
-    body: '{"id": 351, "label": "linodego-test-1712862362503240000-updated", "region":
-      "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
-      true, "members": []}'
+    body: '{"id": 25124077, "label": "go-test-ins-g14gx0ib8h49", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["139.144.245.159"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "eu-west", "specs": {"disk": 25600, "memory":
+      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
+      "e7dea8a2851fa88da8866ef434a553491200ea8c", "has_user_data": false, "placement_group":
+      {"id": 356, "label": "linodego-test-1712862693761548000", "affinity_type": "anti_affinity:local",
+      "is_strict": false}}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -209,7 +217,64 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "183"
+      - "881"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "10"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25124077
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -246,131 +311,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/placement/groups/351
-    method: GET
-  response:
-    body: '{"id": 351, "label": "linodego-test-1712862362503240000-updated", "region":
-      "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
-      true, "members": []}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "183"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"id": 351}'
-    url: https://api.linode.com/v4beta/placement/groups?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 351, "label": "linodego-test-1712862362503240000-updated",
-      "region": "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false,
-      "is_compliant": true, "members": []}], "page": 1, "pages": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "232"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/placement/groups/351
+    url: https://api.linode.com/v4beta/placement/groups/356
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestPlacementGroup_assignment.yaml
+++ b/test/integration/fixtures/TestPlacementGroup_assignment.yaml
@@ -119,7 +119,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-1712862362503240000","region":"eu-west","affinity_type":"anti_affinity:local","is_strict":false}'
+    body: '{"label":"linodego-test-1712862497480882000","region":"eu-west","affinity_type":"anti_affinity:local","is_strict":false}'
     form: {}
     headers:
       Accept:
@@ -131,7 +131,7 @@ interactions:
     url: https://api.linode.com/v4beta/placement/groups
     method: POST
   response:
-    body: '{"id": 351, "label": "linodego-test-1712862362503240000", "region": "eu-west",
+    body: '{"id": 355, "label": "linodego-test-1712862497480882000", "region": "eu-west",
       "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
       true, "members": []}'
     headers:
@@ -178,7 +178,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-1712862362503240000-updated"}'
+    body: '{"region":"eu-west","type":"g6-nanode-1","label":"go-test-ins-z63p4b2z8w8t","root_pass":"$j?W`mM=o6$2026T7;\u003e`Dr*X+XR81FCwIX8crCl7nma]7i=@\u0026riC4FN8146\u003eQv\u003ey","image":"linode/debian9","booted":false}'
     form: {}
     headers:
       Accept:
@@ -187,12 +187,19 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/placement/groups/351
-    method: PUT
+    url: https://api.linode.com/v4beta/linode/instances
+    method: POST
   response:
-    body: '{"id": 351, "label": "linodego-test-1712862362503240000-updated", "region":
-      "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
-      true, "members": []}'
+    body: '{"id": 25124076, "label": "go-test-ins-z63p4b2z8w8t", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["139.144.245.158"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "eu-west", "specs": {"disk": 25600, "memory":
+      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
+      "e7dea8a2851fa88da8866ef434a553491200ea8c", "has_user_data": false, "placement_group":
+      null}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -209,7 +216,66 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "183"
+      - "768"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "10"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"linodes":[25124076]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/placement/groups/355/assign
+    method: POST
+  response:
+    body: '{"id": 355, "label": "linodego-test-1712862497480882000", "region": "eu-west",
+      "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
+      true, "members": [{"linode_id": 25124076, "is_compliant": true}]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "220"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -246,11 +312,80 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/placement/groups/351
+    url: https://api.linode.com/v4beta/linode/instances/25124076
     method: GET
   response:
-    body: '{"id": 351, "label": "linodego-test-1712862362503240000-updated", "region":
-      "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
+    body: '{"id": 25124076, "label": "go-test-ins-z63p4b2z8w8t", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["139.144.245.158"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "eu-west", "specs": {"disk": 25600, "memory":
+      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
+      "e7dea8a2851fa88da8866ef434a553491200ea8c", "has_user_data": false, "placement_group":
+      {"id": 355, "label": "linodego-test-1712862497480882000", "affinity_type": "anti_affinity:local",
+      "is_strict": false}}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "881"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"linodes":[25124076]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/placement/groups/355/unassign
+    method: POST
+  response:
+    body: '{"id": 355, "label": "linodego-test-1712862497480882000", "region": "eu-west",
+      "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
       true, "members": []}'
     headers:
       Access-Control-Allow-Credentials:
@@ -264,12 +399,11 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
       Connection:
       - keep-alive
       Content-Length:
-      - "183"
+      - "175"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -280,9 +414,8 @@ interactions:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
-      - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
-      - linodes:read_only
+      - linodes:read_write
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -307,70 +440,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-      X-Filter:
-      - '{"id": 351}'
-    url: https://api.linode.com/v4beta/placement/groups?page=1
-    method: GET
-  response:
-    body: '{"data": [{"id": 351, "label": "linodego-test-1712862362503240000-updated",
-      "region": "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false,
-      "is_compliant": true, "members": []}], "page": 1, "pages": 1, "results": 1}'
-    headers:
-      Access-Control-Allow-Credentials:
-      - "true"
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
-      Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - keep-alive
-      Content-Length:
-      - "232"
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=31536000
-      Vary:
-      - Authorization, X-Filter
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - linodes:read_only
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "400"
-      X-Xss-Protection:
-      - 1; mode=block
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/placement/groups/351
+    url: https://api.linode.com/v4beta/placement/groups/355
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestPlacementGroup_basic.yaml
+++ b/test/integration/fixtures/TestPlacementGroup_basic.yaml
@@ -11,66 +11,66 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/regions
+    url: https://api.linode.com/v4beta/regions
     method: GET
   response:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
       "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
       Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "2400:8904::f03c:91ff:fea5:659,2400:8904::f03c:91ff:fea5:9282,2400:8904::f03c:91ff:fea5:b9b3,2400:8904::f03c:91ff:fea5:925a,2400:8904::f03c:91ff:fea5:22cb,2400:8904::f03c:91ff:fea5:227a,2400:8904::f03c:91ff:fea5:924c,2400:8904::f03c:91ff:fea5:f7e2,2400:8904::f03c:91ff:fea5:2205,2400:8904::f03c:91ff:fea5:9207"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
       "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
       "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "2600:3c04::f03c:91ff:fea9:f63,2600:3c04::f03c:91ff:fea9:f6d,2600:3c04::f03c:91ff:fea9:f80,2600:3c04::f03c:91ff:fea9:f0f,2600:3c04::f03c:91ff:fea9:f99,2600:3c04::f03c:91ff:fea9:fbd,2600:3c04::f03c:91ff:fea9:fdd,2600:3c04::f03c:91ff:fea9:fe2,2600:3c04::f03c:91ff:fea9:f68,2600:3c04::f03c:91ff:fea9:f4a"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
       "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
       "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "2400:8907::f03c:92ff:fe6e:ec8,2400:8907::f03c:92ff:fe6e:98e4,2400:8907::f03c:92ff:fe6e:1c58,2400:8907::f03c:92ff:fe6e:c299,2400:8907::f03c:92ff:fe6e:c210,2400:8907::f03c:92ff:fe6e:c219,2400:8907::f03c:92ff:fe6e:1c5c,2400:8907::f03c:92ff:fe6e:c24e,2400:8907::f03c:92ff:fe6e:e6b,2400:8907::f03c:92ff:fe6e:e3d"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
       "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "2600:3c00::2,2600:3c00::9,2600:3c00::7,2600:3c00::5,2600:3c00::3,2600:3c00::8,2600:3c00::6,2600:3c00::4,2600:3c00::c,2600:3c00::b"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
       "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
       "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "2600:3c01::2,2600:3c01::9,2600:3c01::5,2600:3c01::7,2600:3c01::3,2600:3c01::8,2600:3c01::4,2600:3c01::b,2600:3c01::c,2600:3c01::6"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
       "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
       Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "2600:3c02::3,2600:3c02::5,2600:3c02::4,2600:3c02::6,2600:3c02::c,2600:3c02::7,2600:3c02::2,2600:3c02::9,2600:3c02::8,2600:3c02::b"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
       "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Block Storage",
       "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Bare Metal",
       "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases", "Metadata"],
       "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "2600:3c03::7,2600:3c03::4,2600:3c03::9,2600:3c03::6,2600:3c03::3,2600:3c03::c,2600:3c03::5,2600:3c03::b,2600:3c03::2,2600:3c03::8"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
       "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
       Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
       "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "2a01:7e00::9,2a01:7e00::3,2a01:7e00::c,2a01:7e00::5,2a01:7e00::6,2a01:7e00::8,2a01:7e00::b,2a01:7e00::4,2a01:7e00::7,2a01:7e00::2"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
       "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "2400:8901::5,2400:8901::4,2400:8901::b,2400:8901::3,2400:8901::9,2400:8901::2,2400:8901::8,2400:8901::7,2400:8901::c,2400:8901::6"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
       "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "2a01:7e01::5,2a01:7e01::9,2a01:7e01::7,2a01:7e01::c,2a01:7e01::2,2a01:7e01::4,2a01:7e01::3,2a01:7e01::6,2a01:7e01::b,2a01:7e01::8"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
       "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
       "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "2400:8902::3,2400:8902::6,2400:8902::c,2400:8902::4,2400:8902::2,2400:8902::8,2400:8902::7,2400:8902::5,2400:8902::b,2400:8902::9"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
       5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
@@ -119,7 +119,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-1712861143410536000","region":"eu-west","affinity_type":"anti_affinity:local","is_strict":false}'
+    body: '{"label":"linodego-test-1712861754851227000","region":"eu-west","affinity_type":"anti_affinity:local","is_strict":false}'
     form: {}
     headers:
       Accept:
@@ -128,10 +128,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/placement/groups
+    url: https://api.linode.com/v4beta/placement/groups
     method: POST
   response:
-    body: '{"id": 335, "label": "linodego-test-1712861143410536000", "region": "eu-west",
+    body: '{"id": 343, "label": "linodego-test-1712861754851227000", "region": "eu-west",
       "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
       true, "members": []}'
     headers:
@@ -178,7 +178,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"linodego-test-1712861143410536000-updated"}'
+    body: '{"label":"linodego-test-1712861754851227000-updated"}'
     form: {}
     headers:
       Accept:
@@ -187,10 +187,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/placement/groups/335
+    url: https://api.linode.com/v4beta/placement/groups/343
     method: PUT
   response:
-    body: '{"id": 335, "label": "linodego-test-1712861143410536000-updated", "region":
+    body: '{"id": 343, "label": "linodego-test-1712861754851227000-updated", "region":
       "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
       true, "members": []}'
     headers:
@@ -246,7 +246,131 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/placement/groups/335
+    url: https://api.linode.com/v4beta/placement/groups/343
+    method: GET
+  response:
+    body: '{"id": 343, "label": "linodego-test-1712861754851227000-updated", "region":
+      "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
+      true, "members": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "183"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"id": 343}'
+    url: https://api.linode.com/v4beta/placement/groups?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 343, "label": "linodego-test-1712861754851227000-updated",
+      "region": "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false,
+      "is_compliant": true, "members": []}], "page": 1, "pages": 1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "232"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/placement/groups/343
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestPlacementGroup_basic.yaml
+++ b/test/integration/fixtures/TestPlacementGroup_basic.yaml
@@ -1,0 +1,295 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/regions
+    method: GET
+  response:
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "2400:8904::f03c:91ff:fea5:659,2400:8904::f03c:91ff:fea5:9282,2400:8904::f03c:91ff:fea5:b9b3,2400:8904::f03c:91ff:fea5:925a,2400:8904::f03c:91ff:fea5:22cb,2400:8904::f03c:91ff:fea5:227a,2400:8904::f03c:91ff:fea5:924c,2400:8904::f03c:91ff:fea5:f7e2,2400:8904::f03c:91ff:fea5:2205,2400:8904::f03c:91ff:fea5:9207"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "2600:3c04::f03c:91ff:fea9:f63,2600:3c04::f03c:91ff:fea9:f6d,2600:3c04::f03c:91ff:fea9:f80,2600:3c04::f03c:91ff:fea9:f0f,2600:3c04::f03c:91ff:fea9:f99,2600:3c04::f03c:91ff:fea9:fbd,2600:3c04::f03c:91ff:fea9:fdd,2600:3c04::f03c:91ff:fea9:fe2,2600:3c04::f03c:91ff:fea9:f68,2600:3c04::f03c:91ff:fea9:f4a"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "2400:8907::f03c:92ff:fe6e:ec8,2400:8907::f03c:92ff:fe6e:98e4,2400:8907::f03c:92ff:fe6e:1c58,2400:8907::f03c:92ff:fe6e:c299,2400:8907::f03c:92ff:fe6e:c210,2400:8907::f03c:92ff:fe6e:c219,2400:8907::f03c:92ff:fe6e:1c5c,2400:8907::f03c:92ff:fe6e:c24e,2400:8907::f03c:92ff:fe6e:e6b,2400:8907::f03c:92ff:fe6e:e3d"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      "ipv6": "2600:3c00::2,2600:3c00::9,2600:3c00::7,2600:3c00::5,2600:3c00::3,2600:3c00::8,2600:3c00::6,2600:3c00::4,2600:3c00::c,2600:3c00::b"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "2600:3c01::2,2600:3c01::9,2600:3c01::5,2600:3c01::7,2600:3c01::3,2600:3c01::8,2600:3c01::4,2600:3c01::b,2600:3c01::c,2600:3c01::6"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "2600:3c02::3,2600:3c02::5,2600:3c02::4,2600:3c02::6,2600:3c02::c,2600:3c02::7,2600:3c02::2,2600:3c02::9,2600:3c02::8,2600:3c02::b"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Block Storage",
+      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Bare Metal",
+      "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases", "Metadata"],
+      "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "2600:3c03::7,2600:3c03::4,2600:3c03::9,2600:3c03::6,2600:3c03::3,2600:3c03::c,2600:3c03::5,2600:3c03::b,2600:3c03::2,2600:3c03::8"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "2a01:7e00::9,2a01:7e00::3,2a01:7e00::c,2a01:7e00::5,2a01:7e00::6,2a01:7e00::8,2a01:7e00::b,2a01:7e00::4,2a01:7e00::7,2a01:7e00::2"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "2400:8901::5,2400:8901::4,2400:8901::b,2400:8901::3,2400:8901::9,2400:8901::2,2400:8901::8,2400:8901::7,2400:8901::c,2400:8901::6"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "2a01:7e01::5,2a01:7e01::9,2a01:7e01::7,2a01:7e01::c,2a01:7e01::2,2a01:7e01::4,2a01:7e01::3,2a01:7e01::6,2a01:7e01::b,2a01:7e01::8"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "2400:8902::3,2400:8902::6,2400:8902::c,2400:8902::4,2400:8902::2,2400:8902::8,2400:8902::7,2400:8902::5,2400:8902::b,2400:8902::9"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=900
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7144"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"label":"linodego-test-1712861143410536000","region":"eu-west","affinity_type":"anti_affinity:local","is_strict":false}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/placement/groups
+    method: POST
+  response:
+    body: '{"id": 335, "label": "linodego-test-1712861143410536000", "region": "eu-west",
+      "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
+      true, "members": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "175"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"label":"linodego-test-1712861143410536000-updated"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/placement/groups/335
+    method: PUT
+  response:
+    body: '{"id": 335, "label": "linodego-test-1712861143410536000-updated", "region":
+      "eu-west", "affinity_type": "anti_affinity:local", "is_strict": false, "is_compliant":
+      true, "members": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "183"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/placement/groups/335
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/fixtures/TestRegions_pgLimits.yaml
+++ b/test/integration/fixtures/TestRegions_pgLimits.yaml
@@ -11,7 +11,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/regions
+    url: https://api.linode.com/v4beta/regions
     method: GET
   response:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",

--- a/test/integration/fixtures/TestRegions_pgLimits.yaml
+++ b/test/integration/fixtures/TestRegions_pgLimits.yaml
@@ -1,0 +1,120 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/regions
+    method: GET
+  response:
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Block Storage",
+      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Bare Metal",
+      "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases", "Metadata"],
+      "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 5, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=900
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7144"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/linode/linodego"
 )
 
@@ -473,6 +475,34 @@ func TestInstance_withMetadata(t *testing.T) {
 	if !inst.HasUserData {
 		t.Fatalf("expected instance.HasUserData to be true, got false")
 	}
+}
+
+func TestInstance_withPG(t *testing.T) {
+	client, clientTeardown := createTestClient(t, "fixtures/TestInstance_withPG")
+
+	pg, pgTeardown, err := createPlacementGroup(t, client)
+	require.NoError(t, err)
+
+	// Create an instance to assign to the PG
+	inst, err := createInstance(t, client, func(client *linodego.Client, options *linodego.InstanceCreateOptions) {
+		options.Region = pg.Region
+		options.PlacementGroup = &linodego.InstanceCreatePlacementGroupOptions{
+			ID: pg.ID,
+		}
+	})
+	require.NoError(t, err)
+
+	defer func() {
+		client.DeleteInstance(context.Background(), inst.ID)
+		pgTeardown()
+		clientTeardown()
+	}()
+
+	require.NotNil(t, inst.PlacementGroup)
+	require.Equal(t, inst.PlacementGroup.ID, pg.ID)
+	require.Equal(t, inst.PlacementGroup.Label, pg.Label)
+	require.Equal(t, inst.PlacementGroup.AffinityType, pg.AffinityType)
+	require.Equal(t, inst.PlacementGroup.IsStrict, pg.IsStrict)
 }
 
 func createInstance(t *testing.T, client *linodego.Client, modifiers ...instanceModifier) (*linodego.Instance, error) {

--- a/test/integration/placement_group_test.go
+++ b/test/integration/placement_group_test.go
@@ -1,0 +1,74 @@
+package integration
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/linode/linodego"
+)
+
+type placementGroupModifier func(*linodego.Client, *linodego.PlacementGroupCreateOptions)
+
+func TestPlacementGroup_basic(t *testing.T) {
+	client, clientTeardown := createTestClient(t, "fixtures/TestPlacementGroup_basic")
+
+	pg, pgTeardown, err := createPlacementGroup(t, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		pgTeardown()
+		clientTeardown()
+	}()
+
+	require.NotEqual(t, pg.ID, 0)
+	require.Contains(t, pg.Label, "linodego-test-")
+	require.NotEmpty(t, pg.Label)
+	require.Equal(t, pg.AffinityType, linodego.AffinityTypeAntiAffinityLocal)
+	require.Equal(t, pg.IsStrict, false)
+
+	pg, err = client.UpdatePlacementGroup(
+		context.Background(),
+		pg.ID,
+		linodego.PlacementGroupUpdateOptions{
+			Label: pg.Label + "-updated",
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, t, pg.Label, pg.Label+"-updated")
+}
+
+func createPlacementGroup(
+	t *testing.T,
+	client *linodego.Client,
+	pgModifier ...placementGroupModifier,
+) (*linodego.PlacementGroup, func(), error) {
+	t.Helper()
+	createOpts := linodego.PlacementGroupCreateOptions{
+		Label:        "linodego-test-" + getUniqueText(),
+		Region:       getRegionsWithCaps(t, client, []string{"Placement Group"})[0],
+		AffinityType: linodego.AffinityTypeAntiAffinityLocal,
+		IsStrict:     false,
+	}
+
+	for _, mod := range pgModifier {
+		mod(client, &createOpts)
+	}
+
+	pg, err := client.CreatePlacementGroup(context.Background(), createOpts)
+	if err != nil {
+		t.Fatalf("failed to create placement group: %s", err)
+	}
+
+	teardown := func() {
+		if err := client.DeletePlacementGroup(context.Background(), pg.ID); err != nil {
+			t.Errorf("failed to delete placement group: %s", err)
+		}
+	}
+	return pg, teardown, err
+}


### PR DESCRIPTION
## 📝 Description

This pull request adds support for the upcoming Placement Groups feature, including the following changes:

* New Endpoints:
    * POST `placement/groups`
    * GET `placement/groups`
    * GET `placement/groups/{pg_id}`
    * PUT `placement/groups/{pg_id}`
    * POST `placement/groups/{pg_id}/assign`
    * POST `placement/groups/{pg_id}/unassign`
    * DELETE `placement/groups/{pg_id}`
 
* Updated Endpoints:
    * GET `/linode/instances` & `/linode/instances/{linode_id}` - Updated to include PG info
    * POST `/linode/instances` - Updated to accept a PG to assign the Linode to on creation
    * POST `/linode/instances/{linode_id}/migrate` - Updated to accept a PG to assign the Linode to on creation
    * POST `/linode/instances/{linode_id}/clone` - Updated to accept a PG to assign the Linode to on creation
    * GET `/regions` & `/regions/{region_id}` - Updated to include PG limits

This pull request also contains the corresponding integration tests and fixtures for these changes.

## ✔️ How to Test

The following test steps assume you have pulled down this PR locally and have pointed your `LINODE_URL` and `LINODE_TOKEN` environment variables accordingly.

### Integration Testing

```
make ARGS="-run TestInstance" fixtures
make ARGS="-run TestPlacementGroup" fixtures
make ARGS="-run TestRegion" fixtures
```

### Manual Testing

1. In a linodego sandbox environment, run the following:

```go
package main

import (
	"context"
	"fmt"
	"log"
	"os"

	"github.com/linode/linodego"
)

const targetRegion = "eu-west"

func main() {
	ctx := context.Background()

	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))

	// Create a PG
	pg, err := client.CreatePlacementGroup(ctx, linodego.PlacementGroupCreateOptions{
		Label:        "test-pg",
		Region:       targetRegion,
		AffinityType: linodego.AffinityTypeAntiAffinityLocal,
		IsStrict:     true,
	})
	if err != nil {
		log.Fatal(err)
	}

	// Provision two instances assigned to the PG
	compliantOnly := true

	for i := 0; i < 2; i++ {
		_, err := client.CreateInstance(ctx, linodego.InstanceCreateOptions{
			Region: targetRegion,
			Type:   "g6-nanode-1",
			Label:  fmt.Sprintf("test-instance-%d", i),
			PlacementGroup: &linodego.InstanceCreatePlacementGroupOptions{
				ID:            pg.ID,
				CompliantOnly: &compliantOnly,
			},
		})
		if err != nil {
			log.Fatal(err)
		}
	}
}
```
2. Navigate to Cloud Manager and ensure a new Placement Group has been created with two instances assigned to it.
3. Modify this code with update logic, assignment logic, etc.
4. Re-run the file and ensure everything works as expected.

