### PR TITLE
Add `last_login` field to `User` struct

### DIFF
--- a/account_users.go
+++ b/account_users.go
@@ -17,10 +17,17 @@ const (
 	UserTypeDefault UserType = "default"
 )
 
+// LastLogin represents a LastLogin object
+type LastLogin struct {
+	LoginDatetime *time.Time `json:"-"`
+	Status        string     `json:"status"`
+}
+
 // User represents a User object
 type User struct {
 	Username            string     `json:"username"`
 	Email               string     `json:"email"`
+	LastLogin           *LastLogin `json:"last_login"`
 	UserType            UserType   `json:"user_type"`
 	Restricted          bool       `json:"restricted"`
 	TFAEnabled          bool       `json:"tfa_enabled"`
@@ -40,6 +47,26 @@ type UserCreateOptions struct {
 type UserUpdateOptions struct {
 	Username   string `json:"username,omitempty"`
 	Restricted *bool  `json:"restricted,omitempty"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (ll *LastLogin) UnmarshalJSON(b []byte) error {
+	type Mask LastLogin
+
+	p := struct {
+		*Mask
+		LoginDatetime *parseabletime.ParseableTime `json:"login_datetime"`
+	}{
+		Mask: (*Mask)(ll),
+	}
+
+	if err := json.Unmarshal(b, &p); err != nil {
+		return err
+	}
+
+	ll.LoginDatetime = (*time.Time)(p.LoginDatetime)
+
+	return nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface


### PR DESCRIPTION
## 📝 Description

The field was previously missing, adding it to the struct now.

## ✔️ How to Test
```bash
make fixtures ARGS="-run TestUser"
```

```go
package main

import (
	"context"
	"fmt"
	"log"
	"net/http"
	"os"

	"github.com/linode/linodego"
	"golang.org/x/oauth2"
)

func main() {
	apiKey, ok := os.LookupEnv("LINODE_TOKEN")
	if !ok {
		log.Fatal("Could not find LINODE_TOKEN, please assert it is set.")
	}
	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: apiKey})

	oauth2Client := &http.Client{
		Transport: &oauth2.Transport{
			Source: tokenSource,
		},
	}

	linodeClient := linodego.NewClient(oauth2Client)
	linodeClient.SetDebug(true)

	usr, _ := linodeClient.GetUser(context.Background(), "YOUR_USERNAME")
	fmt.Println(usr.LastLogin.Status)
}

```