### PR TITLE
Expose region capabilities enum

### DIFF
--- a/regions.go
+++ b/regions.go
@@ -9,19 +9,54 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
+// This is an enumeration of Capabilities Linode offers that can be referenced
+// through the user-facing parts of the application.
+// Defined as strings rather than a custom type to avoid breaking change.
+// Can be changed in the potential v2 version.
+const (
+	Linodes                string = "Linodes"
+	NodeBalancers          string = "NodeBalancers"
+	BlockStorage           string = "Block Storage"
+	ObjectStorage          string = "Object Storage"
+	ObjectStorageRegions   string = "Object Storage Access Key Regions"
+	LKE                    string = "Kubernetes"
+	LkeHaControlPlanes     string = "LKE HA Control Planes"
+	CloudFirewall          string = "Cloud Firewall"
+	GPU                    string = "GPU Linodes"
+	Vlans                  string = "Vlans"
+	VPCs                   string = "VPCs"
+	VPCsExtra              string = "VPCs Extra"
+	MachineImages          string = "Machine Images"
+	BareMetal              string = "Bare Metal"
+	DBAAS                  string = "Managed Databases"
+	BlockStorageMigrations string = "Block Storage Migrations"
+	Metadata               string = "Metadata"
+	PremiumPlans           string = "Premium Plans"
+	EdgePlans              string = "Edge Plans"
+	LKEControlPlaneACL     string = "LKE Network Access Control List (IP ACL)"
+	ACLB                   string = "Akamai Cloud Load Balancer"
+	SupportTicketSeverity  string = "Support Ticket Severity"
+	Backups                string = "Backups"
+	PlacementGroup         string = "Placement Group"
+	DiskEncryption         string = "Disk Encryption"
+)
+
 // Region-related endpoints have a custom expiry time as the
 // `status` field may update for database outages.
 var cacheExpiryTime = time.Minute
 
 // Region represents a linode region object
 type Region struct {
-	ID           string          `json:"id"`
-	Country      string          `json:"country"`
-	Capabilities []string        `json:"capabilities"`
-	Status       string          `json:"status"`
-	Resolvers    RegionResolvers `json:"resolvers"`
-	Label        string          `json:"label"`
-	SiteType     string          `json:"site_type"`
+	ID      string `json:"id"`
+	Country string `json:"country"`
+
+	// A List of enums from the above constants
+	Capabilities []string `json:"capabilities"`
+
+	Status    string          `json:"status"`
+	Resolvers RegionResolvers `json:"resolvers"`
+	Label     string          `json:"label"`
+	SiteType  string          `json:"site_type"`
 }
 
 // RegionResolvers contains the DNS resolvers of a region


### PR DESCRIPTION
## 📝 Description

Add a list of enum for region capabilities. To avoid high-impact breaking change, we only build them into strings instead of a custom type.
