### PR TITLE
fix: Separate plan availability logic from getRegionsWithCaps(...)

### DIFF
--- a/test/integration/images_test.go
+++ b/test/integration/images_test.go
@@ -107,7 +107,7 @@ func TestImage_CreateUpload(t *testing.T) {
 	defer teardown()
 
 	image, uploadURL, err := client.CreateImageUpload(context.Background(), ImageCreateUploadOptions{
-		Region:      getRegionsWithCaps(t, client, []string{"Metadata"}, []string{})[0],
+		Region:      getRegionsWithCaps(t, client, []string{"Metadata"})[0],
 		Label:       "linodego-image-create-upload",
 		Description: "An image that does stuff.",
 		CloudInit:   true,
@@ -132,7 +132,7 @@ func TestImage_CloudInit(t *testing.T) {
 	client, instance, teardown, err := setupInstance(
 		t, "fixtures/TestImage_CloudInit", true,
 		func(client *Client, options *InstanceCreateOptions) {
-			options.Region = getRegionsWithCaps(t, client, []string{"Metadata"}, []string{})[0]
+			options.Region = getRegionsWithCaps(t, client, []string{"Metadata"})[0]
 		})
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/instance_config_test.go
+++ b/test/integration/instance_config_test.go
@@ -67,7 +67,7 @@ func setupInstanceWithVPCAndNATOneToOne(t *testing.T, fixturesYaml string) (
 		t,
 		fixturesYaml,
 		func(client *Client, opts *InstanceCreateOptions) {
-			opts.Region = getRegionsWithCaps(t, client, []string{"Linodes", "VPCs"}, []string{})[0]
+			opts.Region = getRegionsWithCaps(t, client, []string{"Linodes", "VPCs"})[0]
 		},
 	)
 	if err != nil {
@@ -110,7 +110,7 @@ func setupInstanceWith3Interfaces(t *testing.T, fixturesYaml string) (
 		t,
 		fixturesYaml,
 		func(client *Client, opts *InstanceCreateOptions) {
-			opts.Region = getRegionsWithCaps(t, client, []string{"Linodes", "VPCs"}, []string{})[0]
+			opts.Region = getRegionsWithCaps(t, client, []string{"Linodes", "VPCs"})[0]
 		},
 	)
 	if err != nil {
@@ -153,7 +153,7 @@ func TestInstance_ConfigInterfaces_AppendDelete(t *testing.T) {
 		"fixtures/TestInstance_ConfigInterfaces_AppendDelete",
 		func(client *Client, opts *InstanceCreateOptions) {
 			// Ensure we're in a region that supports VLANs
-			opts.Region = getRegionsWithCaps(t, client, []string{"vlans", "VPCs"}, []string{})[0]
+			opts.Region = getRegionsWithCaps(t, client, []string{"vlans", "VPCs"})[0]
 		},
 	)
 	defer teardown()
@@ -303,7 +303,7 @@ func TestInstance_ConfigInterfaces_Update(t *testing.T) {
 		"fixtures/TestInstance_ConfigInterfaces_Update",
 		func(client *Client, opts *InstanceCreateOptions) {
 			// Ensure we're in a region that supports VLANs
-			opts.Region = getRegionsWithCaps(t, client, []string{"vlans", "VPCs"}, []string{})[0]
+			opts.Region = getRegionsWithCaps(t, client, []string{"vlans", "VPCs"})[0]
 		},
 	)
 	defer teardown()
@@ -377,7 +377,7 @@ func TestInstance_ConfigInterface_Update(t *testing.T) {
 		"fixtures/TestInstance_ConfigInterface_Update",
 		func(client *Client, opts *InstanceCreateOptions) {
 			// Ensure we're in a region that supports VLANs
-			opts.Region = getRegionsWithCaps(t, client, []string{"vlans", "VPCs"}, []string{})[0]
+			opts.Region = getRegionsWithCaps(t, client, []string{"vlans", "VPCs"})[0]
 		},
 	)
 	defer teardown()

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -354,7 +354,7 @@ func TestInstance_Rebuild(t *testing.T) {
 		t,
 		"fixtures/TestInstance_Rebuild", true,
 		func(client *linodego.Client, options *linodego.InstanceCreateOptions) {
-			options.Region = getRegionsWithCaps(t, client, []string{"Metadata"}, []string{})[0]
+			options.Region = getRegionsWithCaps(t, client, []string{"Metadata"})[0]
 		},
 	)
 	defer teardown()
@@ -392,7 +392,7 @@ func TestInstance_Clone(t *testing.T) {
 	client, instance, teardownOriginalLinode, err := setupInstance(
 		t, "fixtures/TestInstance_Clone", true,
 		func(client *linodego.Client, options *linodego.InstanceCreateOptions) {
-			targetRegion = getRegionsWithCaps(t, client, []string{"Metadata"}, []string{})[0]
+			targetRegion = getRegionsWithCaps(t, client, []string{"Metadata"})[0]
 
 			options.Region = targetRegion
 		})
@@ -470,7 +470,7 @@ func TestInstance_withMetadata(t *testing.T) {
 			options.Metadata = &linodego.InstanceMetadataOptions{
 				UserData: base64.StdEncoding.EncodeToString([]byte("reallycoolmetadata")),
 			}
-			options.Region = getRegionsWithCaps(t, client, []string{"Metadata"}, []string{})[0]
+			options.Region = getRegionsWithCaps(t, client, []string{"Metadata"})[0]
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -519,7 +519,7 @@ func createInstance(t *testing.T, client *linodego.Client, enableCloudFirewall b
 	createOpts := linodego.InstanceCreateOptions{
 		Label:    "go-test-ins-" + randLabel(),
 		RootPass: randPassword(),
-		Region:   getRegionsWithCaps(t, client, []string{"linodes"}, []string{})[0],
+		Region:   getRegionsWithCaps(t, client, []string{"linodes"})[0],
 		Type:     "g6-nanode-1",
 		Image:    "linode/debian9",
 		Booted:   linodego.Pointer(false),
@@ -567,7 +567,7 @@ func createInstanceWithoutDisks(
 
 	createOpts := linodego.InstanceCreateOptions{
 		Label:  "go-test-ins-wo-disk-" + randLabel(),
-		Region: getRegionsWithCaps(t, client, []string{"linodes"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"linodes"})[0],
 		Type:   "g6-nanode-1",
 		Booted: linodego.Pointer(false),
 	}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/linode/linodego"
@@ -173,29 +175,16 @@ If the plans list is empty, it only checks for the capabilities.
 
 Parameters:
   - capabilities: A list of required capabilities that regions must support.
-  - plans (optional): A list of required plans that must be available in the regions.
 
 Returns:
-  - string values representing the IDs of regions that meet the given criteria.
+  - string values representing the IDs of regions that have a given set of capabilities.
 */
-func getRegionsWithCaps(t *testing.T, client *linodego.Client, capabilities, plans []string) []string {
+func getRegionsWithCaps(t *testing.T, client *linodego.Client, capabilities []string) []string {
 	result := make([]string, 0)
 
 	regions, err := client.ListRegions(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	regionsAvailabilities, err := client.ListRegionsAvailability(context.Background(), nil)
-
-	type availKey struct {
-		Region string
-		Plan   string
-	}
-
-	availMap := make(map[availKey]linodego.RegionAvailability, len(regionsAvailabilities))
-	for _, avail := range regionsAvailabilities {
-		availMap[availKey{Region: avail.Region, Plan: avail.Plan}] = avail
 	}
 
 	regionHasCaps := func(r linodego.Region) bool {
@@ -214,12 +203,37 @@ func getRegionsWithCaps(t *testing.T, client *linodego.Client, capabilities, pla
 		return true
 	}
 
-	// Function to check if a region has the required plans available
-	regionHasPlans := func(regionID string) bool {
-		if len(plans) == 0 {
-			return true
+	for _, region := range regions {
+		if region.Status != "ok" || !regionHasCaps(region) {
+			continue
 		}
 
+		result = append(result, region.ID)
+	}
+
+	return result
+}
+
+// getRegionWithCapsAndPlans resolves a list of regions that meet the given capabilities
+// and has availability for all the provided plans.
+func getRegionsWithCapsAndPlans(t *testing.T, client *linodego.Client, capabilities, plans []string) []string {
+	regionsWithCaps := getRegionsWithCaps(t, client, capabilities)
+
+	regionsAvailabilities, err := client.ListRegionsAvailability(context.Background(), nil)
+	require.NoError(t, err)
+
+	type availKey struct {
+		Region string
+		Plan   string
+	}
+
+	availMap := make(map[availKey]linodego.RegionAvailability, len(regionsAvailabilities))
+	for _, avail := range regionsAvailabilities {
+		availMap[availKey{Region: avail.Region, Plan: avail.Plan}] = avail
+	}
+
+	// Function to check if a region has the required plans available
+	regionHasPlans := func(regionID string) bool {
 		for _, plan := range plans {
 			if avail, ok := availMap[availKey{Region: regionID, Plan: plan}]; !ok || !avail.Available {
 				return false
@@ -228,12 +242,14 @@ func getRegionsWithCaps(t *testing.T, client *linodego.Client, capabilities, pla
 		return true
 	}
 
-	for _, region := range regions {
-		if region.Status != "ok" || !regionHasCaps(region) || !regionHasPlans(region.ID) {
+	result := make([]string, 0, len(regionsWithCaps))
+
+	for _, region := range regionsWithCaps {
+		if !regionHasPlans(region) {
 			continue
 		}
 
-		result = append(result, region.ID)
+		result = append(result, region)
 	}
 
 	return result

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -256,7 +256,7 @@ func setupLKECluster(t *testing.T, clusterModifiers []clusterModifier, fixturesY
 
 	createOpts := linodego.LKEClusterCreateOptions{
 		Label:      label,
-		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes"}, []string{})[0],
+		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes"})[0],
 		K8sVersion: "1.29",
 		Tags:       []string{"testing"},
 		NodePools:  []linodego.LKENodePoolCreateOptions{{Count: 1, Type: "g6-standard-2", Tags: []string{"test"}}},

--- a/test/integration/lke_node_pools_test.go
+++ b/test/integration/lke_node_pools_test.go
@@ -189,7 +189,7 @@ func TestLKENodePool_CreateWithLabelsAndTaints(t *testing.T) {
 			Effect: linodego.LKENodePoolTaintEffectNoSchedule,
 		}},
 		Count: 1,
-		Type: "g6-standard-1",
+		Type:  "g6-standard-1",
 	}
 	_, _, nodePool, teardown, err := setupLKENodePool(t, "fixtures/TestLKENodePool_CreateWithLabelsAndTaints", createOpts)
 	if err != nil {

--- a/test/integration/mysql_test.go
+++ b/test/integration/mysql_test.go
@@ -180,7 +180,7 @@ func createMySQLDatabase(t *testing.T, client *linodego.Client,
 
 	createOpts := linodego.MySQLCreateOptions{
 		Label:           "go-mysql-test-def" + randLabel(),
-		Region:          getRegionsWithCaps(t, client, []string{"Managed Databases"}, []string{})[0],
+		Region:          getRegionsWithCaps(t, client, []string{"Managed Databases"})[0],
 		Type:            "g6-nanode-1",
 		Engine:          "mysql/8.0.30",
 		Encrypted:       false,

--- a/test/integration/nodebalancers_test.go
+++ b/test/integration/nodebalancers_test.go
@@ -86,7 +86,7 @@ func setupNodeBalancer(t *testing.T, fixturesYaml string) (*linodego.Client, *li
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 	createOpts := linodego.NodeBalancerCreateOptions{
 		Label:              &label,
-		Region:             getRegionsWithCaps(t, client, []string{"NodeBalancers"}, []string{})[0],
+		Region:             getRegionsWithCaps(t, client, []string{"NodeBalancers"})[0],
 		ClientConnThrottle: &clientConnThrottle,
 		FirewallID:         GetFirewallID(),
 	}

--- a/test/integration/object_storage_buckets_test.go
+++ b/test/integration/object_storage_buckets_test.go
@@ -41,7 +41,7 @@ func TestObjectStorageBucket_Create_smoke(t *testing.T) {
 func TestObjectStorageBucket_Regional(t *testing.T) {
 	// t.Skip("skipping region test before GA")
 	client, teardown := createTestClient(t, "fixtures/TestObjectStorageBucket_Regional")
-	regions := getRegionsWithCaps(t, client, []string{"Object Storage"}, []string{})
+	regions := getRegionsWithCaps(t, client, []string{"Object Storage"})
 	if len(regions) < 1 {
 		t.Fatal("Can't get region with Object Storage capability")
 	}

--- a/test/integration/object_storage_keys_test.go
+++ b/test/integration/object_storage_keys_test.go
@@ -155,7 +155,7 @@ func TestObjectStorageKeys_Limited_NoAccess(t *testing.T) {
 func TestObjectStorageKeys_Regional_Limited(t *testing.T) {
 	// t.Skip("skipping region test before GA")
 	client, teardown := createTestClient(t, "fixtures/TestObjectStorageKeys_Regional_Limited")
-	regions := getRegionsWithCaps(t, client, []string{"Object Storage"}, []string{})
+	regions := getRegionsWithCaps(t, client, []string{"Object Storage"})
 	if len(regions) < 1 {
 		t.Fatal("Can't get region with Object Storage capability")
 	}

--- a/test/integration/placement_group_test.go
+++ b/test/integration/placement_group_test.go
@@ -122,7 +122,7 @@ func createPlacementGroup(
 	t.Helper()
 	createOpts := linodego.PlacementGroupCreateOptions{
 		Label:                "linodego-test-" + getUniqueText(),
-		Region:               getRegionsWithCaps(t, client, []string{"Placement Group"}, []string{})[0],
+		Region:               getRegionsWithCaps(t, client, []string{"Placement Group"})[0],
 		PlacementGroupType:   linodego.PlacementGroupTypeAntiAffinityLocal,
 		PlacementGroupPolicy: linodego.PlacementGroupPolicyFlexible,
 	}

--- a/test/integration/postgres_test.go
+++ b/test/integration/postgres_test.go
@@ -180,7 +180,7 @@ func createPostgresDatabase(t *testing.T, client *linodego.Client,
 
 	createOpts := linodego.PostgresCreateOptions{
 		Label:           "go-postgres-testing-def" + randLabel(),
-		Region:          getRegionsWithCaps(t, client, []string{"Managed Databases"}, []string{})[0],
+		Region:          getRegionsWithCaps(t, client, []string{"Managed Databases"})[0],
 		Type:            "g6-nanode-1",
 		Engine:          "postgresql/14.6",
 		Encrypted:       false,

--- a/test/integration/tags_test.go
+++ b/test/integration/tags_test.go
@@ -95,7 +95,7 @@ func setupTaggedInstance(t *testing.T, fixturesYaml string) (*Client, *Instance,
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 	createOpts := InstanceCreateOptions{
 		Label:  "go-ins-test-tag",
-		Region: getRegionsWithCaps(t, client, []string{"Linodes"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"Linodes"})[0],
 		Type:   "g6-nanode-1",
 		Tags:   []string{"go-tag-test"},
 	}

--- a/test/integration/vlans_test.go
+++ b/test/integration/vlans_test.go
@@ -96,7 +96,7 @@ func createVLANInstance(t *testing.T, client *linodego.Client, instanceName, vla
 
 		opts.Booted = &trueBool
 		opts.Label = instanceName
-		opts.Region = getRegionsWithCaps(t, client, []string{"Vlans"}, []string{})[0]
+		opts.Region = getRegionsWithCaps(t, client, []string{"Vlans"})[0]
 	})
 	if err != nil {
 		return nil, nil, err

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -16,7 +16,7 @@ func TestVolume_Create_smoke(t *testing.T) {
 
 	createOpts := linodego.VolumeCreateOptions{
 		Label:  "go-vol-test-create",
-		Region: getRegionsWithCaps(t, client, []string{"Linodes"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"Linodes"})[0],
 	}
 	volume, err := client.CreateVolume(context.Background(), createOpts)
 	if err != nil {
@@ -175,7 +175,7 @@ func setupVolume(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 	createOpts := linodego.VolumeCreateOptions{
 		Label:  "go-vol-test-def",
-		Region: getRegionsWithCaps(t, client, []string{"Linodes"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"Linodes"})[0],
 	}
 	volume, err := client.CreateVolume(context.Background(), createOpts)
 	if err != nil {
@@ -201,7 +201,7 @@ func createVolume(
 	t.Helper()
 	createOpts := linodego.VolumeCreateOptions{
 		Label:  "go-vol-test" + randLabel(),
-		Region: getRegionsWithCaps(t, client, []string{"Linodes"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"Linodes"})[0],
 	}
 
 	for _, mod := range vModifier {

--- a/test/integration/vpc_subnet_test.go
+++ b/test/integration/vpc_subnet_test.go
@@ -82,7 +82,7 @@ func createVPCWithSubnet(t *testing.T, client *linodego.Client, vpcModifier ...v
 	t.Helper()
 	createOpts := linodego.VPCCreateOptions{
 		Label:  "go-test-vpc-" + getUniqueText(),
-		Region: getRegionsWithCaps(t, client, []string{"Linodes", "VPCs"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"Linodes", "VPCs"})[0],
 		Subnets: []VPCSubnetCreateOptions{
 			{
 				Label: "linodego-vpc-test-" + getUniqueText(),

--- a/test/integration/vpc_test.go
+++ b/test/integration/vpc_test.go
@@ -35,7 +35,7 @@ func createVPC(t *testing.T, client *linodego.Client, vpcModifier ...vpcModifier
 	t.Helper()
 	createOpts := linodego.VPCCreateOptions{
 		Label:  "go-test-vpc-" + getUniqueText(),
-		Region: getRegionsWithCaps(t, client, []string{"VPCs"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"VPCs"})[0],
 	}
 
 	for _, mod := range vpcModifier {
@@ -59,7 +59,7 @@ func createVPC_invalid_label(t *testing.T, client *linodego.Client) error {
 	t.Helper()
 	createOpts := linodego.VPCCreateOptions{
 		Label:  "gotest_vpc_invalid_label" + getUniqueText(),
-		Region: getRegionsWithCaps(t, client, []string{"VPCs"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"VPCs"})[0],
 	}
 	_, err := client.CreateVPC(context.Background(), createOpts)
 

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -18,7 +18,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 	}
 
 	instance, err := client.CreateInstance(context.Background(), linodego.InstanceCreateOptions{
-		Region:   getRegionsWithCaps(t, client, []string{"Linodes"}, []string{})[0],
+		Region:   getRegionsWithCaps(t, client, []string{"Linodes"})[0],
 		Type:     "g6-nanode-1",
 		Image:    "linode/ubuntu22.04",
 		RootPass: randPassword(),
@@ -102,7 +102,7 @@ func TestWaitForResourceFree(t *testing.T) {
 
 	// Create a booted instance
 	instance, err := client.CreateInstance(context.Background(), linodego.InstanceCreateOptions{
-		Region:   getRegionsWithCaps(t, client, []string{"Linodes"}, []string{})[0],
+		Region:   getRegionsWithCaps(t, client, []string{"Linodes"})[0],
 		Type:     "g6-nanode-1",
 		Image:    "linode/ubuntu22.04",
 		RootPass: randPassword(),
@@ -145,7 +145,7 @@ func TestEventPoller_Secondary(t *testing.T) {
 	}
 
 	instance, err := client.CreateInstance(context.Background(), linodego.InstanceCreateOptions{
-		Region: getRegionsWithCaps(t, client, []string{"Linodes"}, []string{})[0],
+		Region: getRegionsWithCaps(t, client, []string{"Linodes"})[0],
 		Type:   "g6-nanode-1",
 		Label:  "go-ins-poll-test",
 		Booted: linodego.Pointer(false),


### PR DESCRIPTION
## 📝 Description

This pull request separates the plan availability logic from getRegionWithCaps(...) into a separate getRegionsWithCapsAndPlans(...) function.

This prevents us from needing to specify desired plans for tests that don't need them, and lets us avoid re-running all test fixtures as a bonus.

This should resolve the following errors in CI:

```
2024/07/23 14:45:02.320444 WARN RESTY Get "https://api.linode.com/v4beta/regions/availability?page=1": Requested interaction not found, Attempt 1
2024/07/23 14:45:02.320460 ERROR RESTY Get "https://api.linode.com/v4beta/regions/availability?page=1": Requested interaction not found
```

## ✔️ How to Test

1. Pull down this PR locally.
2. Run `make SKIP_LINT=1 test`
3. Ensure the above errors are not raised.