### PR TITLE
ref: Fix case in name for `Client.UnassignPlacementGroupLinodes(...)`

### DIFF
--- a/placement_groups.go
+++ b/placement_groups.go
@@ -124,9 +124,9 @@ func (c *Client) AssignPlacementGroupLinodes(
 	)
 }
 
-// UnAssignPlacementGroupLinodes un-assigns the specified Linodes from the given
+// UnassignPlacementGroupLinodes un-assigns the specified Linodes from the given
 // placement group.
-func (c *Client) UnAssignPlacementGroupLinodes(
+func (c *Client) UnassignPlacementGroupLinodes(
 	ctx context.Context,
 	id int,
 	options PlacementGroupUnAssignOptions,

--- a/test/integration/placement_group_test.go
+++ b/test/integration/placement_group_test.go
@@ -101,7 +101,7 @@ func TestPlacementGroup_assignment(t *testing.T) {
 	require.Equal(t, inst.PlacementGroup.AffinityType, pg.AffinityType)
 
 	// Ensure unassignment works as expected
-	pg, err = client.UnAssignPlacementGroupLinodes(
+	pg, err = client.UnassignPlacementGroupLinodes(
 		context.Background(),
 		pg.ID,
 		linodego.PlacementGroupUnAssignOptions{


### PR DESCRIPTION
## 📝 Description

This change resolves a small case issue in the name for the `Client.UnassignPlacementGroupLinodes(...)` method.

## ✔️ How to Test

N/A