### PR TITLE
expose OnAfterResponse middleware hook

### DIFF
--- a/client.go
+++ b/client.go
@@ -85,8 +85,9 @@ type clientCacheEntry struct {
 }
 
 type (
-	Request = resty.Request
-	Logger  = resty.Logger
+	Request  = resty.Request
+	Response = resty.Response
+	Logger   = resty.Logger
 )
 
 func init() {

--- a/client.go
+++ b/client.go
@@ -141,6 +141,13 @@ func (c *Client) OnBeforeRequest(m func(request *Request) error) {
 	})
 }
 
+// OnAfterResponse adds a handler to the request body to run before the request is sent
+func (c *Client) OnAfterResponse(m func(response *Response) error) {
+	c.resty.OnAfterResponse(func(_ *resty.Client, req *resty.Response) error {
+		return m(req)
+	})
+}
+
 // UseURL parses the individual components of the given API URL and configures the client
 // accordingly. For example, a valid URL.
 // For example:


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**
Exposes a `OnAfterResponse` hook, so middleware such as call-counters can use it.

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**