### PR TITLE
Linode Disk Encryption Support

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -8,6 +8,7 @@ cloud.google.com/go/compute/metadata v0.2.0 h1:nBbNSZyDpkNlo3DepaaLKVuO7ClyifSAm
 cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
 cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 cloud.google.com/go/datastore v1.1.0 h1:/May9ojXjRkPBNVrq+oWLqmWCkr4OU5uRY29bu0mRyQ=
 cloud.google.com/go/pubsub v1.3.1 h1:ukjixP1wl0LpnZ6LWtZJ0mX5tBmjp1f8Sqer8Z2OMUU=
@@ -201,6 +202,7 @@ golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1m
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
+golang.org/x/crypto v0.23.0 h1:dIJU/v2J8Mdglj/8rJ6UUOM3Zc9zLZxVZwwxMooUSAI=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=
@@ -235,8 +237,6 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -12,13 +12,14 @@ import (
 
 // InstanceDisk represents an Instance Disk object
 type InstanceDisk struct {
-	ID         int            `json:"id"`
-	Label      string         `json:"label"`
-	Status     DiskStatus     `json:"status"`
-	Size       int            `json:"size"`
-	Filesystem DiskFilesystem `json:"filesystem"`
-	Created    *time.Time     `json:"-"`
-	Updated    *time.Time     `json:"-"`
+	ID             int                    `json:"id"`
+	Label          string                 `json:"label"`
+	Status         DiskStatus             `json:"status"`
+	Size           int                    `json:"size"`
+	Filesystem     DiskFilesystem         `json:"filesystem"`
+	Created        *time.Time             `json:"-"`
+	Updated        *time.Time             `json:"-"`
+	DiskEncryption InstanceDiskEncryption `json:"disk_encryption"`
 }
 
 // DiskFilesystem constants start with Filesystem and include Linode API Filesystems

--- a/instances.go
+++ b/instances.go
@@ -43,25 +43,26 @@ const (
 
 // Instance represents a linode object
 type Instance struct {
-	ID              int             `json:"id"`
-	Created         *time.Time      `json:"-"`
-	Updated         *time.Time      `json:"-"`
-	Region          string          `json:"region"`
-	Alerts          *InstanceAlert  `json:"alerts"`
-	Backups         *InstanceBackup `json:"backups"`
-	Image           string          `json:"image"`
-	Group           string          `json:"group"`
-	IPv4            []*net.IP       `json:"ipv4"`
-	IPv6            string          `json:"ipv6"`
-	Label           string          `json:"label"`
-	Type            string          `json:"type"`
-	Status          InstanceStatus  `json:"status"`
-	HasUserData     bool            `json:"has_user_data"`
-	Hypervisor      string          `json:"hypervisor"`
-	HostUUID        string          `json:"host_uuid"`
-	Specs           *InstanceSpec   `json:"specs"`
-	WatchdogEnabled bool            `json:"watchdog_enabled"`
-	Tags            []string        `json:"tags"`
+	ID              int                    `json:"id"`
+	Created         *time.Time             `json:"-"`
+	Updated         *time.Time             `json:"-"`
+	Region          string                 `json:"region"`
+	Alerts          *InstanceAlert         `json:"alerts"`
+	Backups         *InstanceBackup        `json:"backups"`
+	Image           string                 `json:"image"`
+	Group           string                 `json:"group"`
+	IPv4            []*net.IP              `json:"ipv4"`
+	IPv6            string                 `json:"ipv6"`
+	Label           string                 `json:"label"`
+	Type            string                 `json:"type"`
+	Status          InstanceStatus         `json:"status"`
+	HasUserData     bool                   `json:"has_user_data"`
+	Hypervisor      string                 `json:"hypervisor"`
+	HostUUID        string                 `json:"host_uuid"`
+	Specs           *InstanceSpec          `json:"specs"`
+	WatchdogEnabled bool                   `json:"watchdog_enabled"`
+	Tags            []string               `json:"tags"`
+	DiskEncryption  InstanceDiskEncryption `json:"disk_encryption"`
 }
 
 // InstanceSpec represents a linode spec
@@ -91,6 +92,13 @@ type InstanceBackup struct {
 		Window string `json:"window,omitempty"`
 	} `json:"schedule,omitempty"`
 }
+
+type InstanceDiskEncryption string
+
+const (
+	InstanceDiskEncryptionEnabled  InstanceDiskEncryption = "enabled"
+	InstanceDiskEncryptionDisabled InstanceDiskEncryption = "disabled"
+)
 
 // InstanceTransfer pool stats for a Linode Instance during the current billing month
 type InstanceTransfer struct {
@@ -129,6 +137,7 @@ type InstanceCreateOptions struct {
 	Tags            []string                               `json:"tags,omitempty"`
 	Metadata        *InstanceMetadataOptions               `json:"metadata,omitempty"`
 	FirewallID      int                                    `json:"firewall_id,omitempty"`
+	DiskEncryption  InstanceDiskEncryption                 `json:"disk_encryption"`
 
 	// Creation fields that need to be set explicitly false, "", or 0 use pointers
 	SwapSize *int  `json:"swap_size,omitempty"`

--- a/instances.go
+++ b/instances.go
@@ -138,7 +138,7 @@ type InstanceCreateOptions struct {
 	Tags            []string                               `json:"tags,omitempty"`
 	Metadata        *InstanceMetadataOptions               `json:"metadata,omitempty"`
 	FirewallID      int                                    `json:"firewall_id,omitempty"`
-	DiskEncryption  InstanceDiskEncryption                 `json:"disk_encryption"`
+	DiskEncryption  InstanceDiskEncryption                 `json:"disk_encryption,omitempty"`
 
 	// Creation fields that need to be set explicitly false, "", or 0 use pointers
 	SwapSize *int  `json:"swap_size,omitempty"`
@@ -387,6 +387,7 @@ type InstanceRebuildOptions struct {
 	Booted          *bool                    `json:"booted,omitempty"`
 	Metadata        *InstanceMetadataOptions `json:"metadata,omitempty"`
 	Type            string                   `json:"type,omitempty"`
+	DiskEncryption  InstanceDiskEncryption   `json:"disk_encryption,omitempty"`
 }
 
 // RebuildInstance Deletes all Disks and Configs on this Linode,

--- a/instances.go
+++ b/instances.go
@@ -63,6 +63,7 @@ type Instance struct {
 	WatchdogEnabled bool                   `json:"watchdog_enabled"`
 	Tags            []string               `json:"tags"`
 	DiskEncryption  InstanceDiskEncryption `json:"disk_encryption"`
+	LKEClusterID    int                    `json:"lke_cluster_id"`
 }
 
 // InstanceSpec represents a linode spec

--- a/k8s/pkg/condition/lke.go
+++ b/k8s/pkg/condition/lke.go
@@ -33,7 +33,7 @@ func ClusterHasReadyNode(ctx context.Context, options linodego.ClusterConditionO
 	return false, nil
 }
 
-// ClusterHasReadyNode is a ClusterConditionFunc which polls for at least one node to have the
+// ClusterNodesReady is a ClusterConditionFunc which polls for all nodes to have the
 // condition NodeReady=True.
 func ClusterNodesReady(ctx context.Context, options linodego.ClusterConditionOptions) (bool, error) {
 	clientset, err := k8s.BuildClientsetFromConfig(options.LKEClusterKubeconfig, options.TransportWrapper)

--- a/k8s/pkg/condition/lke.go
+++ b/k8s/pkg/condition/lke.go
@@ -33,9 +33,39 @@ func ClusterHasReadyNode(ctx context.Context, options linodego.ClusterConditionO
 	return false, nil
 }
 
+// ClusterHasReadyNode is a ClusterConditionFunc which polls for at least one node to have the
+// condition NodeReady=True.
+func ClusterNodesReady(ctx context.Context, options linodego.ClusterConditionOptions) (bool, error) {
+	clientset, err := k8s.BuildClientsetFromConfig(options.LKEClusterKubeconfig, options.TransportWrapper)
+	if err != nil {
+		return false, err
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, v1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get nodes for cluster: %w", err)
+	}
+
+	for _, node := range nodes.Items {
+		for _, condition := range node.Status.Conditions {
+			if condition.Type == corev1.NodeReady && condition.Status != corev1.ConditionTrue {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
 // WaitForLKEClusterReady polls with a given timeout for the LKE Cluster's api-server
 // to be healthy and for the cluster to have at least one node with the NodeReady
 // condition true.
 func WaitForLKEClusterReady(ctx context.Context, client linodego.Client, clusterID int, options linodego.LKEClusterPollOptions) error {
 	return client.WaitForLKEClusterConditions(ctx, clusterID, options, ClusterHasReadyNode)
+}
+
+// WaitForLKEClusterAndNodesReady polls with a given timeout for the LKE
+// Cluster's api-server to be healthy and for all cluster nodes to have the
+// NodeReady condition true.
+func WaitForLKEClusterAndNodesReady(ctx context.Context, client linodego.Client, clusterID int, options linodego.LKEClusterPollOptions) error {
+	return client.WaitForLKEClusterConditions(ctx, clusterID, options, ClusterNodesReady)
 }

--- a/lke_node_pools.go
+++ b/lke_node_pools.go
@@ -47,7 +47,8 @@ type LKENodePool struct {
 	Linodes []LKENodePoolLinode `json:"nodes"`
 	Tags    []string            `json:"tags"`
 
-	Autoscaler LKENodePoolAutoscaler `json:"autoscaler"`
+	Autoscaler     LKENodePoolAutoscaler  `json:"autoscaler"`
+	DiskEncryption InstanceDiskEncryption `json:"disk_encryption,omitempty"`
 }
 
 // LKENodePoolCreateOptions fields are those accepted by CreateLKENodePool

--- a/test/integration/fixtures/TestInstance_DiskEncryption.yaml
+++ b/test/integration/fixtures/TestInstance_DiskEncryption.yaml
@@ -11,7 +11,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/regions
+    url: https://api.linode.com/v4beta/regions
     method: GET
   response:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
@@ -131,7 +131,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/linode/instances
+    url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
     body: '{"id": 25161592, "label": "go-test-ins-72053mvwvvd0", "group": "", "status":
@@ -200,7 +200,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/linode/instances/25161592
+    url: https://api.linode.com/v4beta/linode/instances/25161592
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestInstance_DiskEncryption.yaml
+++ b/test/integration/fixtures/TestInstance_DiskEncryption.yaml
@@ -17,60 +17,60 @@ interactions:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
       "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
       Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "2400:8904::f03c:91ff:fea5:659,2400:8904::f03c:91ff:fea5:9282,2400:8904::f03c:91ff:fea5:b9b3,2400:8904::f03c:91ff:fea5:925a,2400:8904::f03c:91ff:fea5:22cb,2400:8904::f03c:91ff:fea5:227a,2400:8904::f03c:91ff:fea5:924c,2400:8904::f03c:91ff:fea5:f7e2,2400:8904::f03c:91ff:fea5:2205,2400:8904::f03c:91ff:fea5:9207"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
       "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
       "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "2600:3c04::f03c:91ff:fea9:f63,2600:3c04::f03c:91ff:fea9:f6d,2600:3c04::f03c:91ff:fea9:f80,2600:3c04::f03c:91ff:fea9:f0f,2600:3c04::f03c:91ff:fea9:f99,2600:3c04::f03c:91ff:fea9:fbd,2600:3c04::f03c:91ff:fea9:fdd,2600:3c04::f03c:91ff:fea9:fe2,2600:3c04::f03c:91ff:fea9:f68,2600:3c04::f03c:91ff:fea9:f4a"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
       "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
       "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "2400:8907::f03c:92ff:fe6e:ec8,2400:8907::f03c:92ff:fe6e:98e4,2400:8907::f03c:92ff:fe6e:1c58,2400:8907::f03c:92ff:fe6e:c299,2400:8907::f03c:92ff:fe6e:c210,2400:8907::f03c:92ff:fe6e:c219,2400:8907::f03c:92ff:fe6e:1c5c,2400:8907::f03c:92ff:fe6e:c24e,2400:8907::f03c:92ff:fe6e:e6b,2400:8907::f03c:92ff:fe6e:e3d"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
       "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "2600:3c00::2,2600:3c00::9,2600:3c00::7,2600:3c00::5,2600:3c00::3,2600:3c00::8,2600:3c00::6,2600:3c00::4,2600:3c00::c,2600:3c00::b"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
       "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
       "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "2600:3c01::2,2600:3c01::9,2600:3c01::5,2600:3c01::7,2600:3c01::3,2600:3c01::8,2600:3c01::4,2600:3c01::b,2600:3c01::c,2600:3c01::6"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
       "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
       Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "2600:3c02::3,2600:3c02::5,2600:3c02::4,2600:3c02::6,2600:3c02::c,2600:3c02::7,2600:3c02::2,2600:3c02::9,2600:3c02::8,2600:3c02::b"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
       "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
       "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
       "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "2600:3c03::7,2600:3c03::4,2600:3c03::9,2600:3c03::6,2600:3c03::3,2600:3c03::c,2600:3c03::5,2600:3c03::b,2600:3c03::2,2600:3c03::8"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
       "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
       Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
       "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "2a01:7e00::9,2a01:7e00::3,2a01:7e00::c,2a01:7e00::5,2a01:7e00::6,2a01:7e00::8,2a01:7e00::b,2a01:7e00::4,2a01:7e00::7,2a01:7e00::2"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
       "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "2400:8901::5,2400:8901::4,2400:8901::b,2400:8901::3,2400:8901::9,2400:8901::2,2400:8901::8,2400:8901::7,2400:8901::c,2400:8901::6"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
       "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "2a01:7e01::5,2a01:7e01::9,2a01:7e01::7,2a01:7e01::c,2a01:7e01::2,2a01:7e01::4,2a01:7e01::3,2a01:7e01::6,2a01:7e01::b,2a01:7e01::8"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
       "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
       "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "2400:8902::3,2400:8902::6,2400:8902::c,2400:8902::4,2400:8902::2,2400:8902::8,2400:8902::7,2400:8902::5,2400:8902::b,2400:8902::9"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
@@ -136,7 +136,7 @@ interactions:
   response:
     body: '{"id": 25161592, "label": "go-test-ins-72053mvwvvd0", "group": "", "status":
       "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["139.144.131.14"], "ipv6": "2600:3c03::f03d:00ff:fe04:e0a4/128",
+      "type": "g6-nanode-1", "ipv4": ["139.144.131.14"], "ipv6": "1234::5678/128",
       "image": "linode/debian9", "region": "us-east", "specs": {"disk": 25600, "memory":
       1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
       10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":

--- a/test/integration/fixtures/TestInstance_DiskEncryption.yaml
+++ b/test/integration/fixtures/TestInstance_DiskEncryption.yaml
@@ -1,0 +1,252 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/regions
+    method: GET
+  response:
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "2400:8904::f03c:91ff:fea5:659,2400:8904::f03c:91ff:fea5:9282,2400:8904::f03c:91ff:fea5:b9b3,2400:8904::f03c:91ff:fea5:925a,2400:8904::f03c:91ff:fea5:22cb,2400:8904::f03c:91ff:fea5:227a,2400:8904::f03c:91ff:fea5:924c,2400:8904::f03c:91ff:fea5:f7e2,2400:8904::f03c:91ff:fea5:2205,2400:8904::f03c:91ff:fea5:9207"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "2600:3c04::f03c:91ff:fea9:f63,2600:3c04::f03c:91ff:fea9:f6d,2600:3c04::f03c:91ff:fea9:f80,2600:3c04::f03c:91ff:fea9:f0f,2600:3c04::f03c:91ff:fea9:f99,2600:3c04::f03c:91ff:fea9:fbd,2600:3c04::f03c:91ff:fea9:fdd,2600:3c04::f03c:91ff:fea9:fe2,2600:3c04::f03c:91ff:fea9:f68,2600:3c04::f03c:91ff:fea9:f4a"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "2400:8907::f03c:92ff:fe6e:ec8,2400:8907::f03c:92ff:fe6e:98e4,2400:8907::f03c:92ff:fe6e:1c58,2400:8907::f03c:92ff:fe6e:c299,2400:8907::f03c:92ff:fe6e:c210,2400:8907::f03c:92ff:fe6e:c219,2400:8907::f03c:92ff:fe6e:1c5c,2400:8907::f03c:92ff:fe6e:c24e,2400:8907::f03c:92ff:fe6e:e6b,2400:8907::f03c:92ff:fe6e:e3d"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      "ipv6": "2600:3c00::2,2600:3c00::9,2600:3c00::7,2600:3c00::5,2600:3c00::3,2600:3c00::8,2600:3c00::6,2600:3c00::4,2600:3c00::c,2600:3c00::b"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "2600:3c01::2,2600:3c01::9,2600:3c01::5,2600:3c01::7,2600:3c01::3,2600:3c01::8,2600:3c01::4,2600:3c01::b,2600:3c01::c,2600:3c01::6"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "2600:3c02::3,2600:3c02::5,2600:3c02::4,2600:3c02::6,2600:3c02::c,2600:3c02::7,2600:3c02::2,2600:3c02::9,2600:3c02::8,2600:3c02::b"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "2600:3c03::7,2600:3c03::4,2600:3c03::9,2600:3c03::6,2600:3c03::3,2600:3c03::c,2600:3c03::5,2600:3c03::b,2600:3c03::2,2600:3c03::8"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "2a01:7e00::9,2a01:7e00::3,2a01:7e00::c,2a01:7e00::5,2a01:7e00::6,2a01:7e00::8,2a01:7e00::b,2a01:7e00::4,2a01:7e00::7,2a01:7e00::2"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "2400:8901::5,2400:8901::4,2400:8901::b,2400:8901::3,2400:8901::9,2400:8901::2,2400:8901::8,2400:8901::7,2400:8901::c,2400:8901::6"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "2a01:7e01::5,2a01:7e01::9,2a01:7e01::7,2a01:7e01::c,2a01:7e01::2,2a01:7e01::4,2a01:7e01::3,2a01:7e01::6,2a01:7e01::b,2a01:7e01::8"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "2400:8902::3,2400:8902::6,2400:8902::c,2400:8902::4,2400:8902::2,2400:8902::8,2400:8902::7,2400:8902::5,2400:8902::b,2400:8902::9"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=900
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"region":"us-east","type":"g6-nanode-1","label":"go-test-ins-72053mvwvvd0","root_pass":"TKfph1YRz3$A''xB:+y:zjp95QFW$OB9^7NW29]0?evp15]f69;Cb2#7Pv0?^G`x.","image":"linode/debian9","disk_encryption":"enabled","booted":false}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/linode/instances
+    method: POST
+  response:
+    body: '{"id": 25161592, "label": "go-test-ins-72053mvwvvd0", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["139.144.131.14"], "ipv6": "2600:3c03::f03d:00ff:fe04:e0a4/128",
+      "image": "linode/debian9", "region": "us-east", "specs": {"disk": 25600, "memory":
+      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
+      "6f6d2db69b53136a16a2b9fa33f42654a2c5d4a7", "has_user_data": false, "placement_group":
+      null, "disk_encryption": "enabled"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "797"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "10"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.dev.linode.com/v4beta/linode/instances/25161592
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/fixtures/TestInstance_Disks_List_WithEncryption.yaml
+++ b/test/integration/fixtures/TestInstance_Disks_List_WithEncryption.yaml
@@ -1,0 +1,319 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/regions
+    method: GET
+  response:
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=900
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"region":"us-east","type":"g6-nanode-1","label":"go-test-ins-1i45oc3t4w6j","root_pass":"0.''d2R3FRt=]x\u003e27n)\u0026DIpH^55WhI{9j3/aBaK7v[us1{`K(Uui90R[RWfg}95N2","image":"linode/debian9","booted":false}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances
+    method: POST
+  response:
+    body: '{"id": 25167333, "label": "go-test-ins-1i45oc3t4w6j", "group": "", "status":
+      "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["172.234.6.92"], "ipv6": "1234::5678/128",
+      "image": "linode/debian9", "region": "us-east", "specs": {"disk": 25600, "memory":
+      1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
+      "6f6d2db69b53136a16a2b9fa33f42654a2c5d4a7", "has_user_data": false, "placement_group":
+      null, "disk_encryption": "enabled"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "795"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "10"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25167333/disks
+    method: GET
+  response:
+    body: '{"data": [{"id": 6241630, "status": "not ready", "label": "Debian 9 Disk",
+      "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "filesystem":
+      "ext4", "size": 25088, "disk_encryption": "enabled"}, {"id": 6241631, "status":
+      "not ready", "label": "512 MB Swap Image", "created": "2018-01-02T03:04:05",
+      "updated": "2018-01-02T03:04:05", "filesystem": "swap", "size": 512, "disk_encryption":
+      "enabled"}], "page": 1, "pages": 1, "results": 2}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "451"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25167333
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/fixtures/TestInstance_RebuildWithEncryption.yaml
+++ b/test/integration/fixtures/TestInstance_RebuildWithEncryption.yaml
@@ -1,0 +1,525 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/regions
+    method: GET
+  response:
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=900
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"region":"us-east","type":"g6-nanode-1","label":"go-test-ins-wo-disk-x69y691y7ovf","disk_encryption":"enabled","booted":false}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances
+    method: POST
+  response:
+    body: '{"id": 25167331, "label": "go-test-ins-wo-disk-x69y691y7ovf", "group":
+      "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-nanode-1", "ipv4": ["172.234.6.47"], "ipv6": "1234::5678/128",
+      "image": null, "region": "us-east", "specs": {"disk": 25600, "memory": 1024,
+      "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu": 90, "network_in":
+      10, "network_out": 10, "transfer_quota": 80, "io": 10000}, "backups": {"enabled":
+      false, "available": false, "schedule": {"day": null, "window": null}, "last_successful":
+      null}, "hypervisor": "kvm", "watchdog_enabled": true, "tags": [], "host_uuid":
+      "6f6d2db69b53136a16a2b9fa33f42654a2c5d4a7", "has_user_data": false, "placement_group":
+      null, "disk_encryption": "enabled"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "791"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "10"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"label":"go-test-conf-6za102rzcp03","devices":{},"interfaces":null}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25167331/configs
+    method: POST
+  response:
+    body: '{"id": 3395020, "label": "go-test-conf-6za102rzcp03", "helpers": {"updatedb_disabled":
+      true, "distro": true, "modules_dep": true, "network": true, "devtmpfs_automount":
+      true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
+      "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
+      "devices": {"sda": null, "sdb": null, "sdc": null, "sdd": null, "sde": null,
+      "sdf": null, "sdg": null, "sdh": null}, "initrd": null, "run_level": "default",
+      "virt_mode": "paravirt", "interfaces": []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "538"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":25167331,"entity.type":"linode"}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 28420979, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 0, "time_remaining": null, "rate": null,
+      "duration": null, "action": "linode_create", "username": "avest", "entity":
+      {"label": "go-test-ins-wo-disk-x69y691y7ovf", "id": 25167331, "type": "linode",
+      "url": "/v4/linode/instances/25167331"}, "status": "scheduled", "secondary_entity":
+      null, "message": ""}], "page": 1, "pages": 1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "451"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+      X-Filter:
+      - '{"+order":"desc","+order_by":"created","action":"linode_create","created":{"+gte":"2018-01-02T03:04:05"},"entity.id":25167331,"entity.type":"linode","id":{"+gte":28420979}}'
+    url: https://api.linode.com/v4beta/account/events?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": 28420979, "created": "2018-01-02T03:04:05", "seen": false,
+      "read": false, "percent_complete": 100, "time_remaining": 0, "rate": null, "duration":
+      28.0, "action": "linode_create", "username": "avest", "entity": {"label": "go-test-ins-wo-disk-x69y691y7ovf",
+      "id": 25167331, "type": "linode", "url": "/v4/linode/instances/25167331"}, "status":
+      "finished", "secondary_entity": null, "message": ""}], "page": 1, "pages": 1,
+      "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "449"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - events:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"image":"linode/alpine3.19","root_pass":"q!d77=8f3lX47c|[Ir6jZhA5:b*L\\Mp(g{PBW/0|G3tz7`X\u003cYKF657bz.2D0=\\Wl","type":"g6-standard-2","disk_encryption":"disabled"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25167331/rebuild
+    method: POST
+  response:
+    body: '{"id": 25167331, "label": "go-test-ins-wo-disk-x69y691y7ovf", "group":
+      "", "status": "rebuilding", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
+      "type": "g6-standard-2", "ipv4": ["172.234.6.47"], "ipv6": "1234::5678/128",
+      "image": "linode/alpine3.19", "region": "us-east", "specs": {"disk": 25600,
+      "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000}, "alerts": {"cpu":
+      90, "network_in": 10, "network_out": 10, "transfer_quota": 80, "io": 10000},
+      "backups": {"enabled": false, "available": false, "schedule": {"day": null,
+      "window": null}, "last_successful": null}, "hypervisor": "kvm", "watchdog_enabled":
+      true, "tags": [], "host_uuid": "6f6d2db69b53136a16a2b9fa33f42654a2c5d4a7", "has_user_data":
+      false, "placement_group": null, "disk_encryption": "disabled"}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "807"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/linode/instances/25167331
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/fixtures/TestLKECluster_APIEndpoints_List.yaml
+++ b/test/integration/fixtures/TestLKECluster_APIEndpoints_List.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-apiend","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-apiend","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76166, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-apiend", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7323, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-apiend", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "243"
+      - "242"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,7 +187,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76166/api-endpoints
+    url: https://api.linode.com/v4beta/lke/clusters/7323/api-endpoints
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster API Endpoints are not yet available. Please
@@ -184,6 +199,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "96"
       Content-Type:
@@ -199,8 +216,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -213,94 +230,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76166/api-endpoints
+    url: https://api.linode.com/v4beta/lke/clusters/7323/api-endpoints
     method: GET
   response:
-    body: '{"errors": [{"reason": "Cluster API Endpoints are not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "96"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_only
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76166/api-endpoints
-    method: GET
-  response:
-    body: '{"errors": [{"reason": "Cluster API Endpoints are not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "96"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_only
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76166/api-endpoints
-    method: GET
-  response:
-    body: '{"page": 1, "pages": 1, "results": 4, "data": [{"endpoint": "https://065a2454-9ec1-45de-95dd-59581bddc587.ap-west-2.linodelke.net:443"},
-      {"endpoint": "https://065a2454-9ec1-45de-95dd-59581bddc587.ap-west-2.linodelke.net:6443"},
-      {"endpoint": "https://172.105.44.221:443"}, {"endpoint": "https://172.105.44.221:6443"}]}'
+    body: '{"page": 1, "pages": 1, "results": 4, "data": [{"endpoint": "https://2dfc5e68-f61d-4303-ab74-441e835acdaa.cpc1-cjj1-testing.linodelke.net:443"},
+      {"endpoint": "https://2dfc5e68-f61d-4303-ab74-441e835acdaa.cpc1-cjj1-testing.linodelke.net:6443"},
+      {"endpoint": "https://172.234.0.10:443"}, {"endpoint": "https://172.234.0.10:6443"}]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -315,8 +250,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "317"
+      - "329"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -338,7 +275,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -354,7 +291,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76166
+    url: https://api.linode.com/v4beta/lke/clusters/7323
     method: DELETE
   response:
     body: '{}'
@@ -371,6 +308,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -393,7 +332,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKECluster_Dashboard_Get.yaml
+++ b/test/integration/fixtures/TestLKECluster_Dashboard_Get.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-dash","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-dash","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76168, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-dash", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7325, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-dash", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "241"
+      - "240"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,12 +187,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76168
+    url: https://api.linode.com/v4beta/lke/clusters/7325
     method: GET
   response:
-    body: '{"id": 76168, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-dash", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7325, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-dash", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -192,8 +207,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "241"
+      - "240"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -215,7 +232,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -231,10 +248,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76168/dashboard
+    url: https://api.linode.com/v4beta/lke/clusters/7325/dashboard
     method: GET
   response:
-    body: '{"url": "https://4540c914-7a8a-4f92-8d98-ddd1d60d9476.dashboard.ap-west-2.linodelke.net"}'
+    body: '{"url": "https://9808ce20-641e-45e2-8905-5bc8a3ee788a.dashboard.cpc1-cjj1-testing.linodelke.net"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -249,8 +266,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "89"
+      - "97"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -272,7 +291,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -288,7 +307,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76168
+    url: https://api.linode.com/v4beta/lke/clusters/7325
     method: DELETE
   response:
     body: '{}'
@@ -305,6 +324,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -327,7 +348,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKECluster_GetFound.yaml
+++ b/test/integration/fixtures/TestLKECluster_GetFound.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-found","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-found","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76163, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-found", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7320, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-found", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "242"
+      - "241"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,12 +187,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76163
+    url: https://api.linode.com/v4beta/lke/clusters/7320
     method: GET
   response:
-    body: '{"id": 76163, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-found", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7320, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-found", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -192,8 +207,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "242"
+      - "241"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -215,7 +232,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -231,7 +248,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76163
+    url: https://api.linode.com/v4beta/lke/clusters/7320
     method: DELETE
   response:
     body: '{}'
@@ -248,6 +265,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -270,7 +289,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKECluster_GetMissing.yaml
+++ b/test/integration/fixtures/TestLKECluster_GetMissing.yaml
@@ -24,6 +24,8 @@ interactions:
       - '*'
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "37"
       Content-Type:
@@ -39,7 +41,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 404 Not Found
+      - "400"
+    status: 404 NOT FOUND
     code: 404
     duration: ""

--- a/test/integration/fixtures/TestLKECluster_Kubeconfig_Get.yaml
+++ b/test/integration/fixtures/TestLKECluster_Kubeconfig_Get.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-kube-get","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-kube-get","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76167, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-kube-get", "region": "ap-west",
-      "k8s_version": "1.23", "control_plane": {"high_availability": false}, "tags":
+    body: '{"id": 7324, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-kube-get", "region": "us-east",
+      "k8s_version": "1.28", "control_plane": {"high_availability": false}, "tags":
       ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -135,8 +148,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "245"
+      - "244"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -157,7 +172,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -173,12 +188,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167
+    url: https://api.linode.com/v4beta/lke/clusters/7324
     method: GET
   response:
-    body: '{"id": 76167, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-kube-get", "region": "ap-west",
-      "k8s_version": "1.23", "control_plane": {"high_availability": false}, "tags":
+    body: '{"id": 7324, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-kube-get", "region": "us-east",
+      "k8s_version": "1.28", "control_plane": {"high_availability": false}, "tags":
       ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -194,8 +209,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "245"
+      - "244"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -217,7 +234,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -233,7 +250,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7324/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -245,6 +262,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -260,8 +279,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -274,7 +293,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7324/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -286,6 +305,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -301,8 +322,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -315,7 +336,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7324/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -327,6 +348,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -342,8 +365,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -356,7 +379,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7324/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -368,6 +391,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -383,8 +408,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -397,7 +422,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7324/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -409,6 +434,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -424,8 +451,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -438,174 +465,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7324/kubeconfig
     method: GET
   response:
-    body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "92"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
-    method: GET
-  response:
-    body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "92"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
-    method: GET
-  response:
-    body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "92"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
-    method: GET
-  response:
-    body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "92"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167/kubeconfig
-    method: GET
-  response:
-    body: '{"kubeconfig": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KCmNsdXN0ZXJzOgotIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTXZha05EUVdWaFowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYaE5la1V5VFZSUk1VMVdiMWhFVkUxNVRWUkJlRTFFUlRKTlZGRXhUVlp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlMzUkRDa0p4WW1oeVVFdENlbUZQY0dvdlJubFZPRGRRVnpWTE5VTnZWSFZzYkZaVVFUbERhVFJVVm1kWWVuTnhXbVE0T0dscFVGbEVlRWRUVEhobFZEaFpjRFlLTTB0aGNrMW5TVGxrTmpCUWExbGlVemxrWVZwVE5EVkVNVGhpY2pCUFJXdDJjVzluWTJ0QmVUWjJibGt2VVM5S2FXWlpWamwxZG5SeVdtNVVPRlZoU2dwTWRFdFZOV3B2VDFaUmFuQnBiV1ZIUVRKR2Jsa3JjMVJyTTFrM1VYaHhVWFJHUVZONGJFNVBLemg1Tm5WTWJIbGhVV2N5V0hWMk5scEdjMU40UW5RekNsSXdkMmRpZGtWaVVrNXJOV28zYzNoa1lUVmxUV1J0UjFoQ1EyRlBRMXBOVUhRd2JIUnBjbTlJYmtRNU9ESkRSVFpqTURKWE9UbHhLMlpGWWs1a1oxQUtkRFJ1VUVKTmFIVTBRa3cxYm1sd1VGRmxRVE5DZVVwUlkwRklZMjVQVmpGRE1sSnpMMDFITW5BMGJsWTNRMGxqWm1nelpISktTVVI2ZERGTlpuSmpWUXBYWkhSbFRWUTJTazVKTjA5WmVtcFlhV3ByUTBGM1JVRkJZVTVhVFVaamQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpEWm1GM00ydDFRVXhxWW10S1EzUnpRVVF3Ulhock1qSm9hR2ROUWxWSFFURlZaRVZSVVU4S1RVRjVRME50ZERGWmJWWjVZbTFXTUZwWVRYZEVVVmxLUzI5YVNXaDJZMDVCVVVWTVFsRkJSR2RuUlVKQlJFMVROR1pEVVU1emVrNUhTMlEzU0hoVlR3cGtiemN4VkZONFMzYzVaM1JNS3pOSlF6bExWMXBCTlVoT2EzVlBXSE5MYnpkd1RHSTNhbkJCWWtwc1NFaFNkRTQxVkZoamJUSXlMemRrTWprNE5HRkZDbkpLTW10VWNraHlRbTEyYjB3MWEwY3pkMGMzYkRSTFltSnBSVFYwYWtZelNYZHVORkJYYlRsd1FYUlJNM1UwTjA5SlFWVjNaazF0Y0haRlYydFpXbG9LTmxvMloycGxkMDlNUW5CdmQyZEhja1pXUmpkSFRXbHlNRk53TkRKMWJpOUtPSEpFVUZvMVNtdHlZMEphUTNOT05GcHBiVFZ2ZVdOVk9XdHVNRkYyUmdwalJ6QjJkRFJSUzBKUVRtc3haM0p1UlZSWmVGcDZUMk0xY0VSa1RFbFdNbWhCYVRWUmJEQklia1pwU1N0aE1XczNhR3A2Umk5TlEzZE5aRzFFUm5rNENuQnJXa2htYTBwWFVVb3JSWEI1UkV0c2JXTlJWMVJRWVZkUGVFVjZXRlpJYzBobGNuTjRaMEowUkcxRVptSm5la0Z0TVhWM1QyTnVlbE5XTUV0RWNra0tWa2hOUFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzRjYmY4MmI2LTUwYTQtNGI4Ny1iMTkwLWZjOTQ0ZjRmNDFlMy5hcC13ZXN0LTIubGlub2RlbGtlLm5ldDo0NDMKICBuYW1lOiBsa2U3NjE2NwoKdXNlcnM6Ci0gbmFtZTogbGtlNzYxNjctYWRtaW4KICB1c2VyOgogICAgYXMtdXNlci1leHRyYToge30KICAgIHRva2VuOiBleUpoYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SWpsSFpYcE5iMWhuZVY5SWRHWm5VM2hsYkRoTWFGRTNYelpEUVhCTGFqTnBVMmRLUTBrd09FUnZUVVVpZlEuZXlKcGMzTWlPaUpyZFdKbGNtNWxkR1Z6TDNObGNuWnBZMlZoWTJOdmRXNTBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5dVlXMWxjM0JoWTJVaU9pSnJkV0psTFhONWMzUmxiU0lzSW10MVltVnlibVYwWlhNdWFXOHZjMlZ5ZG1salpXRmpZMjkxYm5RdmMyVmpjbVYwTG01aGJXVWlPaUpzYTJVdFlXUnRhVzR0ZEc5clpXNHRlbTR5Y21naUxDSnJkV0psY201bGRHVnpMbWx2TDNObGNuWnBZMlZoWTJOdmRXNTBMM05sY25acFkyVXRZV05qYjNWdWRDNXVZVzFsSWpvaWJHdGxMV0ZrYldsdUlpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU9XSXpNelk0TnpFdE9UZ3lOUzAwTUdRMUxXRmhOakl0TUdabVlqTmxZVEZsT0RBd0lpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbXQxWW1VdGMzbHpkR1Z0T214clpTMWhaRzFwYmlKOS5mOHhIb1BoQmp1b1lwcDg1dmRybXplVzVFNlhqX05TcTluMk5zZUZmYVJJOHF1cEg5bXQxM01zcDlhY25ZMXhNc3NOcHhUa245Q1hSQTN5dlloa1AtZ09GRU1MeWRkMEJ3R3RfdmtpV3cwUzA2bmh0aG1uUk5UbDEzLXhJT19nYVZUV3RFVUliUTZaeU11dVRTQmkzYVJQb3dxR3oyeDdfVFdDNEFTeHdiXzBaVTM0NkpQVEd6LXkyWDhjVmZzem1PbWtZd0V5cFczZ2E2R1Mtdkl4cVctWk1IUVpzT3pEUjhLZ1ItWUtPQnJScGVtN3FFYVZmTmo0dVRwUG8xLWRLNkFPaDhQR2dLQm5SWk5PSEdlZUQ1VmVHczQteS1PWm5NX1h2cFY2alVYRTlqWldyZHhuc2pQaDNUbjF2eFZHZ3pwZl92ZmpiZmNKREx4bUlRNTB4V1EKCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBsa2U3NjE2NwogICAgbmFtZXNwYWNlOiBkZWZhdWx0CiAgICB1c2VyOiBsa2U3NjE2Ny1hZG1pbgogIG5hbWU6IGxrZTc2MTY3LWN0eAoKY3VycmVudC1jb250ZXh0OiBsa2U3NjE2Ny1jdHgK"}'
+    body: '{"kubeconfig": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KCmNsdXN0ZXJzOgotIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVUkNWRU5EUVdVeVowRjNTVUpCWjBsSlEwVjZTamxTVFRNeVlUQjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGRHVkVWVVRVSkZSMEV4VlVVS1FYaE5TMkV6Vm1sYVdFcDFXbGhTYkdONlFXVkdkekI1VGtSQk1VMVVVWGhQUkZVd1RYcEtZVVozTUhwT1JFRXhUVlJKZUU5RVZUVk5la3BoVFVKVmVBcEZla0ZTUW1kT1ZrSkJUVlJEYlhReFdXMVdlV0p0VmpCYVdFMTNaMmRGYVUxQk1FZERVM0ZIVTBsaU0wUlJSVUpCVVZWQlFUUkpRa1IzUVhkblowVkxDa0Z2U1VKQlVVTTJhRWRNVldkUlQxbEZjVzV6YjJkNlMyaHdlSGsxT0VaVFZ6bEZkSEpLYVVSb1ZsWlZiMFY1U1ZsVllqbFRkSFp0VkdWamNsQkpNMUlLUWpadGRUbG5XbFZqZHpadmJETTFTVmRpV1hSSE5DOTJTM0UyUnpNdlVrZHNUVGREWm10Q1VGWlRaazB3ZEhWRE1YRktNRFV2VjBOWVJtcGFSRTA0ZFFwNlVrNHdVSGgyVmxJdksweGtaV0p6VEdGbmFuWXlWVE5WWVZSaVlVaGpVbHBNU1ZCaVZYVnRMMUJqYTFvMWNFUjJaMFZHZVRaWlZHRTJTRmN5ZFV4NUNsbFZhMDlOVW05U2FqZGxVSFF2Tldkdk5VUmpUSGxYV0d0bU1FeE9LMnc1YkZWWU5YQjFjMWg1ZFdwUE1IRTNjVTFHU1VwU1ZWWjZhamhSTkVscGJ6a0thRk5VZEZCMVlXSjRXbnBJTldaV2VIbzBZbXQxYVhKemFUVXJhazFrY2xoaEt6RkdNRkpzUkc5dFpVdHFVVFJrY0N0YVFWTkpPWEppYjNaQ00yOUlkUXBhTTJ3clpXdE9lVzV4YW1OSVF6QkpZVmxGVlV4NGRuWnljMEpFUVdkTlFrRkJSMnBYVkVKWVRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRQ2tKblRsWklVazFDUVdZNFJVSlVRVVJCVVVndlRVSXdSMEV4VldSRVoxRlhRa0pSVFZaaWRITndVamd5UjNwNVdsUXZTa3R3YTNwSlRuRnlaMDlFUVZZS1FtZE9Wa2hTUlVWRWFrRk5aMmR3Y21SWFNteGpiVFZzWkVkV2VrMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUWtGUlFsbHdabE5UYnl0b013cDNWM1l6ZFM4elV6aG5lVU5aVVc1NVpWVnpZblZ4VWxsa1psaHdUazFSWW01NlMxVlRaV1UxTVhKT2RIRldZMWtyYjJoSVlVOVNSRmd3ZVRoNlQxVmlDbkZWZUhGRk1HMW9NSGhZT0hKWUsxUnVkVTF0ZWpsaGFXZFZTMGhETHl0TWFraHZUMVZNYTNwb1p6TnlhMHRoY0ZSSFdHRnZiV0p4Y0dwRVFuUjBTVUlLYUM4ck5EbGlMM0YyWjI5M1prTTJWVzlPVmtKeVpFaFdOeXRwZFZBMGVrbzNVelZFV0UxcmVEYzVORXRyYlN0WFpVeGFaV05uZEM5MVkwUmpVMEk1U1FwWVIyNVdaa05OTTBSU2MzTnlNR0Z2V2twUVRXNU9TVVJSYzJwMVExSm1TMWxxWTNsWGEyeDBNRE15ZGtKNmRuUk9lRVZwY3paVmIzUm1iRTAwTmtvd0NsRkVlRmQxTUZOcVMweGpPSGsyYTNCSGRXMWhiVzlxVFVaaFNXdElPVE5uUkhGUWRITXljMHhVZUd0NFNqaHlMeTl5TkRoV1FsWlVXVWg0SzJJd1RWRUtNV3RMY2tSaFZXSjFiVmhyQ2kwdExTMHRSVTVFSUVORlVsUkpSa2xEUVZSRkxTMHRMUzBLCiAgICBzZXJ2ZXI6IGh0dHBzOi8vYzg2YWRmOTctZjdjMS00MmRlLWFhZWYtYmI0MjQzZmM0OThlLmNwYzEtY2pqMS10ZXN0aW5nLmxpbm9kZWxrZS5uZXQ6NDQzCiAgbmFtZTogbGtlNzMyNAoKdXNlcnM6Ci0gbmFtZTogbGtlNzMyNC1hZG1pbgogIHVzZXI6CiAgICBhcy11c2VyLWV4dHJhOiB7fQogICAgdG9rZW46IGV5SmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJa0pJTjJGQ2RXdDRSa3BTVURoeWJHTjVUVEpzU1dKbFVUZG5TMTlwVFU1TWJtdEJTekJoVFRaSldsRWlmUS5leUpwYzNNaU9pSnJkV0psY201bGRHVnpMM05sY25acFkyVmhZMk52ZFc1MElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl1WVcxbGMzQmhZMlVpT2lKcmRXSmxMWE41YzNSbGJTSXNJbXQxWW1WeWJtVjBaWE11YVc4dmMyVnlkbWxqWldGalkyOTFiblF2YzJWamNtVjBMbTVoYldVaU9pSnNhMlV0WVdSdGFXNHRkRzlyWlc0dGNIRjNjWE1pTENKcmRXSmxjbTVsZEdWekxtbHZMM05sY25acFkyVmhZMk52ZFc1MEwzTmxjblpwWTJVdFlXTmpiM1Z1ZEM1dVlXMWxJam9pYkd0bExXRmtiV2x1SWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXpaWEoyYVdObExXRmpZMjkxYm5RdWRXbGtJam9pTkdFelkyVmhOMk10TkRrM05pMDBNV1ZoTFRnelpEa3ROR1kxWWpBME9UVmpNbU0xSWl3aWMzVmlJam9pYzNsemRHVnRPbk5sY25acFkyVmhZMk52ZFc1ME9tdDFZbVV0YzNsemRHVnRPbXhyWlMxaFpHMXBiaUo5Lno5SkpyQVAwY0lyYVotNWg1djlXWENfbW5TOGE2OHpBeG9JR2lBa2w2SnQ2SmNkejg1VmcwdFh5bVJseHl1T0VHbmxMeVpmQ3NxTFVzc3FDYkQ2SkFvNExqR2JqcFB3MmZLZXZMNEZJOU53aV85a0N4b2N5U0Z3M3g3cHUxaUJYOW0zbFNLYWtoZlE0NFJwOWhpNmU0RWdfcFlUbF9paVJqZWtsZ09CQnM1LURMOGZvVTMwR0x2ZlVJUkl1ODdKUG0xTHNFbzRfZ2J5cHJHdU5kdVBzdHkzZElHV0dWNjFTLW9RRGwwaVU2ZlpaZmxURnlKb1NrU21EUnlNa29mVHpzZzV4V2NyN29KZ0J4S2Jpa09HcklrYkMxbzZfUl9nVGk5RnY3cHBPN0lMMFJpZXNxbmpETXM5VEdYaUllOTlfS0c0RkFHNllqTTh5bEVBMzNrMTR5ZwoKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGxrZTczMjQKICAgIG5hbWVzcGFjZTogZGVmYXVsdAogICAgdXNlcjogbGtlNzMyNC1hZG1pbgogIG5hbWU6IGxrZTczMjQtY3R4CgpjdXJyZW50LWNvbnRleHQ6IGxrZTczMjQtY3R4Cg=="}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -620,6 +483,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "3774"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -641,7 +508,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -657,7 +524,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76167
+    url: https://api.linode.com/v4beta/lke/clusters/7324
     method: DELETE
   response:
     body: '{}'
@@ -674,6 +541,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -696,7 +565,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKECluster_Nodes_Recycle.yaml
+++ b/test/integration/fixtures/TestLKECluster_Nodes_Recycle.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-recycle","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-recycle","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76165, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-recycle", "region": "ap-west",
-      "k8s_version": "1.23", "control_plane": {"high_availability": false}, "tags":
+    body: '{"id": 7322, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-recycle", "region": "us-east",
+      "k8s_version": "1.28", "control_plane": {"high_availability": false}, "tags":
       ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -135,8 +148,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "244"
+      - "243"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -157,7 +172,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -173,7 +188,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76165/recycle
+    url: https://api.linode.com/v4beta/lke/clusters/7322/recycle
     method: POST
   response:
     body: '{}'
@@ -190,6 +205,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -212,7 +229,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -228,7 +245,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76165
+    url: https://api.linode.com/v4beta/lke/clusters/7322
     method: DELETE
   response:
     body: '{}'
@@ -245,6 +262,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -267,7 +286,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKECluster_Update.yaml
+++ b/test/integration/fixtures/TestLKECluster_Update.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-update","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-update","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76164, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-update", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7321, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-update", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "243"
+      - "242"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,14 +171,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"k8s_version":"1.23","label":"go-lke-test-update-updated","tags":["test=true"],"control_plane":{"high_availability":true}}'
+    body: '{"k8s_version":"1.29","label":"go-lke-test-update-updated","tags":["test=true"]}'
     form: {}
     headers:
       Accept:
@@ -172,12 +187,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76164
+    url: https://api.linode.com/v4beta/lke/clusters/7321
     method: PUT
   response:
-    body: '{"id": 76164, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-update-updated", "region": "ap-west",
-      "k8s_version": "1.23", "control_plane": {"high_availability": true}, "tags":
+    body: '{"id": 7321, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-update-updated", "region": "us-east",
+      "k8s_version": "1.29", "control_plane": {"high_availability": false}, "tags":
       ["test=true"]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -192,6 +207,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "252"
       Content-Security-Policy:
@@ -214,7 +231,67 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"control_plane":{"high_availability":true}}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/lke/clusters/7321
+    method: PUT
+  response:
+    body: '{"id": 7321, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-update-updated", "region": "us-east",
+      "k8s_version": "1.29", "control_plane": {"high_availability": true}, "tags":
+      ["test=true"]}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "251"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - lke:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -230,7 +307,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76164
+    url: https://api.linode.com/v4beta/lke/clusters/7321
     method: DELETE
   response:
     body: '{}'
@@ -247,6 +324,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -269,7 +348,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKECluster_WaitForReady.yaml
+++ b/test/integration/fixtures/TestLKECluster_WaitForReady.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":3,"type":"g6-standard-2","disks":null,"tags":null}],"label":"go-lke-test-wait","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":3,"type":"g6-standard-2","disks":null,"tags":null}],"label":"go-lke-test-wait","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76162, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-wait", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7332, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-wait", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "241"
+      - "240"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,7 +187,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7332/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -184,6 +199,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -199,8 +216,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -213,7 +230,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7332/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -225,6 +242,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -240,8 +259,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -254,7 +273,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7332/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -266,6 +285,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -281,8 +302,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -295,7 +316,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7332/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -307,6 +328,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -322,8 +345,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -336,7 +359,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7332/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -348,6 +371,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -363,8 +388,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -377,7 +402,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7332/kubeconfig
     method: GET
   response:
     body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
@@ -389,6 +414,8 @@ interactions:
       - HEAD, GET, OPTIONS, POST, PUT, DELETE
       Access-Control-Allow-Origin:
       - '*'
+      Connection:
+      - keep-alive
       Content-Length:
       - "92"
       Content-Type:
@@ -404,8 +431,8 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
+      - "400"
+    status: 503 SERVICE UNAVAILABLE
     code: 503
     duration: ""
 - request:
@@ -418,133 +445,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
+    url: https://api.linode.com/v4beta/lke/clusters/7332/kubeconfig
     method: GET
   response:
-    body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "92"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
-    method: GET
-  response:
-    body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "92"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
-    method: GET
-  response:
-    body: '{"errors": [{"reason": "Cluster kubeconfig is not yet available. Please
-      try again later."}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
-      Access-Control-Allow-Methods:
-      - HEAD, GET, OPTIONS, POST, PUT, DELETE
-      Access-Control-Allow-Origin:
-      - '*'
-      Content-Length:
-      - "92"
-      Content-Type:
-      - application/json
-      Server:
-      - nginx
-      Vary:
-      - Authorization, X-Filter
-      X-Accepted-Oauth-Scopes:
-      - lke:read_write
-      X-Frame-Options:
-      - DENY
-      X-Oauth-Scopes:
-      - '*'
-      X-Ratelimit-Limit:
-      - "800"
-    status: 503 Service Unavailable
-    code: 503
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
-      User-Agent:
-      - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162/kubeconfig
-    method: GET
-  response:
-    body: '{"kubeconfig": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KCmNsdXN0ZXJzOgotIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTXZha05EUVdWaFowRjNTVUpCWjBsQ1FVUkJUa0puYTNGb2EybEhPWGN3UWtGUmMwWkJSRUZXVFZKTmQwVlJXVVJXVVZGRVJYZHdjbVJYU213S1kyMDFiR1JIVm5wTlFqUllSRlJKZVUxVVFYaE5la1V5VFVSbmVrMUdiMWhFVkUxNVRWUkJlRTFFUlRKTlJHZDZUVVp2ZDBaVVJWUk5Ra1ZIUVRGVlJRcEJlRTFMWVROV2FWcFlTblZhV0ZKc1kzcERRMEZUU1hkRVVWbEtTMjlhU1doMlkwNUJVVVZDUWxGQlJHZG5SVkJCUkVORFFWRnZRMmRuUlVKQlRuVm1Da1JXZVRaQmNsUTFXbnA0VDB4UFRtbENVVEZRUVRZMlRqaEVVbGRyU2t0cVUwZEVhRUZ1VkVoc2VXWm5RMmd6TW1SbGRrOWhjMjVUVldKc1QxZzNlVThLVTFWTFYzQjBVRVl4VUZsNmEwUnZWakZwT1U1YU5FMTFNRW8yV1RsbFYyRTBkMjF4VDJSdlF6aFVaMlV5YlVKVVVHSmhZM0ZyUWxoV2RuQk5SaTlMWXdvM1dXMUpOMUZwWjNaaWFtSmFkWFI1UVdjNU5WZzVZazlaT0VWVGVXOXlUMGxzVUdkemVsTkJUbHBrYzNKU1dITjNiVGQ1UjFKR1pHcGllVmRyZG1wQkNqRkhURzF6VldkeWVERjJTM1ZsWkRaSlNrUlVia1ZUUVhkWE5IbFJXa1JCZGxwb1oxYzBZU3RaTkRoUldtMURjblZYT1doQ1RIcEdhV0pIYVZWWWExY0tTWFo0YmpKSGVIZzNSRWx2Y0dkck5HOWpTMFJMYUVad2FEbFRSRlZ5YzBoNFJVWTRSR1pwWVdwYVZEbE1ORUo1WjJ4VlpGWjRjVklyVjJWdFVFSk1kUXBPVFVWSllVRkRWazlRTUVwaGRVTXhaQzlqUTBGM1JVRkJZVTVhVFVaamQwUm5XVVJXVWpCUVFWRklMMEpCVVVSQlowdHJUVUU0UjBFeFZXUkZkMFZDQ2k5M1VVWk5RVTFDUVdZNGQwaFJXVVJXVWpCUFFrSlpSVVpOVVVFeVdsRXJSRVJwYTNkWWIwZDNiVkpqTkN0b1R6UllSM0pOUWxWSFFURlZaRVZSVVU4S1RVRjVRME50ZERGWmJWWjVZbTFXTUZwWVRYZEVVVmxLUzI5YVNXaDJZMDVCVVVWTVFsRkJSR2RuUlVKQlRHZHpaekpzU25ac2VqTnlZalUyT0ZsRUt3cFBkVlpKU0ZkV1IxTmhjemhRY1RWbWVVOHpSMGRIWWtreVpFTk1NQ3RQUVV4eGFWbExRWHBhYlZWeFRVVk9Talp2VVdselVYVkhWWG9yTjFKYVlsQnpDbE5IUW14T01ERnJVMGRzUXk5TmNVbENXR2hyY25WdWJsVkpXVGxWVmtKTVREaEtVRWhEUlhkd2J6RkVURGhqVjFSSU4xVlRVQzlqWjI5bGRIaFZjVm9LYjNGSVRUTlljRmhxY3prNWVVZFhTRzlEYjI1cVVrTmhiMFkzV1M4MlFVRnhkbWRXUkZwM2JUWlRSM1EyYm1odmNFcEVPVkJEVUZkMVppOTRkbU12UWdwRmJXTlVXVkpyU3pSTFJuVmFiVlZZZUZGbGVIUXljMGg2VmtWTGNIRnlWM05hVTNaeVkwZDRkbU4zVTA0MWF6WnNjRUZ3VjNSUFJ6a3dZMWxIY2s1eENtUm5URzExV1ZFMWNtOXVjbTl6VlVGaGRDOVpOR2QwVW5KQ01sUkhUMW81Y0VoNU9XNURNamxIVjJKclkwNWtLMmwwVkRKM2NWaGtaMEpTZWtOWmNuQUtjRW93UFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PQogICAgc2VydmVyOiBodHRwczovLzE0NmQwZTI3LWNjM2YtNGMwOS1hNTBjLWExYjEzOGZhMDQzYi5hcC13ZXN0LTIubGlub2RlbGtlLm5ldDo0NDMKICBuYW1lOiBsa2U3NjE2MgoKdXNlcnM6Ci0gbmFtZTogbGtlNzYxNjItYWRtaW4KICB1c2VyOgogICAgYXMtdXNlci1leHRyYToge30KICAgIHRva2VuOiBleUpoYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SWpBM1ZWWXdYMVpUUVRFeVZtdE5OQzFZVW1aa0xWUnRMVlI1WlRWNlZqTXdTV1pqTTBJMGFVMTROVVVpZlEuZXlKcGMzTWlPaUpyZFdKbGNtNWxkR1Z6TDNObGNuWnBZMlZoWTJOdmRXNTBJaXdpYTNWaVpYSnVaWFJsY3k1cGJ5OXpaWEoyYVdObFlXTmpiM1Z1ZEM5dVlXMWxjM0JoWTJVaU9pSnJkV0psTFhONWMzUmxiU0lzSW10MVltVnlibVYwWlhNdWFXOHZjMlZ5ZG1salpXRmpZMjkxYm5RdmMyVmpjbVYwTG01aGJXVWlPaUpzYTJVdFlXUnRhVzR0ZEc5clpXNHRPVGxvYlRraUxDSnJkV0psY201bGRHVnpMbWx2TDNObGNuWnBZMlZoWTJOdmRXNTBMM05sY25acFkyVXRZV05qYjNWdWRDNXVZVzFsSWpvaWJHdGxMV0ZrYldsdUlpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl6WlhKMmFXTmxMV0ZqWTI5MWJuUXVkV2xrSWpvaU5EVmhNak5oTkRndFpHVTFPQzAwWVdFMkxUbGpZVE10TXpabU9URXlOakV5WldFeElpd2ljM1ZpSWpvaWMzbHpkR1Z0T25ObGNuWnBZMlZoWTJOdmRXNTBPbXQxWW1VdGMzbHpkR1Z0T214clpTMWhaRzFwYmlKOS5DcDcxZlRCTlRVTUJOY2RINFk0RmtaZ2RRUV83dWktNlp2T2hYSU5KeWota3Jmb3VMZVNUdnl6d1ZTdDNTQlB3NmJYMmVrRVlWamRwb251TUREMnFyNmM4eTR6VWpkclpzdzR2TGd0WWJob1djN1V2YURlLWpMUjRhZ1p3RWlFem90ZDRNVVZEb1hfWEpVb2pTUV8yRWM4MTdlbktJSHVQMjFGdzloblpsNWUtY01HSUlBVTVqMzAxZ1B6cjFFVXJaSXVCTjJZRU1oNFVRcmlObVVtYTRRaFFzTDVlT1RlZG82SVBNa3o1MGdxc201STVZdFhReU1JTFQ4bjlpR3FWeFlZM0hqbENVRWVjSFdTNHVaVUhZc1B2OE1fVXdOSlBWdC1qcGVLYXdTNmMtMFBaX2w0Wm5ITHJibXBaTzktejQ5QzJmSW1vX0JFTmpEQ2N2T2FkT0EKCmNvbnRleHRzOgotIGNvbnRleHQ6CiAgICBjbHVzdGVyOiBsa2U3NjE2MgogICAgbmFtZXNwYWNlOiBkZWZhdWx0CiAgICB1c2VyOiBsa2U3NjE2Mi1hZG1pbgogIG5hbWU6IGxrZTc2MTYyLWN0eAoKY3VycmVudC1jb250ZXh0OiBsa2U3NjE2Mi1jdHgK"}'
+    body: '{"kubeconfig": "CmFwaVZlcnNpb246IHYxCmtpbmQ6IENvbmZpZwpwcmVmZXJlbmNlczoge30KCmNsdXN0ZXJzOgotIGNsdXN0ZXI6CiAgICBjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YTogTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVUkNWRU5EUVdVeVowRjNTVUpCWjBsSlV6TnJkRW9yY25kSGVVVjNSRkZaU2t0dldrbG9kbU5PUVZGRlRFSlJRWGRHVkVWVVRVSkZSMEV4VlVVS1FYaE5TMkV6Vm1sYVdFcDFXbGhTYkdONlFXVkdkekI1VGtSQk1VMVVVWGhQVkVsNVRWUkdZVVozTUhwT1JFRXhUVlJKZUU5VVNUTk5WRVpoVFVKVmVBcEZla0ZTUW1kT1ZrSkJUVlJEYlhReFdXMVdlV0p0VmpCYVdFMTNaMmRGYVUxQk1FZERVM0ZIVTBsaU0wUlJSVUpCVVZWQlFUUkpRa1IzUVhkblowVkxDa0Z2U1VKQlVVUnJLMHMxY0dzNVExWnBRbGRRYTA5M2RucENkbTVDTUhaV1JUUmlWM28wZG5OVmVIQTRUVVExU0ZWUWJucFlkVEV6ZHpFMFVtRnFVM2NLZDNkU05rMU5iR1I0UVhOWk1pOVBVbmc1VTFOR01WRXdTSGhuU2pCR2VIbGxTV3BwZVZnclRWSmxiMmxCV0M4MlpFTnZZVEJwZFZkNFNGaHlTRGRVWmdwRFkzY3lOekpOVTFCMmNDdHdWVmtyYWxCd2MxTlBMMlJNTUVsbk5URnhjVmxEYVhSMk4xbG9WRWQwVVVSWGExWkxRMEpZVFRKMWNGSmpTbU5qVldSWUNqVkxhV0ZZYTFaWlJVaFhhbmxRYjBkeWNHUlNVemhxVEZabEwzRXhha1JaSzJKRFVIRm9kVU0zZVV0aVEyUjNjelJPUVd0U05WQlhjMUJGWm5WSFVVd0tPVFZFY0hsUWVuSklUVkJoY2tsdlV5dGhUVU5FYzFKUFYwMUlNVTlyVjJwS1JEQkdWMVkwT0RZeVdEZGpNRzVCYVV0TU1FRkZORGxpYmxaSGNHUlVOQXBDUlZoU09ETTVUM0ZsYldwTFozVmFjME5oVXpKcGVHTnlPRzFvUVdkTlFrRkJSMnBYVkVKWVRVRTBSMEV4VldSRWQwVkNMM2RSUlVGM1NVTndSRUZRQ2tKblRsWklVazFDUVdZNFJVSlVRVVJCVVVndlRVSXdSMEV4VldSRVoxRlhRa0pUWTNkUGFEWTJlVFpXTlVZek5FeFVSbGwzV0dsRVprWmhMM0JxUVZZS1FtZE9Wa2hTUlVWRWFrRk5aMmR3Y21SWFNteGpiVFZzWkVkV2VrMUJNRWREVTNGSFUwbGlNMFJSUlVKRGQxVkJRVFJKUWtGUlFrNXNSSGh1TmtwM1pnb3lVV2QzWldwdlRqQklaRkphY0hFMmFUSnpNV1ZpTjNaVFVXUndTMW8zT0dSNU9XMHhZekZSV2toMlFUaHZUbTkyWVZKWk1rdG9ObEZwTmpoNGFEVmhDbEZWUVRoeVVHaGhUV1JvTWtGME56ZFpVQzlJVGsxeFFraEhZVzUxWTBSblJtbHBhVk13WTJsTVVHRlNPVkE1ZWsxTFdqZEpWRkYzVG5sMmQzUnJhR0lLTDNsMU1tMHZjbkpxZWtkUWFEaGlOV1pIYzJrd1FWaEhLM2R1UVRWMWJFOUhXVWxKUzFreVQyMVNUVTB3U0N0WVkwSTNWRXRYWmxGeFNtWldVVWRIYXdvMFFVRm1jV3hXU0RkMlJVTldSa1ppVmxWM04xcFBUMkZVU0RSQlRITnhWekp0VVdRMFdqSkxTRFY1ZWl0Vk1GcGhWRGs1VjJoUE5XMU1MMUJ1WVdsWUNtVm1VbmhGTkRSWVlXWlFSbTR6VjJkdU5qTTNaMGxwZGtkSlZpdHFOM0pPU1hkQ016bFhVVkJDTlVkMk1VUm1NMUJDTldSclRURkVWWGwyWkVFelF6WUtUalYwZEdobWJVeDVVVXAxQ2kwdExTMHRSVTVFSUVORlVsUkpSa2xEUVZSRkxTMHRMUzBLCiAgICBzZXJ2ZXI6IGh0dHBzOi8vZTNjNjcyZmEtZWRhNC00N2RjLTkwNzMtMjgyYTVjY2ZkYmMwLmNwYzEtY2pqMS10ZXN0aW5nLmxpbm9kZWxrZS5uZXQ6NDQzCiAgbmFtZTogbGtlNzMzMgoKdXNlcnM6Ci0gbmFtZTogbGtlNzMzMi1hZG1pbgogIHVzZXI6CiAgICBhcy11c2VyLWV4dHJhOiB7fQogICAgdG9rZW46IGV5SmhiR2NpT2lKU1V6STFOaUlzSW10cFpDSTZJa3MxVW5oM1RsZHNjVU5OUlhkTWMxaEVMVWhuTFVFMWIyUTVXR3BrZFZsV01td3lXbFJmUm10Zk5XTWlmUS5leUpwYzNNaU9pSnJkV0psY201bGRHVnpMM05sY25acFkyVmhZMk52ZFc1MElpd2lhM1ZpWlhKdVpYUmxjeTVwYnk5elpYSjJhV05sWVdOamIzVnVkQzl1WVcxbGMzQmhZMlVpT2lKcmRXSmxMWE41YzNSbGJTSXNJbXQxWW1WeWJtVjBaWE11YVc4dmMyVnlkbWxqWldGalkyOTFiblF2YzJWamNtVjBMbTVoYldVaU9pSnNhMlV0WVdSdGFXNHRkRzlyWlc0dGJXWjBjV01pTENKcmRXSmxjbTVsZEdWekxtbHZMM05sY25acFkyVmhZMk52ZFc1MEwzTmxjblpwWTJVdFlXTmpiM1Z1ZEM1dVlXMWxJam9pYkd0bExXRmtiV2x1SWl3aWEzVmlaWEp1WlhSbGN5NXBieTl6WlhKMmFXTmxZV05qYjNWdWRDOXpaWEoyYVdObExXRmpZMjkxYm5RdWRXbGtJam9pTTJRek1EaGxNMll0TVdJMU5DMDBaV1poTFdFMVlUVXROVEUwTVRRME5USmxPV1l3SWl3aWMzVmlJam9pYzNsemRHVnRPbk5sY25acFkyVmhZMk52ZFc1ME9tdDFZbVV0YzNsemRHVnRPbXhyWlMxaFpHMXBiaUo5LmxIbXEtWVo5U2ZHU0tqaFVsZWF4YVpwRTlVQ3JScnE0d0JOVWZlZlZYOFBhRnRRd0V1THVHX3NXRlZFUnVQc3k3QVdxX1h4aFJjSTVmdlNPN2IyRGVyWERncWF5SHU0bk1LcXdINk52cFpZblVTN0hkeWJMZ3dRSmlyclVFdzQ2YW5WSDNWTk9KOGIyQ3N1TE50MUFNZTdYNmQzSXU3MTVCOWU4ZjJkTVQ2dmd6R0h5YjBxN0Z6ZloxY3pKYjl5dHotWndVMUhpRzdSN1c5ZjY4OTBSZG1idnlKcXE5X3lxRElXbkUtSWJESG5uVGtqSXM5NWM0OTBWYnBwQlQ0QmtfSGNHNW50dmRCY0FYT3NlYXZKMGdqYlVmNG1OZk9BN3VSVkp4Um1wQ2dSc3NwaGxtX3lQSkVTSEhPWVJTLWdWRkVFc3FyYzhkel8wekNWanh2ZE5mZwoKY29udGV4dHM6Ci0gY29udGV4dDoKICAgIGNsdXN0ZXI6IGxrZTczMzIKICAgIG5hbWVzcGFjZTogZGVmYXVsdAogICAgdXNlcjogbGtlNzMzMi1hZG1pbgogIG5hbWU6IGxrZTczMzItY3R4CgpjdXJyZW50LWNvbnRleHQ6IGxrZTczMzItY3R4Cg=="}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -559,6 +463,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "3774"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -580,7 +488,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -596,7 +504,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76162
+    url: https://api.linode.com/v4beta/lke/clusters/7332
     method: DELETE
   response:
     body: '{}'
@@ -613,6 +521,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -635,7 +545,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKECluster_WaitForReady_Cluster.yaml
+++ b/test/integration/fixtures/TestLKECluster_WaitForReady_Cluster.yaml
@@ -7,14 +7,393 @@ interactions:
     headers:
       Accept:
       - application/json, */*
-    url: https://146d0e27-cc3f-4c09-a50c-a1b138fa043b.ap-west-2.linodelke.net:443/api/v1/nodes
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"459"},"items":[]}
+    headers:
+      Audit-Id:
+      - f62ac6df-94f2-428e-8229-d8be979f88b2
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"464"},"items":[]}
+    headers:
+      Audit-Id:
+      - 44b9410f-d017-4e95-b667-1b92f15a837c
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"468"},"items":[]}
+    headers:
+      Audit-Id:
+      - dce0dbc3-43b5-4536-a343-a1b2a5ee54db
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"473"},"items":[]}
+    headers:
+      Audit-Id:
+      - 8820efd0-5e7c-4288-b195-ba9848770904
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"476"},"items":[]}
+    headers:
+      Audit-Id:
+      - e8c2f6de-ce04-4251-beda-0adf63a54bf1
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"482"},"items":[]}
+    headers:
+      Audit-Id:
+      - d577a50f-cbfb-4166-bdc1-e8fc068bef1d
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"485"},"items":[]}
+    headers:
+      Audit-Id:
+      - 0fc31923-50e5-4d57-99bc-7c5953ae22d6
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"491"},"items":[]}
+    headers:
+      Audit-Id:
+      - e2c33679-0281-4185-a577-fefda3fababc
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"501"},"items":[]}
+    headers:
+      Audit-Id:
+      - 39b02dc2-0e01-4489-8913-06f864ac0021
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"504"},"items":[]}
+    headers:
+      Audit-Id:
+      - 388890ae-974f-4706-be7d-7743040edea1
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"518"},"items":[]}
+    headers:
+      Audit-Id:
+      - 0bf221d0-805d-4c82-8fd8-a2acae36649b
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"521"},"items":[]}
+    headers:
+      Audit-Id:
+      - b79259ea-1acb-449c-a53f-46da2dc830cf
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"527"},"items":[]}
+    headers:
+      Audit-Id:
+      - c22831e3-9541-40b7-a88a-dc70a07f8f4e
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
     method: GET
   response:
     body: |
       {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"530"},"items":[]}
     headers:
       Audit-Id:
-      - 9fe3b0b9-6be8-4bc5-8fb5-a5de89ad0ad2
+      - 6ee13253-37cb-4122-8b9a-11cd0f6e8efb
       Cache-Control:
       - no-cache, private
       Content-Length:
@@ -22,9 +401,9 @@ interactions:
       Content-Type:
       - application/json
       X-Kubernetes-Pf-Flowschema-Uid:
-      - 89083a2b-4ffe-48eb-ba1a-e2ca012cadd7
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
       X-Kubernetes-Pf-Prioritylevel-Uid:
-      - 3833eb11-2ae9-4b3a-991a-57858f5ff927
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
     status: 200 OK
     code: 200
     duration: ""
@@ -34,14 +413,16 @@ interactions:
     headers:
       Accept:
       - application/json, */*
-    url: https://146d0e27-cc3f-4c09-a50c-a1b138fa043b.ap-west-2.linodelke.net:443/api/v1/nodes
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
     method: GET
   response:
     body: |
-      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"537"},"items":[]}
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"536"},"items":[]}
     headers:
       Audit-Id:
-      - bd644c7a-ec95-4b9e-a395-a36236651512
+      - c2e609f4-f046-481d-b485-3eebc09955c8
       Cache-Control:
       - no-cache, private
       Content-Length:
@@ -49,9 +430,9 @@ interactions:
       Content-Type:
       - application/json
       X-Kubernetes-Pf-Flowschema-Uid:
-      - 89083a2b-4ffe-48eb-ba1a-e2ca012cadd7
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
       X-Kubernetes-Pf-Prioritylevel-Uid:
-      - 3833eb11-2ae9-4b3a-991a-57858f5ff927
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
     status: 200 OK
     code: 200
     duration: ""
@@ -61,24 +442,26 @@ interactions:
     headers:
       Accept:
       - application/json, */*
-    url: https://146d0e27-cc3f-4c09-a50c-a1b138fa043b.ap-west-2.linodelke.net:443/api/v1/nodes
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
     method: GET
   response:
     body: |
-      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"602"},"items":[{"metadata":{"name":"lke76162-118349-634837eff28c","uid":"887829d5-ff94-4545-b16e-4860be6648b3","resourceVersion":"598","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-west","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke76162-118349-634837eff28c","kubernetes.io/os":"linux","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"ap-west"},"annotations":{"node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.0/24\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:allocatable":{"f:ephemeral-storage":{}},"f:capacity":{"f:ephemeral-storage":{}},"f:conditions":{"k:{\"type\":\"Ready\"}":{"f:message":{}}}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.0.0/24","podCIDRs":["10.2.0.0/24"],"providerID":"linode://39523013","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82517840Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4028096Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76048441219","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3925696Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized"}],"addresses":[{"type":"Hostname","address":"lke76162-118349-634837eff28c"},{"type":"ExternalIP","address":"172.105.62.27"},{"type":"InternalIP","address":"192.168.141.86"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"53a924549f02403785267878854d7b25","systemUUID":"53a924549f02403785267878854d7b25","bootID":"0fb3be06-012f-4937-bb32-588a29856d58","kernelVersion":"5.10.0-14-cloud-amd64","osImage":"Debian GNU/Linux 11 (bullseye)","containerRuntimeVersion":"docker://20.10.15","kubeletVersion":"v1.23.6","kubeProxyVersion":"v1.23.6","operatingSystem":"linux","architecture":"amd64"}}}]}
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"539"},"items":[]}
     headers:
       Audit-Id:
-      - c2e927b3-b829-4d55-bb47-1d1c74de2e5e
+      - dc878b37-4fb4-430d-88ac-1199d0b7ce2d
       Cache-Control:
       - no-cache, private
       Content-Length:
-      - "4086"
+      - "86"
       Content-Type:
       - application/json
       X-Kubernetes-Pf-Flowschema-Uid:
-      - 89083a2b-4ffe-48eb-ba1a-e2ca012cadd7
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
       X-Kubernetes-Pf-Prioritylevel-Uid:
-      - 3833eb11-2ae9-4b3a-991a-57858f5ff927
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
     status: 200 OK
     code: 200
     duration: ""
@@ -88,22 +471,26 @@ interactions:
     headers:
       Accept:
       - application/json, */*
-    url: https://146d0e27-cc3f-4c09-a50c-a1b138fa043b.ap-west-2.linodelke.net:443/api/v1/nodes
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
     method: GET
   response:
     body: |
-      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"775"},"items":[{"metadata":{"name":"lke76162-118349-634837ef23d0","uid":"20218a65-f9a4-44bc-bc05-0aae618c89cd","resourceVersion":"715","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-west","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke76162-118349-634837ef23d0","kubernetes.io/os":"linux","lke.linode.com/pool-id":"118349","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"ap-west"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/var/run/dockershim.sock","lke.linode.com/wgip":"172.31.1.1","lke.linode.com/wgpub":"wjTMSXXXIVbzlfmnMdhF1lbgaHZ8eiYpcxICdT3pdBk=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.1.0/24\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:message":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.1.0/24","podCIDRs":["10.2.1.0/24"],"providerID":"linode://39523012","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82517840Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4028104Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76048441219","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3925704Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized"}],"addresses":[{"type":"Hostname","address":"lke76162-118349-634837ef23d0"},{"type":"ExternalIP","address":"172.105.62.26"},{"type":"InternalIP","address":"192.168.142.88"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"b4affd53550b4f58b071cfdcc43e6a93","systemUUID":"b4affd53550b4f58b071cfdcc43e6a93","bootID":"f8b50fb1-3649-4dbc-8424-70e68d756f29","kernelVersion":"5.10.0-14-cloud-amd64","osImage":"Debian GNU/Linux 11 (bullseye)","containerRuntimeVersion":"docker://20.10.15","kubeletVersion":"v1.23.6","kubeProxyVersion":"v1.23.6","operatingSystem":"linux","architecture":"amd64"}}},{"metadata":{"name":"lke76162-118349-634837eff28c","uid":"887829d5-ff94-4545-b16e-4860be6648b3","resourceVersion":"770","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-west","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke76162-118349-634837eff28c","kubernetes.io/os":"linux","lke.linode.com/pool-id":"118349","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"ap-west"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/var/run/dockershim.sock","lke.linode.com/wgip":"172.31.0.1","lke.linode.com/wgpub":"Lc1h/w/fV6FbHBVHmEHM9EZyK+F0ojXS27IbdYvRMic=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.0/24\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:allocatable":{"f:ephemeral-storage":{}},"f:capacity":{"f:ephemeral-storage":{}},"f:conditions":{"k:{\"type\":\"Ready\"}":{"f:message":{}}}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.0.0/24","podCIDRs":["10.2.0.0/24"],"providerID":"linode://39523013","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82517840Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4028096Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76048441219","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3925696Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized"}],"addresses":[{"type":"Hostname","address":"lke76162-118349-634837eff28c"},{"type":"ExternalIP","address":"172.105.62.27"},{"type":"InternalIP","address":"192.168.141.86"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"53a924549f02403785267878854d7b25","systemUUID":"53a924549f02403785267878854d7b25","bootID":"0fb3be06-012f-4937-bb32-588a29856d58","kernelVersion":"5.10.0-14-cloud-amd64","osImage":"Debian GNU/Linux 11 (bullseye)","containerRuntimeVersion":"docker://20.10.15","kubeletVersion":"v1.23.6","kubeProxyVersion":"v1.23.6","operatingSystem":"linux","architecture":"amd64"}}},{"metadata":{"name":"lke76162-118349-634837f0bf12","uid":"e7294b6e-3907-4d37-b24e-883770914ab0","resourceVersion":"772","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-west","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke76162-118349-634837f0bf12","kubernetes.io/os":"linux","lke.linode.com/pool-id":"118349","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"ap-west"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/var/run/dockershim.sock","lke.linode.com/wgip":"172.31.2.1","lke.linode.com/wgpub":"1/okeF6mP/ZRYdFD28nLjRlyWbKMJ1aiAnaWq1g4MQU=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.2.0/24\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}}]},"spec":{"podCIDR":"10.2.2.0/24","podCIDRs":["10.2.2.0/24"],"providerID":"linode://39523014","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82517840Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4028104Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76048441219","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3925704Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"[container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized, CSINode is not yet initialized]"}],"addresses":[{"type":"Hostname","address":"lke76162-118349-634837f0bf12"},{"type":"ExternalIP","address":"172.105.62.55"},{"type":"InternalIP","address":"192.168.141.133"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"54669e805a6949a28451b3cbf64d033f","systemUUID":"54669e805a6949a28451b3cbf64d033f","bootID":"990f4bfa-ddc7-4a61-9b1d-b238a56a6a17","kernelVersion":"5.10.0-14-cloud-amd64","osImage":"Debian GNU/Linux 11 (bullseye)","containerRuntimeVersion":"docker://20.10.15","kubeletVersion":"v1.23.6","kubeProxyVersion":"v1.23.6","operatingSystem":"linux","architecture":"amd64"}}}]}
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"545"},"items":[]}
     headers:
       Audit-Id:
-      - d4320a17-b045-4c19-8e9b-4c2706a7aad1
+      - be4e1e02-cdfc-4ed7-9510-11207ad723a6
       Cache-Control:
       - no-cache, private
+      Content-Length:
+      - "86"
       Content-Type:
       - application/json
       X-Kubernetes-Pf-Flowschema-Uid:
-      - 89083a2b-4ffe-48eb-ba1a-e2ca012cadd7
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
       X-Kubernetes-Pf-Prioritylevel-Uid:
-      - 3833eb11-2ae9-4b3a-991a-57858f5ff927
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
     status: 200 OK
     code: 200
     duration: ""
@@ -113,22 +500,281 @@ interactions:
     headers:
       Accept:
       - application/json, */*
-    url: https://146d0e27-cc3f-4c09-a50c-a1b138fa043b.ap-west-2.linodelke.net:443/api/v1/nodes
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
     method: GET
   response:
     body: |
-      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"846"},"items":[{"metadata":{"name":"lke76162-118349-634837ef23d0","uid":"20218a65-f9a4-44bc-bc05-0aae618c89cd","resourceVersion":"798","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-west","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke76162-118349-634837ef23d0","kubernetes.io/os":"linux","lke.linode.com/pool-id":"118349","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"ap-west"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/var/run/dockershim.sock","lke.linode.com/wgip":"172.31.1.1","lke.linode.com/wgpub":"wjTMSXXXIVbzlfmnMdhF1lbgaHZ8eiYpcxICdT3pdBk=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.1.0/24\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:message":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.1.0/24","podCIDRs":["10.2.1.0/24"],"providerID":"linode://39523012","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82517840Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4028104Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76048441219","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3925704Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized"}],"addresses":[{"type":"Hostname","address":"lke76162-118349-634837ef23d0"},{"type":"ExternalIP","address":"172.105.62.26"},{"type":"InternalIP","address":"192.168.142.88"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"b4affd53550b4f58b071cfdcc43e6a93","systemUUID":"b4affd53550b4f58b071cfdcc43e6a93","bootID":"f8b50fb1-3649-4dbc-8424-70e68d756f29","kernelVersion":"5.10.0-14-cloud-amd64","osImage":"Debian GNU/Linux 11 (bullseye)","containerRuntimeVersion":"docker://20.10.15","kubeletVersion":"v1.23.6","kubeProxyVersion":"v1.23.6","operatingSystem":"linux","architecture":"amd64"}}},{"metadata":{"name":"lke76162-118349-634837eff28c","uid":"887829d5-ff94-4545-b16e-4860be6648b3","resourceVersion":"845","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-west","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke76162-118349-634837eff28c","kubernetes.io/os":"linux","lke.linode.com/pool-id":"118349","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"ap-west"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/var/run/dockershim.sock","lke.linode.com/wgip":"172.31.0.1","lke.linode.com/wgpub":"Lc1h/w/fV6FbHBVHmEHM9EZyK+F0ojXS27IbdYvRMic=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.0/24\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:allocatable":{"f:ephemeral-storage":{}},"f:capacity":{"f:ephemeral-storage":{}}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:lastTransitionTime":{},"f:message":{},"f:reason":{},"f:status":{}}},"f:images":{}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.0.0/24","podCIDRs":["10.2.0.0/24"],"providerID":"linode://39523013","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82517840Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4028096Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76048441219","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3925696Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"True","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletReady","message":"kubelet is posting ready status. AppArmor enabled"}],"addresses":[{"type":"Hostname","address":"lke76162-118349-634837eff28c"},{"type":"ExternalIP","address":"172.105.62.27"},{"type":"InternalIP","address":"192.168.141.86"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"53a924549f02403785267878854d7b25","systemUUID":"53a924549f02403785267878854d7b25","bootID":"0fb3be06-012f-4937-bb32-588a29856d58","kernelVersion":"5.10.0-14-cloud-amd64","osImage":"Debian GNU/Linux 11 (bullseye)","containerRuntimeVersion":"docker://20.10.15","kubeletVersion":"v1.23.6","kubeProxyVersion":"v1.23.6","operatingSystem":"linux","architecture":"amd64"},"images":[{"names":["bitnami/kubectl@sha256:c4a8d9c0cd9c5f903830ea64816c83adf307ff1d775bc3e5b77f1d49d3960205","bitnami/kubectl:1.16.3-debian-10-r36"],"sizeBytes":182705735},{"names":["linode/kube-proxy-amd64@sha256:956fae45da675f68310f51b43654eee078a861d3d2ff2544a3e218ac4aaed8e9","linode/kube-proxy-amd64:v1.23.10"],"sizeBytes":112319634},{"names":["linode/pause@sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108","linode/pause:3.2"],"sizeBytes":682696}]}},{"metadata":{"name":"lke76162-118349-634837f0bf12","uid":"e7294b6e-3907-4d37-b24e-883770914ab0","resourceVersion":"837","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"ap-west","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke76162-118349-634837f0bf12","kubernetes.io/os":"linux","lke.linode.com/pool-id":"118349","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"ap-west"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"/var/run/dockershim.sock","lke.linode.com/wgip":"172.31.2.1","lke.linode.com/wgpub":"1/okeF6mP/ZRYdFD28nLjRlyWbKMJ1aiAnaWq1g4MQU=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.2.0/24\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux-amd64","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:message":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.2.0/24","podCIDRs":["10.2.2.0/24"],"providerID":"linode://39523014","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82517840Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4028104Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76048441219","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3925704Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:docker: network plugin is not ready: cni config uninitialized"}],"addresses":[{"type":"Hostname","address":"lke76162-118349-634837f0bf12"},{"type":"ExternalIP","address":"172.105.62.55"},{"type":"InternalIP","address":"192.168.141.133"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"54669e805a6949a28451b3cbf64d033f","systemUUID":"54669e805a6949a28451b3cbf64d033f","bootID":"990f4bfa-ddc7-4a61-9b1d-b238a56a6a17","kernelVersion":"5.10.0-14-cloud-amd64","osImage":"Debian GNU/Linux 11 (bullseye)","containerRuntimeVersion":"docker://20.10.15","kubeletVersion":"v1.23.6","kubeProxyVersion":"v1.23.6","operatingSystem":"linux","architecture":"amd64"}}}]}
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"548"},"items":[]}
     headers:
       Audit-Id:
-      - 427f611f-4216-4a80-b6d9-53d892a8d6df
+      - cbcb96c1-c8f5-45d0-b8e1-4ef236ed2055
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"557"},"items":[]}
+    headers:
+      Audit-Id:
+      - 5a7b70bb-fd98-43d9-ab28-6250147888eb
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"561"},"items":[]}
+    headers:
+      Audit-Id:
+      - aa649de5-65ba-42db-8091-155808014cd2
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"572"},"items":[]}
+    headers:
+      Audit-Id:
+      - f635c3f2-d083-4a88-9f30-4ae48a7465af
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"576"},"items":[]}
+    headers:
+      Audit-Id:
+      - 458fe0ef-2880-4dd6-a274-025821aed876
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"580"},"items":[]}
+    headers:
+      Audit-Id:
+      - 084dd604-0f90-498c-a143-fa69090495ce
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"585"},"items":[]}
+    headers:
+      Audit-Id:
+      - 50940564-40f8-463e-b8a0-a9caa69c9efc
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "86"
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"692"},"items":[{"metadata":{"name":"lke7332-7625-1d36641e0000","uid":"f8b1330f-9fa7-4a84-87bc-84b2543952c9","resourceVersion":"690","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-1d36641e0000","kubernetes.io/os":"linux","lke.linode.com/pool-id":"7625","node.k8s.linode.com/host-uuid":"03530127a19b0fa7234dec4175db15f25a2adce1","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","lke.linode.com/wgip":"172.31.0.1","lke.linode.com/wgpub":"KUkgkub2ZfreyuEcAahFdlg2DIZSGo7M0dECXoc/SyQ=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.0/25\"":{}}}}},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:message":{}}}}},"subresource":"status"},{"manager":"manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:taints":{}}}}]},"spec":{"podCIDR":"10.2.0.0/25","podCIDRs":["10.2.0.0/25"],"providerID":"linode://25165073","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026160Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923760Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-1d36641e0000"},{"type":"ExternalIP","address":"143.42.180.29"},{"type":"InternalIP","address":"192.168.242.142"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"48a14acdf6264f63af861d99d40ac5ef","systemUUID":"48a14acdf6264f63af861d99d40ac5ef","bootID":"cfba2c5c-478e-4e85-b799-303c4616fac6","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"}}},{"metadata":{"name":"lke7332-7625-4527543a0000","uid":"516732da-143b-440c-8502-fc0268bb29c8","resourceVersion":"692","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-4527543a0000","kubernetes.io/os":"linux","lke.linode.com/pool-id":"7625","node.k8s.linode.com/host-uuid":"53257e56e7692e143036a5fbf7daaf92b5350bf3","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","lke.linode.com/wgip":"172.31.0.2","lke.linode.com/wgpub":"j1OfGU8UZrb0sB9sOxAL5LQrbtLlw764KCTlKonJPkQ=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.128/25\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{},"f:taints":{}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}}]},"spec":{"podCIDR":"10.2.0.128/25","podCIDRs":["10.2.0.128/25"],"providerID":"linode://25165072","taints":[{"key":"lke.linode.com/labels-taints","value":"waiting","effect":"NoSchedule"},{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026160Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923760Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"[container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized, CSINode is not yet initialized]"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-4527543a0000"},{"type":"ExternalIP","address":"143.42.180.26"},{"type":"InternalIP","address":"192.168.242.133"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"4a8a5f365882450c998d4bab09f3d16d","systemUUID":"4a8a5f365882450c998d4bab09f3d16d","bootID":"51ee1328-0a18-43b8-afbe-f885df286956","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"}}}]}
+    headers:
+      Audit-Id:
+      - 88e4558e-a0bc-4c3c-8f1c-389519382a3d
       Cache-Control:
       - no-cache, private
       Content-Type:
       - application/json
       X-Kubernetes-Pf-Flowschema-Uid:
-      - 89083a2b-4ffe-48eb-ba1a-e2ca012cadd7
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
       X-Kubernetes-Pf-Prioritylevel-Uid:
-      - 3833eb11-2ae9-4b3a-991a-57858f5ff927
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"776"},"items":[{"metadata":{"name":"lke7332-7625-1d36641e0000","uid":"f8b1330f-9fa7-4a84-87bc-84b2543952c9","resourceVersion":"714","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-1d36641e0000","kubernetes.io/os":"linux","lke.linode.com/pool-id":"7625","node.k8s.linode.com/host-uuid":"03530127a19b0fa7234dec4175db15f25a2adce1","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","lke.linode.com/wgip":"172.31.0.1","lke.linode.com/wgpub":"KUkgkub2ZfreyuEcAahFdlg2DIZSGo7M0dECXoc/SyQ=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.0/25\"":{}}}}},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:taints":{}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:message":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.0.0/25","podCIDRs":["10.2.0.0/25"],"providerID":"linode://25165073","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026160Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923760Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-1d36641e0000"},{"type":"ExternalIP","address":"143.42.180.29"},{"type":"InternalIP","address":"192.168.242.142"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"48a14acdf6264f63af861d99d40ac5ef","systemUUID":"48a14acdf6264f63af861d99d40ac5ef","bootID":"cfba2c5c-478e-4e85-b799-303c4616fac6","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"}}},{"metadata":{"name":"lke7332-7625-4527543a0000","uid":"516732da-143b-440c-8502-fc0268bb29c8","resourceVersion":"729","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-4527543a0000","kubernetes.io/os":"linux","lke.linode.com/pool-id":"7625","node.k8s.linode.com/host-uuid":"53257e56e7692e143036a5fbf7daaf92b5350bf3","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","lke.linode.com/wgip":"172.31.0.2","lke.linode.com/wgpub":"j1OfGU8UZrb0sB9sOxAL5LQrbtLlw764KCTlKonJPkQ=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.128/25\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:taints":{}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:message":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.0.128/25","podCIDRs":["10.2.0.128/25"],"providerID":"linode://25165072","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026160Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923760Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-4527543a0000"},{"type":"ExternalIP","address":"143.42.180.26"},{"type":"InternalIP","address":"192.168.242.133"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"4a8a5f365882450c998d4bab09f3d16d","systemUUID":"4a8a5f365882450c998d4bab09f3d16d","bootID":"51ee1328-0a18-43b8-afbe-f885df286956","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"}}},{"metadata":{"name":"lke7332-7625-4f06fd870000","uid":"e0b3532b-5c5a-46fe-8572-4242b2b03eab","resourceVersion":"760","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-4f06fd870000","kubernetes.io/os":"linux","node.k8s.linode.com/host-uuid":"2e8c6f5e2c38ef3261c570ae22ac2b65435af20b","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.1.0/25\"":{}}}}},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:spec":{"f:taints":{}}}}]},"spec":{"podCIDR":"10.2.1.0/25","podCIDRs":["10.2.1.0/25"],"providerID":"linode://25165074","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026152Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923752Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"[container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized, CSINode is not yet initialized]"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-4f06fd870000"},{"type":"ExternalIP","address":"143.42.180.43"},{"type":"InternalIP","address":"192.168.242.145"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"4074f1da59194890903e3b9edf941d4c","systemUUID":"4074f1da59194890903e3b9edf941d4c","bootID":"d3aeff59-4c5f-433a-91d4-179a46f17743","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"}}}]}
+    headers:
+      Audit-Id:
+      - 97b041e7-0cae-4c35-b4c2-0dca54e5220e
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - integration.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+    url: https://e3c672fa-eda4-47dc-9073-282a5ccfdbc0.cpc1-cjj1-testing.linodelke.net:443/api/v1/nodes
+    method: GET
+  response:
+    body: |
+      {"kind":"NodeList","apiVersion":"v1","metadata":{"resourceVersion":"894"},"items":[{"metadata":{"name":"lke7332-7625-1d36641e0000","uid":"f8b1330f-9fa7-4a84-87bc-84b2543952c9","resourceVersion":"892","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-1d36641e0000","kubernetes.io/os":"linux","lke.linode.com/pool-id":"7625","node.k8s.linode.com/host-uuid":"03530127a19b0fa7234dec4175db15f25a2adce1","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east","topology.linode.com/region":"us-east"},"annotations":{"csi.volume.kubernetes.io/nodeid":"{\"linodebs.csi.linode.com\":\"25165073\"}","kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","lke.linode.com/wgip":"172.31.0.1","lke.linode.com/wgpub":"KUkgkub2ZfreyuEcAahFdlg2DIZSGo7M0dECXoc/SyQ=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.0/25\"":{}}}}},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{}}}},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:csi.volume.kubernetes.io/nodeid":{}},"f:labels":{"f:topology.linode.com/region":{}}},"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:lastTransitionTime":{},"f:message":{},"f:reason":{},"f:status":{}}},"f:images":{}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.0.0/25","podCIDRs":["10.2.0.0/25"],"providerID":"linode://25165073"},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026160Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923760Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"True","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletReady","message":"kubelet is posting ready status. AppArmor enabled"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-1d36641e0000"},{"type":"ExternalIP","address":"143.42.180.29"},{"type":"InternalIP","address":"192.168.242.142"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"48a14acdf6264f63af861d99d40ac5ef","systemUUID":"48a14acdf6264f63af861d99d40ac5ef","bootID":"cfba2c5c-478e-4e85-b799-303c4616fac6","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"},"images":[{"names":["docker.io/calico/cni@sha256:a38d53cb8688944eafede2f0eadc478b1b403cefeff7953da57fe9cd2d65e977","docker.io/calico/cni:v3.25.0"],"sizeBytes":87984941},{"names":["docker.io/bitnami/kubectl@sha256:c4a8d9c0cd9c5f903830ea64816c83adf307ff1d775bc3e5b77f1d49d3960205","docker.io/bitnami/kubectl:1.16.3-debian-10-r36"],"sizeBytes":65850129},{"names":["docker.io/linode/kube-proxy-amd64@sha256:1b0dd4309665fc3803e4a617cd777a8437fc7d18c4604988c6bd68176bbeb17a","docker.io/linode/kube-proxy-amd64:v1.28.9"],"sizeBytes":28114606},{"names":["docker.io/linode/linode-blockstorage-csi-driver@sha256:944e3e6351ca3186e5d8faf0a1b9765c4d759903617f7d5cc1086d58d7c7dd97"],"sizeBytes":13754364},{"names":["docker.io/linode/csi-node-driver-registrar@sha256:9622c6a6dac7499a055a382930f4de82905a3c5735c0753f7094115c9c871309","docker.io/linode/csi-node-driver-registrar:v1.3.0"],"sizeBytes":7717137},{"names":["docker.io/calico/pod2daemon-flexvol@sha256:01ddd57d428787b3ac689daa685660defe4bd7810069544bd43a9103a7b0a789","docker.io/calico/pod2daemon-flexvol:v3.25.0"],"sizeBytes":7076045},{"names":["registry.k8s.io/pause@sha256:1ff6c18fbef2045af6b9c16bf034cc421a29027b800e4f9b68ae9b1cb3e9ae07","registry.k8s.io/pause:3.5"],"sizeBytes":301416}]}},{"metadata":{"name":"lke7332-7625-4527543a0000","uid":"516732da-143b-440c-8502-fc0268bb29c8","resourceVersion":"838","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-4527543a0000","kubernetes.io/os":"linux","lke.linode.com/pool-id":"7625","node.k8s.linode.com/host-uuid":"53257e56e7692e143036a5fbf7daaf92b5350bf3","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","lke.linode.com/wgip":"172.31.0.2","lke.linode.com/wgpub":"j1OfGU8UZrb0sB9sOxAL5LQrbtLlw764KCTlKonJPkQ=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.0.128/25\"":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:lastTransitionTime":{},"f:message":{},"f:reason":{},"f:status":{}}}}},"subresource":"status"}]},"spec":{"podCIDR":"10.2.0.128/25","podCIDRs":["10.2.0.128/25"],"providerID":"linode://25165072"},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026160Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923760Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"True","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletReady","message":"kubelet is posting ready status. AppArmor enabled"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-4527543a0000"},{"type":"ExternalIP","address":"143.42.180.26"},{"type":"InternalIP","address":"192.168.242.133"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"4a8a5f365882450c998d4bab09f3d16d","systemUUID":"4a8a5f365882450c998d4bab09f3d16d","bootID":"51ee1328-0a18-43b8-afbe-f885df286956","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"}}},{"metadata":{"name":"lke7332-7625-4f06fd870000","uid":"e0b3532b-5c5a-46fe-8572-4242b2b03eab","resourceVersion":"878","creationTimestamp":"2018-01-02T03:04:05Z","labels":{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"g6-standard-2","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"lke7332-7625-4f06fd870000","kubernetes.io/os":"linux","lke.linode.com/pool-id":"7625","node.k8s.linode.com/host-uuid":"2e8c6f5e2c38ef3261c570ae22ac2b65435af20b","node.kubernetes.io/instance-type":"g6-standard-2","topology.kubernetes.io/region":"us-east"},"annotations":{"kubeadm.alpha.kubernetes.io/cri-socket":"unix:///run/containerd/containerd.sock","lke.linode.com/wgip":"172.31.0.3","lke.linode.com/wgpub":"A6JTx7Cd15edQ0VDt5m6lpfIh0Lky8mGq6O+dQan+2k=","node.alpha.kubernetes.io/ttl":"0","volumes.kubernetes.io/controller-managed-attach-detach":"true"},"managedFields":[{"manager":"kubeadm","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:kubeadm.alpha.kubernetes.io/cri-socket":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:volumes.kubernetes.io/controller-managed-attach-detach":{}},"f:labels":{".":{},"f:beta.kubernetes.io/arch":{},"f:beta.kubernetes.io/os":{},"f:kubernetes.io/arch":{},"f:kubernetes.io/hostname":{},"f:kubernetes.io/os":{}}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:beta.kubernetes.io/instance-type":{},"f:failure-domain.beta.kubernetes.io/region":{},"f:node.k8s.linode.com/host-uuid":{},"f:node.kubernetes.io/instance-type":{},"f:topology.kubernetes.io/region":{}}},"f:spec":{"f:providerID":{}}}},{"manager":"linode-cloud-controller-manager-linux","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:addresses":{"k:{\"type\":\"ExternalIP\"}":{".":{},"f:address":{},"f:type":{}},"k:{\"type\":\"InternalIP\"}":{"f:address":{}}}}},"subresource":"status"},{"manager":"kubectl-annotate","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:lke.linode.com/wgip":{},"f:lke.linode.com/wgpub":{}}}}},{"manager":"kubectl-label","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{"f:lke.linode.com/pool-id":{}}}}},{"manager":"kubelet","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:status":{"f:conditions":{"k:{\"type\":\"DiskPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"MemoryPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"PIDPressure\"}":{"f:lastHeartbeatTime":{}},"k:{\"type\":\"Ready\"}":{"f:lastHeartbeatTime":{},"f:message":{}}}}},"subresource":"status"},{"manager":"kube-controller-manager","operation":"Update","apiVersion":"v1","time":"2018-01-02T03:04:05Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{"f:node.alpha.kubernetes.io/ttl":{}}},"f:spec":{"f:podCIDR":{},"f:podCIDRs":{".":{},"v:\"10.2.1.0/25\"":{}},"f:taints":{}}}}]},"spec":{"podCIDR":"10.2.1.0/25","podCIDRs":["10.2.1.0/25"],"providerID":"linode://25165074","taints":[{"key":"node.kubernetes.io/not-ready","effect":"NoSchedule"},{"key":"node.kubernetes.io/not-ready","effect":"NoExecute","timeAdded":"2018-01-02T03:04:05Z"}]},"status":{"capacity":{"cpu":"2","ephemeral-storage":"82486728Ki","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"4026152Ki","pods":"110"},"allocatable":{"cpu":"2","ephemeral-storage":"76019768399","hugepages-1Gi":"0","hugepages-2Mi":"0","memory":"3923752Ki","pods":"110"},"conditions":[{"type":"MemoryPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientMemory","message":"kubelet has sufficient memory available"},{"type":"DiskPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasNoDiskPressure","message":"kubelet has no disk pressure"},{"type":"PIDPressure","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletHasSufficientPID","message":"kubelet has sufficient PID available"},{"type":"Ready","status":"False","lastHeartbeatTime":"2018-01-02T03:04:05Z","lastTransitionTime":"2018-01-02T03:04:05Z","reason":"KubeletNotReady","message":"container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"}],"addresses":[{"type":"Hostname","address":"lke7332-7625-4f06fd870000"},{"type":"ExternalIP","address":"143.42.180.43"},{"type":"InternalIP","address":"192.168.242.145"}],"daemonEndpoints":{"kubeletEndpoint":{"Port":10250}},"nodeInfo":{"machineID":"4074f1da59194890903e3b9edf941d4c","systemUUID":"4074f1da59194890903e3b9edf941d4c","bootID":"d3aeff59-4c5f-433a-91d4-179a46f17743","kernelVersion":"6.1.0-20-cloud-amd64","osImage":"Debian GNU/Linux 12 (bookworm)","containerRuntimeVersion":"containerd://1.6.31","kubeletVersion":"v1.28.3","kubeProxyVersion":"v1.28.3","operatingSystem":"linux","architecture":"amd64"}}}]}
+    headers:
+      Audit-Id:
+      - 725b3866-37c9-45f8-90ef-633f30782a96
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+      X-Kubernetes-Pf-Flowschema-Uid:
+      - affd9597-fa49-4927-ac33-19f7f8bb16ea
+      X-Kubernetes-Pf-Prioritylevel-Uid:
+      - b4189e81-3f07-47e7-9092-805f9b1eb04b
     status: 200 OK
     code: 200
     duration: ""

--- a/test/integration/fixtures/TestLKEClusters_List.yaml
+++ b/test/integration/fixtures/TestLKEClusters_List.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-list","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-list","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76169, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-list", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7326, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-list", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "241"
+      - "240"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -175,9 +190,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: GET
   response:
-    body: '{"data": [{"id": 76169, "status": "ready", "created": "2018-01-02T03:04:05",
-      "updated": "2018-01-02T03:04:05", "label": "go-lke-test-list", "region": "ap-west",
-      "k8s_version": "1.23", "control_plane": {"high_availability": false}, "tags":
+    body: '{"data": [{"id": 7326, "status": "ready", "created": "2018-01-02T03:04:05",
+      "updated": "2018-01-02T03:04:05", "label": "go-lke-test-list", "region": "us-east",
+      "k8s_version": "1.28", "control_plane": {"high_availability": false}, "tags":
       ["testing"]}], "page": 1, "pages": 1, "results": 1}'
     headers:
       Access-Control-Allow-Credentials:
@@ -193,8 +208,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "290"
+      - "289"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -216,7 +233,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -232,7 +249,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76169
+    url: https://api.linode.com/v4beta/lke/clusters/7326
     method: DELETE
   response:
     body: '{}'
@@ -249,6 +266,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -271,7 +290,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKENodePoolNode_Delete.yaml
+++ b/test/integration/fixtures/TestLKENodePoolNode_Delete.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76172, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7329, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "240"
+      - "239"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,13 +187,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76172/pools
+    url: https://api.linode.com/v4beta/lke/clusters/7329/pools
     method: POST
   response:
-    body: '{"id": 118362, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "118362-63483a962f5f",
-      "instance_id": 39523226, "status": "not_ready"}, {"id": "118362-63483a970178",
-      "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}], "autoscaler": {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"]}'
+    body: '{"id": 7621, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7621-05d83c170000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7621-4bee65fd0000", "instance_id":
+      null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
+      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
+      "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -192,8 +208,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "334"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -214,7 +232,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -230,7 +248,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76172/nodes/118362-63483a962f5f
+    url: https://api.linode.com/v4beta/lke/clusters/7329/nodes/7621-05d83c170000
     method: DELETE
   response:
     body: '{}'
@@ -247,6 +265,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -269,7 +289,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -285,12 +305,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76172/pools/118362
+    url: https://api.linode.com/v4beta/lke/clusters/7329/pools/7621
     method: GET
   response:
-    body: '{"id": 118362, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "118362-63483a970178",
-      "instance_id": 39523228, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}], "autoscaler": {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"]}'
+    body: '{"id": 7621, "type": "g6-standard-2", "count": 1, "nodes": [{"id": "7621-4bee65fd0000",
+      "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type":
+      "ext4"}], "autoscaler": {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"],
+      "disk_encryption": "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -305,8 +326,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "259"
+      - "281"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -328,7 +351,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -344,7 +367,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76172/pools/118362
+    url: https://api.linode.com/v4beta/lke/clusters/7329/pools/7621
     method: DELETE
   response:
     body: '{}'
@@ -361,6 +384,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -383,7 +408,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -399,7 +424,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76172
+    url: https://api.linode.com/v4beta/lke/clusters/7329
     method: DELETE
   response:
     body: '{}'
@@ -416,6 +441,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -438,7 +465,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKENodePool_GetFound.yaml
+++ b/test/integration/fixtures/TestLKENodePool_GetFound.yaml
@@ -11,7 +11,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/regions
+    url: https://api.dev.linode.com/v4beta/regions
     method: GET
   response:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
@@ -122,7 +122,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-central","k8s_version":"1.29","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-east","k8s_version":"1.29","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -131,11 +131,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters
+    url: https://api.dev.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 7288, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "us-central", "k8s_version":
+    body: '{"id": 7289, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "us-east", "k8s_version":
       "1.29", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
@@ -153,7 +153,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "242"
+      - "239"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -193,14 +193,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/7288/pools
+    url: https://api.dev.linode.com/v4beta/lke/clusters/7289/pools
     method: POST
   response:
-    body: '{"id": 7567, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7567-017662250000",
-      "instance_id": null, "status": "not_ready"}, {"id": "7567-420b2aa10000", "instance_id":
+    body: '{"id": 7569, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7569-37371b6c0000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7569-3b1321000000", "instance_id":
       null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
       {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
-      "disabled"}'
+      "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -217,7 +217,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "355"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -257,14 +257,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/7288/pools/7567
+    url: https://api.dev.linode.com/v4beta/lke/clusters/7289/pools/7569
     method: GET
   response:
-    body: '{"id": 7567, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7567-017662250000",
-      "instance_id": null, "status": "not_ready"}, {"id": "7567-420b2aa10000", "instance_id":
+    body: '{"id": 7569, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7569-37371b6c0000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7569-3b1321000000", "instance_id":
       null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
       {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
-      "disabled"}'
+      "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -282,7 +282,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - "355"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -323,7 +323,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/7288/pools/7567
+    url: https://api.dev.linode.com/v4beta/lke/clusters/7289/pools/7569
     method: DELETE
   response:
     body: '{}'
@@ -383,7 +383,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/7288
+    url: https://api.dev.linode.com/v4beta/lke/clusters/7289
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestLKENodePool_GetFound.yaml
+++ b/test/integration/fixtures/TestLKENodePool_GetFound.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "2400:8904::f03c:91ff:fea5:659,2400:8904::f03c:91ff:fea5:9282,2400:8904::f03c:91ff:fea5:b9b3,2400:8904::f03c:91ff:fea5:925a,2400:8904::f03c:91ff:fea5:22cb,2400:8904::f03c:91ff:fea5:227a,2400:8904::f03c:91ff:fea5:924c,2400:8904::f03c:91ff:fea5:f7e2,2400:8904::f03c:91ff:fea5:2205,2400:8904::f03c:91ff:fea5:9207"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "2600:3c04::f03c:91ff:fea9:f63,2600:3c04::f03c:91ff:fea9:f6d,2600:3c04::f03c:91ff:fea9:f80,2600:3c04::f03c:91ff:fea9:f0f,2600:3c04::f03c:91ff:fea9:f99,2600:3c04::f03c:91ff:fea9:fbd,2600:3c04::f03c:91ff:fea9:fdd,2600:3c04::f03c:91ff:fea9:fe2,2600:3c04::f03c:91ff:fea9:f68,2600:3c04::f03c:91ff:fea9:f4a"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "2400:8907::f03c:92ff:fe6e:ec8,2400:8907::f03c:92ff:fe6e:98e4,2400:8907::f03c:92ff:fe6e:1c58,2400:8907::f03c:92ff:fe6e:c299,2400:8907::f03c:92ff:fe6e:c210,2400:8907::f03c:92ff:fe6e:c219,2400:8907::f03c:92ff:fe6e:1c5c,2400:8907::f03c:92ff:fe6e:c24e,2400:8907::f03c:92ff:fe6e:e6b,2400:8907::f03c:92ff:fe6e:e3d"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "2600:3c00::2,2600:3c00::9,2600:3c00::7,2600:3c00::5,2600:3c00::3,2600:3c00::8,2600:3c00::6,2600:3c00::4,2600:3c00::c,2600:3c00::b"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "2600:3c01::2,2600:3c01::9,2600:3c01::5,2600:3c01::7,2600:3c01::3,2600:3c01::8,2600:3c01::4,2600:3c01::b,2600:3c01::c,2600:3c01::6"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "2600:3c02::3,2600:3c02::5,2600:3c02::4,2600:3c02::6,2600:3c02::c,2600:3c02::7,2600:3c02::2,2600:3c02::9,2600:3c02::8,2600:3c02::b"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "2600:3c03::7,2600:3c03::4,2600:3c03::9,2600:3c03::6,2600:3c03::3,2600:3c03::c,2600:3c03::5,2600:3c03::b,2600:3c03::2,2600:3c03::8"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "2a01:7e00::9,2a01:7e00::3,2a01:7e00::c,2a01:7e00::5,2a01:7e00::6,2a01:7e00::8,2a01:7e00::b,2a01:7e00::4,2a01:7e00::7,2a01:7e00::2"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "2400:8901::5,2400:8901::4,2400:8901::b,2400:8901::3,2400:8901::9,2400:8901::2,2400:8901::8,2400:8901::7,2400:8901::c,2400:8901::6"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "2a01:7e01::5,2a01:7e01::9,2a01:7e01::7,2a01:7e01::c,2a01:7e01::2,2a01:7e01::4,2a01:7e01::3,2a01:7e01::6,2a01:7e01::b,2a01:7e01::8"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "2400:8902::3,2400:8902::6,2400:8902::c,2400:8902::4,2400:8902::2,2400:8902::8,2400:8902::7,2400:8902::5,2400:8902::b,2400:8902::9"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -97,16 +110,19 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-central","k8s_version":"1.29","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +134,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76170, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7288, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "us-central", "k8s_version":
+      "1.29", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +150,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "240"
+      - "242"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -154,9 +172,12 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,13 +193,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76170/pools
+    url: https://api.linode.com/v4beta/lke/clusters/7288/pools
     method: POST
   response:
-    body: '{"id": 118358, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "118358-63483a5f4cbe",
-      "instance_id": null, "status": "not_ready"}, {"id": "118358-63483a601b59", "instance_id":
+    body: '{"id": 7567, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7567-017662250000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7567-420b2aa10000", "instance_id":
       null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
-      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"]}'
+      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
+      "disabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -192,8 +214,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "330"
+      - "355"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -212,9 +236,12 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -230,13 +257,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76170/pools/118358
+    url: https://api.linode.com/v4beta/lke/clusters/7288/pools/7567
     method: GET
   response:
-    body: '{"id": 118358, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "118358-63483a5f4cbe",
-      "instance_id": 39523193, "status": "not_ready"}, {"id": "118358-63483a601b59",
-      "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}], "autoscaler": {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"]}'
+    body: '{"id": 7567, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7567-017662250000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7567-420b2aa10000", "instance_id":
+      null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
+      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
+      "disabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -251,8 +279,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "334"
+      - "355"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -272,9 +302,12 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -290,7 +323,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76170/pools/118358
+    url: https://api.linode.com/v4beta/lke/clusters/7288/pools/7567
     method: DELETE
   response:
     body: '{}'
@@ -307,6 +340,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -327,9 +362,12 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -345,7 +383,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76170
+    url: https://api.linode.com/v4beta/lke/clusters/7288
     method: DELETE
   response:
     body: '{}'
@@ -362,6 +400,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -382,9 +422,12 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - '*'
+      - account:read_write databases:read_write domains:read_write events:read_write
+        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
+        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
+        volumes:read_write vpc:read_write
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKENodePool_GetFound.yaml
+++ b/test/integration/fixtures/TestLKENodePool_GetFound.yaml
@@ -11,66 +11,66 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/regions
+    url: https://api.linode.com/v4beta/regions
     method: GET
   response:
     body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
       "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
       Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "2400:8904::f03c:91ff:fea5:659,2400:8904::f03c:91ff:fea5:9282,2400:8904::f03c:91ff:fea5:b9b3,2400:8904::f03c:91ff:fea5:925a,2400:8904::f03c:91ff:fea5:22cb,2400:8904::f03c:91ff:fea5:227a,2400:8904::f03c:91ff:fea5:924c,2400:8904::f03c:91ff:fea5:f7e2,2400:8904::f03c:91ff:fea5:2205,2400:8904::f03c:91ff:fea5:9207"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
       "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
       "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "2600:3c04::f03c:91ff:fea9:f63,2600:3c04::f03c:91ff:fea9:f6d,2600:3c04::f03c:91ff:fea9:f80,2600:3c04::f03c:91ff:fea9:f0f,2600:3c04::f03c:91ff:fea9:f99,2600:3c04::f03c:91ff:fea9:fbd,2600:3c04::f03c:91ff:fea9:fdd,2600:3c04::f03c:91ff:fea9:fe2,2600:3c04::f03c:91ff:fea9:f68,2600:3c04::f03c:91ff:fea9:f4a"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
       "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
       "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "2400:8907::f03c:92ff:fe6e:ec8,2400:8907::f03c:92ff:fe6e:98e4,2400:8907::f03c:92ff:fe6e:1c58,2400:8907::f03c:92ff:fe6e:c299,2400:8907::f03c:92ff:fe6e:c210,2400:8907::f03c:92ff:fe6e:c219,2400:8907::f03c:92ff:fe6e:1c5c,2400:8907::f03c:92ff:fe6e:c24e,2400:8907::f03c:92ff:fe6e:e6b,2400:8907::f03c:92ff:fe6e:e3d"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
       "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "2600:3c00::2,2600:3c00::9,2600:3c00::7,2600:3c00::5,2600:3c00::3,2600:3c00::8,2600:3c00::6,2600:3c00::4,2600:3c00::c,2600:3c00::b"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
       "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
       "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "2600:3c01::2,2600:3c01::9,2600:3c01::5,2600:3c01::7,2600:3c01::3,2600:3c01::8,2600:3c01::4,2600:3c01::b,2600:3c01::c,2600:3c01::6"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
       "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
       Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "2600:3c02::3,2600:3c02::5,2600:3c02::4,2600:3c02::6,2600:3c02::c,2600:3c02::7,2600:3c02::2,2600:3c02::9,2600:3c02::8,2600:3c02::b"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
       "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
       "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
       "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "2600:3c03::7,2600:3c03::4,2600:3c03::9,2600:3c03::6,2600:3c03::3,2600:3c03::c,2600:3c03::5,2600:3c03::b,2600:3c03::2,2600:3c03::8"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
       "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
       Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
       "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "2a01:7e00::9,2a01:7e00::3,2a01:7e00::c,2a01:7e00::5,2a01:7e00::6,2a01:7e00::8,2a01:7e00::b,2a01:7e00::4,2a01:7e00::7,2a01:7e00::2"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
       "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "2400:8901::5,2400:8901::4,2400:8901::b,2400:8901::3,2400:8901::9,2400:8901::2,2400:8901::8,2400:8901::7,2400:8901::c,2400:8901::6"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
       "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "2a01:7e01::5,2a01:7e01::9,2a01:7e01::7,2a01:7e01::c,2a01:7e01::2,2a01:7e01::4,2a01:7e01::3,2a01:7e01::6,2a01:7e01::b,2a01:7e01::8"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
       "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
       "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "2400:8902::3,2400:8902::6,2400:8902::c,2400:8902::4,2400:8902::2,2400:8902::8,2400:8902::7,2400:8902::5,2400:8902::b,2400:8902::9"},
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
       5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
@@ -110,10 +110,7 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write databases:read_write domains:read_write events:read_write
-        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
-        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
-        volumes:read_write vpc:read_write
+      - '*'
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:
@@ -122,7 +119,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-east","k8s_version":"1.29","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -131,12 +128,12 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/lke/clusters
+    url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 7289, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+    body: '{"id": 7327, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
       "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "us-east", "k8s_version":
-      "1.29", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -172,10 +169,7 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write databases:read_write domains:read_write events:read_write
-        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
-        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
-        volumes:read_write vpc:read_write
+      - '*'
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:
@@ -193,11 +187,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/lke/clusters/7289/pools
+    url: https://api.linode.com/v4beta/lke/clusters/7327/pools
     method: POST
   response:
-    body: '{"id": 7569, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7569-37371b6c0000",
-      "instance_id": null, "status": "not_ready"}, {"id": "7569-3b1321000000", "instance_id":
+    body: '{"id": 7617, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7617-24ef62820000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7617-49656cd60000", "instance_id":
       null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
       {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
       "enabled"}'
@@ -236,10 +230,7 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write databases:read_write domains:read_write events:read_write
-        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
-        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
-        volumes:read_write vpc:read_write
+      - '*'
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:
@@ -257,11 +248,11 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/lke/clusters/7289/pools/7569
+    url: https://api.linode.com/v4beta/lke/clusters/7327/pools/7617
     method: GET
   response:
-    body: '{"id": 7569, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7569-37371b6c0000",
-      "instance_id": null, "status": "not_ready"}, {"id": "7569-3b1321000000", "instance_id":
+    body: '{"id": 7617, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7617-24ef62820000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7617-49656cd60000", "instance_id":
       null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
       {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
       "enabled"}'
@@ -302,10 +293,7 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write databases:read_write domains:read_write events:read_write
-        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
-        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
-        volumes:read_write vpc:read_write
+      - '*'
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:
@@ -323,7 +311,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/lke/clusters/7289/pools/7569
+    url: https://api.linode.com/v4beta/lke/clusters/7327/pools/7617
     method: DELETE
   response:
     body: '{}'
@@ -362,10 +350,7 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write databases:read_write domains:read_write events:read_write
-        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
-        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
-        volumes:read_write vpc:read_write
+      - '*'
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:
@@ -383,7 +368,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.dev.linode.com/v4beta/lke/clusters/7289
+    url: https://api.linode.com/v4beta/lke/clusters/7327
     method: DELETE
   response:
     body: '{}'
@@ -422,10 +407,7 @@ interactions:
       - DENY
       - DENY
       X-Oauth-Scopes:
-      - account:read_write databases:read_write domains:read_write events:read_write
-        firewall:read_write images:read_write ips:read_write linodes:read_write lke:read_write
-        longview:read_write nodebalancers:read_write object_storage:read_write stackscripts:read_write
-        volumes:read_write vpc:read_write
+      - '*'
       X-Ratelimit-Limit:
       - "400"
       X-Xss-Protection:

--- a/test/integration/fixtures/TestLKENodePool_GetMissing.yaml
+++ b/test/integration/fixtures/TestLKENodePool_GetMissing.yaml
@@ -24,6 +24,8 @@ interactions:
       - '*'
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "37"
       Content-Type:
@@ -39,7 +41,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 404 Not Found
+      - "400"
+    status: 404 NOT FOUND
     code: 404
     duration: ""

--- a/test/integration/fixtures/TestLKENodePool_Update.yaml
+++ b/test/integration/fixtures/TestLKENodePool_Update.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76173, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7330, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "240"
+      - "239"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,13 +187,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76173/pools
+    url: https://api.linode.com/v4beta/lke/clusters/7330/pools
     method: POST
   response:
-    body: '{"id": 118365, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "118365-63483ab318f8",
-      "instance_id": null, "status": "not_ready"}, {"id": "118365-63483ab3eaa0", "instance_id":
+    body: '{"id": 7623, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7623-10677a820000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7623-168dfd9c0000", "instance_id":
       null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
-      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"]}'
+      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
+      "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -192,8 +208,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "330"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -214,7 +232,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -230,13 +248,13 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76173/pools/118365
+    url: https://api.linode.com/v4beta/lke/clusters/7330/pools/7623
     method: PUT
   response:
-    body: '{"id": 118365, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "118365-63483ab318f8",
-      "instance_id": 39523246, "status": "not_ready"}, {"id": "118365-63483ab3eaa0",
-      "instance_id": 39523247, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}], "autoscaler": {"enabled": true, "min": 2, "max": 5}, "tags": []}'
+    body: '{"id": 7623, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7623-10677a820000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7623-168dfd9c0000", "instance_id":
+      null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
+      {"enabled": true, "min": 2, "max": 5}, "tags": [], "disk_encryption": "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -250,8 +268,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "328"
+      - "344"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -272,7 +292,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -288,15 +308,15 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76173/pools/118365
+    url: https://api.linode.com/v4beta/lke/clusters/7330/pools/7623
     method: PUT
   response:
-    body: '{"id": 118365, "type": "g6-standard-2", "count": 3, "nodes": [{"id": "118365-63483ab318f8",
-      "instance_id": 39523246, "status": "not_ready"}, {"id": "118365-63483ab3eaa0",
-      "instance_id": 39523247, "status": "not_ready"}, {"id": "118365-63483ab82d2f",
-      "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}], "autoscaler": {"enabled": true, "min": 2, "max": 5}, "tags": ["bar",
-      "foo", "test"]}'
+    body: '{"id": 7623, "type": "g6-standard-2", "count": 3, "nodes": [{"id": "7623-10677a820000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7623-168dfd9c0000", "instance_id":
+      null, "status": "not_ready"}, {"id": "7623-354bf7970000", "instance_id": null,
+      "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
+      {"enabled": true, "min": 2, "max": 5}, "tags": ["bar", "foo", "test"], "disk_encryption":
+      "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -310,8 +330,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "423"
+      - "437"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -332,7 +354,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -348,7 +370,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76173/pools/118365
+    url: https://api.linode.com/v4beta/lke/clusters/7330/pools/7623
     method: DELETE
   response:
     body: '{}'
@@ -365,6 +387,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -387,7 +411,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -403,7 +427,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76173
+    url: https://api.linode.com/v4beta/lke/clusters/7330
     method: DELETE
   response:
     body: '{}'
@@ -420,6 +444,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -442,7 +468,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKENodePools_List.yaml
+++ b/test/integration/fixtures/TestLKENodePools_List.yaml
@@ -14,56 +14,65 @@ interactions:
     url: https://api.linode.com/v4beta/regions
     method: GET
   response:
-    body: '{"data": [{"id": "ap-west", "country": "in", "capabilities": ["Linodes",
-      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ca-central", "country": "ca", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-southeast", "country": "au", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-central", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
+    body: '{"data": [{"id": "ap-west", "label": "Mumbai, India", "country": "in",
+      "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans", "VPCs", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, Ontario, CAN",
+      "country": "ca", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, NSW, Australia",
+      "country": "au", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Vlans",
+      "VPCs", "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-central", "label": "Dallas, TX, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Kubernetes",
       "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-west", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-southeast", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA, USA", "country":
+      "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "173.230.145.5,173.230.147.5,173.230.155.5,173.255.212.5,173.255.219.5,173.255.241.5,173.255.243.5,173.255.244.5,74.207.241.5,74.207.242.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-southeast", "label": "Atlanta, GA, USA",
+      "country": "us", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed
+      Databases"], "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ, USA", "country":
+      "us", "capabilities": ["Linodes", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "us-east", "country": "us", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Bare Metal", "Block Storage Migrations", "Managed Databases"], "status": "ok",
-      "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-west", "country": "uk", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-south", "country": "sg", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "eu-central", "country": "de", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases"], "status": "ok", "resolvers":
-      {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}},
-      {"id": "ap-northeast", "country": "jp", "capabilities": ["Linodes", "NodeBalancers",
-      "Block Storage", "Kubernetes", "Cloud Firewall", "Block Storage Migrations",
-      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"}}],
-      "page": 1, "pages": 1, "results": 11}'
+      "Bare Metal", "Vlans", "VPCs", "Block Storage Migrations", "Managed Databases",
+      "Placement Group"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,207.192.69.4,207.192.69.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, England, UK",
+      "country": "uk", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Placement Group"],
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5,176.58.107.5,176.58.116.5,176.58.121.5,151.236.220.5,212.71.252.5,212.71.253.5,109.74.192.20,109.74.193.20,109.74.194.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
+      "de", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Object Storage",
+      "Managed Databases"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
+      "jp", "capabilities": ["Linodes", "Backups", "NodeBalancers", "Managed Databases"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 100, "maximum_linodes_per_pg":
+      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 11}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -78,6 +87,10 @@ interactions:
       Cache-Control:
       - private, max-age=900
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "7192"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -99,14 +112,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"ap-west","k8s_version":"1.23","tags":["testing"]}'
+    body: '{"node_pools":[{"count":1,"type":"g6-standard-2","disks":null,"tags":["test"]}],"label":"go-lke-test-def","region":"us-east","k8s_version":"1.28","tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -118,9 +131,9 @@ interactions:
     url: https://api.linode.com/v4beta/lke/clusters
     method: POST
   response:
-    body: '{"id": 76171, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
-      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "ap-west", "k8s_version":
-      "1.23", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
+    body: '{"id": 7328, "status": "ready", "created": "2018-01-02T03:04:05", "updated":
+      "2018-01-02T03:04:05", "label": "go-lke-test-def", "region": "us-east", "k8s_version":
+      "1.28", "control_plane": {"high_availability": false}, "tags": ["testing"]}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -134,8 +147,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "240"
+      - "239"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -156,7 +171,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -172,13 +187,14 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76171/pools
+    url: https://api.linode.com/v4beta/lke/clusters/7328/pools
     method: POST
   response:
-    body: '{"id": 118360, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "118360-63483a7a95f3",
-      "instance_id": null, "status": "not_ready"}, {"id": "118360-63483a7b6526", "instance_id":
+    body: '{"id": 7619, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "7619-0a55a93c0000",
+      "instance_id": null, "status": "not_ready"}, {"id": "7619-5f31de190000", "instance_id":
       null, "status": "not_ready"}], "disks": [{"size": 1000, "type": "ext4"}], "autoscaler":
-      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"]}'
+      {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"], "disk_encryption":
+      "enabled"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -192,8 +208,10 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "330"
+      - "354"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -214,7 +232,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -230,17 +248,18 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76171/pools
+    url: https://api.linode.com/v4beta/lke/clusters/7328/pools
     method: GET
   response:
-    body: '{"data": [{"id": 118359, "type": "g6-standard-2", "count": 1, "nodes":
-      [{"id": "118359-63483a79a0e4", "instance_id": 39523208, "status": "not_ready"}],
-      "disks": [], "autoscaler": {"enabled": false, "min": 1, "max": 1}, "tags": ["test"]},
-      {"id": 118360, "type": "g6-standard-2", "count": 2, "nodes": [{"id": "118360-63483a7a95f3",
-      "instance_id": 39523209, "status": "not_ready"}, {"id": "118360-63483a7b6526",
-      "instance_id": null, "status": "not_ready"}], "disks": [{"size": 1000, "type":
-      "ext4"}], "autoscaler": {"enabled": false, "min": 2, "max": 2}, "tags": ["testing"]}],
-      "page": 1, "pages": 1, "results": 2}'
+    body: '{"data": [{"id": 7618, "type": "g6-standard-2", "count": 1, "nodes": [{"id":
+      "7618-08ab67bd0000", "instance_id": null, "status": "not_ready"}], "disks":
+      [], "autoscaler": {"enabled": false, "min": 1, "max": 1}, "tags": ["test"],
+      "disk_encryption": "enabled"}, {"id": 7619, "type": "g6-standard-2", "count":
+      2, "nodes": [{"id": "7619-0a55a93c0000", "instance_id": null, "status": "not_ready"},
+      {"id": "7619-5f31de190000", "instance_id": null, "status": "not_ready"}], "disks":
+      [{"size": 1000, "type": "ext4"}], "autoscaler": {"enabled": false, "min": 2,
+      "max": 2}, "tags": ["testing"], "disk_encryption": "enabled"}], "page": 1, "pages":
+      1, "results": 2}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -255,8 +274,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "611"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -278,7 +299,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -294,7 +315,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76171/pools/118360
+    url: https://api.linode.com/v4beta/lke/clusters/7328/pools/7619
     method: DELETE
   response:
     body: '{}'
@@ -311,6 +332,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -333,7 +356,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -349,7 +372,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/clusters/76171
+    url: https://api.linode.com/v4beta/lke/clusters/7328
     method: DELETE
   response:
     body: '{}'
@@ -366,6 +389,8 @@ interactions:
       - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
       Cache-Control:
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "2"
       Content-Security-Policy:
@@ -388,7 +413,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKEVersion_GetFound.yaml
+++ b/test/integration/fixtures/TestLKEVersion_GetFound.yaml
@@ -11,10 +11,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/lke/versions/1.23
+    url: https://api.linode.com/v4beta/lke/versions/1.29
     method: GET
   response:
-    body: '{"id": "1.23"}'
+    body: '{"id": "1.29"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -29,6 +29,8 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
       - "14"
       Content-Security-Policy:
@@ -52,7 +54,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/fixtures/TestLKEVersion_GetMissing.yaml
+++ b/test/integration/fixtures/TestLKEVersion_GetMissing.yaml
@@ -24,6 +24,8 @@ interactions:
       - '*'
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
+      Connection:
+      - keep-alive
       Content-Length:
       - "37"
       Content-Type:
@@ -39,7 +41,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
-    status: 404 Not Found
+      - "400"
+    status: 404 NOT FOUND
     code: 404
     duration: ""

--- a/test/integration/fixtures/TestLKEVersions_List.yaml
+++ b/test/integration/fixtures/TestLKEVersions_List.yaml
@@ -14,7 +14,8 @@ interactions:
     url: https://api.linode.com/v4beta/lke/versions
     method: GET
   response:
-    body: '{"data": [{"id": "1.23"}], "page": 1, "pages": 1, "results": 1}'
+    body: '{"data": [{"id": "1.29"}, {"id": "1.28"}, {"id": "1.27"}], "page": 1, "pages":
+      1, "results": 3}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -29,8 +30,10 @@ interactions:
       Cache-Control:
       - private, max-age=0, s-maxage=0, no-cache, no-store
       - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
       Content-Length:
-      - "63"
+      - "95"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
@@ -52,7 +55,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "800"
+      - "400"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -475,6 +475,22 @@ func TestInstance_withMetadata(t *testing.T) {
 	}
 }
 
+func TestInstance_DiskEncryption(t *testing.T) {
+	_, inst, teardown, err := setupInstance(t, "fixtures/TestInstance_DiskEncryption", func(c *linodego.Client, ico *linodego.InstanceCreateOptions) {
+		ico.DiskEncryption = linodego.InstanceDiskEncryptionEnabled
+		ico.Region = "us-east"
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(teardown)
+
+	if inst.DiskEncryption != linodego.InstanceDiskEncryptionEnabled {
+		t.Fatalf("expected instance to have disk encryption enabled, got: %s, want: %s", inst.DiskEncryption, linodego.InstanceDiskEncryptionEnabled)
+	}
+}
+
 func createInstance(t *testing.T, client *linodego.Client, modifiers ...instanceModifier) (*linodego.Instance, error) {
 	if t != nil {
 		t.Helper()

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -386,7 +386,7 @@ func TestInstance_Rebuild(t *testing.T) {
 	}
 
 	rebuildOpts := linodego.InstanceRebuildOptions{
-		Image: "linode/alpine3.15",
+		Image: "linode/alpine3.19",
 		Metadata: &linodego.InstanceMetadataOptions{
 			UserData: base64.StdEncoding.EncodeToString([]byte("cool")),
 		},

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -253,7 +253,7 @@ func setupLKECluster(t *testing.T, clusterModifiers []clusterModifier, fixturesY
 
 	createOpts := linodego.LKEClusterCreateOptions{
 		Label:      label,
-		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes"})[0],
+		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes", "Disk Encryption"})[0],
 		K8sVersion: "1.29",
 		Tags:       []string{"testing"},
 		NodePools:  []linodego.LKENodePoolCreateOptions{{Count: 1, Type: "g6-standard-2", Tags: []string{"test"}}},

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -74,13 +74,12 @@ func TestLKECluster_Update(t *testing.T) {
 
 	updatedTags := []string{"test=true"}
 	updatedLabel := cluster.Label + "-updated"
-	updatedK8sVersion := "1.23"
-	updatedControlPlane := &linodego.LKEClusterControlPlane{HighAvailability: true}
-	updatedCluster, err := client.UpdateLKECluster(context.TODO(), cluster.ID, linodego.LKEClusterUpdateOptions{
-		Tags:         &updatedTags,
-		Label:        updatedLabel,
-		K8sVersion:   updatedK8sVersion,
-		ControlPlane: updatedControlPlane,
+	updatedK8sVersion := "1.29"
+
+	updatedCluster, err := client.UpdateLKECluster(context.Background(), cluster.ID, linodego.LKEClusterUpdateOptions{
+		Tags:       &updatedTags,
+		Label:      updatedLabel,
+		K8sVersion: updatedK8sVersion,
 	})
 	if err != nil {
 		t.Fatalf("failed to update LKE Cluster (%d): %s", cluster.ID, err)
@@ -96,6 +95,17 @@ func TestLKECluster_Update(t *testing.T) {
 
 	if !reflect.DeepEqual(updatedTags, updatedCluster.Tags) {
 		t.Errorf("expected tags to be updated to %#v; got %#v", updatedTags, updatedCluster.Tags)
+	}
+
+	// Update the LKE cluster to HA
+	// This needs to be done in a separate API request from the K8s version upgrade
+	updatedControlPlane := &linodego.LKEClusterControlPlane{HighAvailability: true}
+
+	updatedCluster, err = client.UpdateLKECluster(context.Background(), cluster.ID, linodego.LKEClusterUpdateOptions{
+		ControlPlane: updatedControlPlane,
+	})
+	if err != nil {
+		t.Fatalf("failed to update LKE Cluster (%d): %s", cluster.ID, err)
 	}
 
 	if !reflect.DeepEqual(*updatedControlPlane, updatedCluster.ControlPlane) {
@@ -222,11 +232,12 @@ func TestLKEVersion_GetFound(t *testing.T) {
 	client, teardown := createTestClient(t, "fixtures/TestLKEVersion_GetFound")
 	defer teardown()
 
-	i, err := client.GetLKEVersion(context.Background(), "1.23")
+	i, err := client.GetLKEVersion(context.Background(), "1.29")
 	if err != nil {
 		t.Errorf("Error getting version, expected struct, got %v and error %v", i, err)
 	}
-	if i.ID != "1.23" {
+
+	if i.ID != "1.29" {
 		t.Errorf("Expected a specific version, but got a different one %v", i)
 	}
 }
@@ -254,7 +265,7 @@ func setupLKECluster(t *testing.T, clusterModifiers []clusterModifier, fixturesY
 	createOpts := linodego.LKEClusterCreateOptions{
 		Label:      label,
 		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes", "Disk Encryption"})[0],
-		K8sVersion: "1.29",
+		K8sVersion: "1.28",
 		Tags:       []string{"testing"},
 		NodePools:  []linodego.LKENodePoolCreateOptions{{Count: 1, Type: "g6-standard-2", Tags: []string{"test"}}},
 	}

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -254,7 +254,7 @@ func setupLKECluster(t *testing.T, clusterModifiers []clusterModifier, fixturesY
 	createOpts := linodego.LKEClusterCreateOptions{
 		Label:      label,
 		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes"})[0],
-		K8sVersion: "1.23",
+		K8sVersion: "1.29",
 		Tags:       []string{"testing"},
 		NodePools:  []linodego.LKENodePoolCreateOptions{{Count: 1, Type: "g6-standard-2", Tags: []string{"test"}}},
 	}

--- a/test/integration/lke_node_pools_test.go
+++ b/test/integration/lke_node_pools_test.go
@@ -74,16 +74,36 @@ func TestLKENodePool_GetFound(t *testing.T) {
 		t.Errorf("DiskEncryption not enabled, got: %s, want: %s", i.DiskEncryption, linodego.InstanceDiskEncryptionEnabled)
 	}
 
-	for _, node := range i.Linodes {
-		instance, err := client.GetInstance(context.Background(), node.InstanceID)
-		if err != nil {
-			t.Errorf("failed to get Linode, got err: %v", err)
-		}
+	// TODO - This field is not yet implemented in dev
+	// We must wait for the k8s nodes to be ready as a proxy for waiting
+	// for the Linodes in the node pool to be ready. The inital pool is
+	// returned with instances that have no IDs
+	// wrapper, teardownClusterClient := transportRecorderWrapper(t, "fixtures/TestLKENodePool_GetFound")
+	// defer teardownClusterClient()
 
-		if instance.LKEClusterID != lkeCluster.ID {
-			t.Errorf("linode: %d is LKENodePool member but got linode LKEClusterID: %d, want: %d", instance.ID, instance.LKEClusterID, lkeCluster.ID)
-		}
-	}
+	//if err := k8scondition.WaitForLKEClusterAndNodesReady(context.TODO(), *client, lkeCluster.ID, linodego.LKEClusterPollOptions{
+	//	Retry:            true,
+	//	TimeoutSeconds:   0,
+	//	TransportWrapper: wrapper,
+	//}); err != nil {
+	//	t.Fatalf("got err waiting for LKE cluster and nodes to be ready, err: %v", err)
+	//}
+
+	//i, err = client.GetLKENodePool(context.TODO(), lkeCluster.ID, pool.ID)
+	//if err != nil {
+	//	t.Fatalf("failed to get lke node pool, got err: %v", err)
+	//}
+
+	// for _, node := range i.Linodes {
+	//	instance, err := client.GetInstance(context.Background(), node.InstanceID)
+	//	if err != nil {
+	//		t.Errorf("failed to get Linode, got err: %v", err)
+	//	}
+
+	//	if instance.LKEClusterID != lkeCluster.ID {
+	//		t.Errorf("linode: %d is LKENodePool member but got linode LKEClusterID: %d, want: %d", instance.ID, instance.LKEClusterID, lkeCluster.ID)
+	//	}
+	//}
 }
 
 func TestLKENodePools_List(t *testing.T) {

--- a/test/integration/lke_node_pools_test.go
+++ b/test/integration/lke_node_pools_test.go
@@ -73,6 +73,17 @@ func TestLKENodePool_GetFound(t *testing.T) {
 	if i.DiskEncryption != linodego.InstanceDiskEncryptionEnabled {
 		t.Errorf("DiskEncryption not enabled, got: %s, want: %s", i.DiskEncryption, linodego.InstanceDiskEncryptionEnabled)
 	}
+
+	for _, node := range i.Linodes {
+		instance, err := client.GetInstance(context.Background(), node.InstanceID)
+		if err != nil {
+			t.Errorf("failed to get Linode, got err: %v", err)
+		}
+
+		if instance.LKEClusterID != lkeCluster.ID {
+			t.Errorf("linode: %d is LKENodePool member but got linode LKEClusterID: %d, want: %d", instance.ID, instance.LKEClusterID, lkeCluster.ID)
+		}
+	}
 }
 
 func TestLKENodePools_List(t *testing.T) {

--- a/test/integration/lke_node_pools_test.go
+++ b/test/integration/lke_node_pools_test.go
@@ -69,6 +69,10 @@ func TestLKENodePool_GetFound(t *testing.T) {
 	if diff := cmp.Diff([]string{"testing"}, i.Tags); diff != "" {
 		t.Errorf("unexpected tags:\n%s", diff)
 	}
+
+	if i.DiskEncryption != linodego.InstanceDiskEncryptionEnabled {
+		t.Errorf("DiskEncryption not enabled, got: %s, want: %s", i.DiskEncryption, linodego.InstanceDiskEncryptionEnabled)
+	}
 }
 
 func TestLKENodePools_List(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Allows Linode instances to be created with disk encryption. 

Also handles creating LKE node pools with disk encryption enabled 

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

Use cmd/test.go from this [branch](https://github.com/linode/linodego/pull/504) 
Add disk encryption tags to your user and `go run cmd/test.go` to create a Linode with and without encryption plus an LKE cluster with a single node pool that has encryption enabled. 

**How do I run the relevant unit/integration tests?**

Be a little tough as there currently are none. I will ask DX for their advice here. 

