### PR TITLE
new: Support `available` for AccountAvailability

### DIFF
--- a/account_availability.go
+++ b/account_availability.go
@@ -8,13 +8,16 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-// AccountAvailability returns the resources information in a region which are NOT available to an account.
+// AccountAvailability returns the resources availability in a region to an account.
 type AccountAvailability struct {
 	// region id
 	Region string `json:"region"`
 
 	// the unavailable resources in a region to the customer
 	Unavailable []string `json:"unavailable"`
+
+	// the available resources in a region to the customer
+	Available []string `json:"available"`
 }
 
 // AccountAvailabilityPagedResponse represents a paginated Account Availability API response
@@ -38,7 +41,7 @@ func (resp *AccountAvailabilityPagedResponse) castResult(r *resty.Request, e str
 	return castedRes.Pages, castedRes.Results, nil
 }
 
-// ListAccountAvailabilities lists all available regions and the resources which are NOT available to the account.
+// ListAccountAvailabilities lists all regions and the resource availabilities to the account.
 func (c *Client) ListAccountAvailabilities(ctx context.Context, opts *ListOptions) ([]AccountAvailability, error) {
 	response := AccountAvailabilityPagedResponse{}
 	err := c.listHelper(ctx, &response, opts)
@@ -48,7 +51,7 @@ func (c *Client) ListAccountAvailabilities(ctx context.Context, opts *ListOption
 	return response.Data, nil
 }
 
-// GetAccountAvailability gets the unavailable resources in a region to the customer.
+// GetAccountAvailability gets the resources availability in a region to the customer.
 func (c *Client) GetAccountAvailability(ctx context.Context, regionID string) (*AccountAvailability, error) {
 	req := c.R(ctx).SetResult(&AccountAvailability{})
 	regionID = url.PathEscape(regionID)

--- a/go.work.sum
+++ b/go.work.sum
@@ -206,13 +206,12 @@ golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.19.0/go.mod h1:2CuTdWZ7KHSQwUzKva0cbMg6q2DMI3Mmxp+gKJbskEk=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.126.0 h1:q4GJq+cAdMAC7XP7njvQ4tvohGLiSlytuL4BQxbIZ+o=
 google.golang.org/api v0.126.0/go.mod h1:mBwVAtz+87bEN6CbA1GtZPDOqY2R5ONPqJeIlvyo4Aw=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc h1:8DyZCyvI8mE1IdLy/60bS+52xfymkE72wv1asokgtao=
 google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:xZnkP7mREFX5MORlOPEzLMr+90PPZQ2QWzrVTWfAq64=
 google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc h1:kVKPf/IiYSBWEWtkIn6wZXwWGCnLKcC8oWfZvXjsGnM=

--- a/test/integration/fixtures/TestAccountAvailability_Get.yaml
+++ b/test/integration/fixtures/TestAccountAvailability_Get.yaml
@@ -14,7 +14,8 @@ interactions:
     url: https://api.linode.com/v4beta/account/availability/us-east
     method: GET
   response:
-    body: '{"region": "us-east", "unavailable": []}'
+    body: '{"region": "us-east", "available": ["Linodes", "NodeBalancers", "Block
+      Storage", "Kubernetes"], "unavailable": []}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -29,8 +30,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "40"
+      - "114"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -52,7 +55,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1200"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestAccountAvailability_Get.yaml
+++ b/test/integration/fixtures/TestAccountAvailability_Get.yaml
@@ -28,8 +28,7 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
       Content-Length:
@@ -38,8 +37,10 @@ interactions:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Tue, 16 Apr 2024 20:58:13 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -53,7 +54,10 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:

--- a/test/integration/fixtures/TestAccountAvailability_List.yaml
+++ b/test/integration/fixtures/TestAccountAvailability_List.yaml
@@ -14,13 +14,24 @@ interactions:
     url: https://api.linode.com/v4beta/account/availability
     method: GET
   response:
-    body: '{"data": [{"region": "ap-west", "unavailable": []}, {"region": "ca-central",
-      "unavailable": []}, {"region": "ap-southeast", "unavailable": []}, {"region":
-      "us-central", "unavailable": []}, {"region": "us-west", "unavailable": []},
-      {"region": "us-southeast", "unavailable": []}, {"region": "us-east", "unavailable":
-      []}, {"region": "eu-west", "unavailable": []}, {"region": "ap-south", "unavailable":
-      []}, {"region": "eu-central", "unavailable": []}, {"region": "ap-northeast",
-      "unavailable": []}], "page": 1, "pages": 1, "results": 11}'
+    body: '{"data": [{"region": "us-central", "available": ["Linodes", "NodeBalancers",
+      "Block Storage", "Kubernetes"], "unavailable": []}, {"region": "us-west", "available":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
+      []}, {"region": "us-southeast", "available": ["Linodes", "NodeBalancers", "Block
+      Storage", "Kubernetes"], "unavailable": []}, {"region": "us-east", "available":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
+      []}, {"region": "eu-west", "available": ["Linodes", "NodeBalancers", "Block
+      Storage", "Kubernetes"], "unavailable": []}, {"region": "ap-south", "available":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
+      []}, {"region": "eu-central", "available": ["Linodes", "NodeBalancers", "Block
+      Storage", "Kubernetes"], "unavailable": []}, {"region": "ap-northeast", "available":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
+      []}, {"region": "ap-west", "available": ["Linodes", "NodeBalancers", "Block
+      Storage", "Kubernetes"], "unavailable": []}, {"region": "ca-central", "available":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
+      []}, {"region": "ap-southeast", "available": ["Linodes", "NodeBalancers", "Block
+      Storage", "Kubernetes"], "unavailable": []}], "page": 1, "pages": 1, "results":
+      11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -35,6 +46,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "1349"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -44,7 +59,6 @@ interactions:
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
-      - Accept-Encoding
       - Authorization, X-Filter
       - Authorization, X-Filter
       X-Accepted-Oauth-Scopes:
@@ -57,7 +71,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1200"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestAccountAvailability_List.yaml
+++ b/test/integration/fixtures/TestAccountAvailability_List.yaml
@@ -30,8 +30,27 @@ interactions:
       Storage", "Kubernetes"], "unavailable": []}, {"region": "ca-central", "available":
       ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
       []}, {"region": "ap-southeast", "available": ["Linodes", "NodeBalancers", "Block
-      Storage", "Kubernetes"], "unavailable": []}], "page": 1, "pages": 1, "results":
-      11}'
+      Storage", "Kubernetes"], "unavailable": []}, {"region": "us-iad", "available":
+      ["Linodes", "NodeBalancers", "Block Storage"], "unavailable": ["Kubernetes"]},
+      {"region": "us-ord", "available": ["Linodes", "NodeBalancers", "Block Storage",
+      "Kubernetes"], "unavailable": []}, {"region": "fr-par", "available": ["Linodes",
+      "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable": []}, {"region":
+      "us-sea", "available": ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"],
+      "unavailable": []}, {"region": "br-gru", "available": ["Linodes", "NodeBalancers",
+      "Block Storage", "Kubernetes"], "unavailable": []}, {"region": "nl-ams", "available":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
+      []}, {"region": "se-sto", "available": ["Linodes", "NodeBalancers", "Block Storage",
+      "Kubernetes"], "unavailable": []}, {"region": "es-mad", "available": ["Linodes",
+      "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable": []}, {"region":
+      "in-maa", "available": ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"],
+      "unavailable": []}, {"region": "jp-osa", "available": ["Linodes", "NodeBalancers",
+      "Block Storage", "Kubernetes"], "unavailable": []}, {"region": "it-mil", "available":
+      ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable":
+      []}, {"region": "us-mia", "available": ["Linodes", "NodeBalancers", "Block Storage",
+      "Kubernetes"], "unavailable": []}, {"region": "id-cgk", "available": ["Linodes",
+      "NodeBalancers", "Block Storage", "Kubernetes"], "unavailable": []}, {"region":
+      "us-lax", "available": ["Linodes", "NodeBalancers", "Block Storage", "Kubernetes"],
+      "unavailable": []}], "page": 1, "pages": 1, "results": 25}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -44,23 +63,23 @@ interactions:
       Access-Control-Expose-Headers:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
-      - private, max-age=0, s-maxage=0, no-cache, no-store
-      - private, max-age=60, s-maxage=60
+      - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
-      Content-Length:
-      - "1349"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
-      Server:
-      - nginx
+      Expires:
+      - Tue, 16 Apr 2024 20:58:12 GMT
+      Pragma:
+      - no-cache
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - account:read_only
       X-Content-Type-Options:
@@ -69,7 +88,10 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:


### PR DESCRIPTION
## 📝 Description

AccountAvailability now returns both `available` and `unavailable` resources in a region. 

## ✔️ How to Test

`make testunit`
`make testint`

This change currently is only available in Alpha. The production release is scheduled in the next week.

To test against alpha, you'll need to set up the dev url and api token.

```
export LINODE_URL=https://api.dev.linode.com/
export LINODE_API_VERSION=v4beta
export LINODE_TOKEN=...
```

1. In a sandbox environment, run the following code block
```go
import (
	"context"
	"fmt"
	"os"

	"github.com/linode/linodego"
)

func main() {
	client := linodego.NewClient(nil)
	client.SetToken(os.Getenv("LINODE_TOKEN"))

	availabilities, err := client.ListAccountAvailabilities(context.Background(), &linodego.ListOptions{})
	if err != nil {
		panic(err)
	}

	if len(availabilities) > 0 {
		fmt.Printf("region: %v, available: %v, unavailable: %v \n", availabilities[0].Region, availabilities[0].Available, availabilities[0].Unavailable)

		availability, err := client.GetAccountAvailability(context.Background(), availabilities[0].Region)
		if err != nil {
			panic(err)
		}

		fmt.Printf("region: %v, available: %v, unavailable: %v", availability.Region, availability.Available, availability.Unavailable)
	}
}
```
2. Observe that no error is raised and the two availability info printed are identical. 