### PR TITLE
feat: allow setting root CA from string

### DIFF
--- a/client.go
+++ b/client.go
@@ -431,9 +431,15 @@ func (c *Client) updateHostURL() {
 	)
 }
 
-// SetRootCertificate adds a root certificate to the underlying TLS client config
+// SetRootCertificate adds a path to the root certificate to the underlying TLS client config.
 func (c *Client) SetRootCertificate(path string) *Client {
 	c.resty.SetRootCertificate(path)
+	return c
+}
+
+// SetRootCertificateFromString adds a root certificate to the underlying TLS client config.
+func (c *Client) SetRootCertificateFromString(pemContent string) *Client {
+	c.resty.SetRootCertificateFromString(pemContent)
 	return c
 }
 


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

X-ref to the https://github.com/linode/linode-cosi-driver/issues/69 and https://github.com/linode/linode-cosi-driver/pull/82

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

It is essentially only exposing the underlying _resty_ method to the Linode Client.

**How do I run the relevant unit/integration tests?**
N/A