### PR TITLE
test: Add slack notifications to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [test]
-    if: always() && github.repository == 'linode/linodego' # Run even if integration tests fail and only on main repository
+    if: always() # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,69 @@ jobs:
         env:
           LINODE_CLI_OBJ_ACCESS_KEY: ${{ secrets.LINODE_CLI_OBJ_ACCESS_KEY }}
           LINODE_CLI_OBJ_SECRET_KEY: ${{ secrets.LINODE_CLI_OBJ_SECRET_KEY }}
+
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always() && github.repository == 'linode/linodego' # Run even if integration tests fail and only on main repository
+
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":rocket: *${{ github.workflow }} Completed in: ${{ github.repository }}* :white_check_mark:"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Build Result:*\n${{ steps.test.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branch:*\n`${{ github.ref_name }}`"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit Hash:*\n<${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Run URL:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run Details>"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "Triggered by: :bust_in_silhouette: `${{ github.actor }}`"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
   notify-slack:
     runs-on: ubuntu-latest
     needs: [test]
-    if: always() # Run even if integration tests fail and only on main repository
+    if: always() && github.repository == 'linode/linodego' # Run even if integration tests fail and only on main repository
 
     steps:
       - name: Notify Slack
@@ -106,7 +106,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Build Result:*\n${{ needs.test.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
+                      "text": "*Build Result:*\n${{ needs.test.result == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Build Result:*\n${{ steps.test.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
+                      "text": "*Build Result:*\n${{ needs.test.outcome == 'success' && ':large_green_circle: Build Passed' || ':red_circle: Build Failed' }}"
                     },
                     {
                       "type": "mrkdwn",


### PR DESCRIPTION
## 📝 Description

- Adding slack notifications to CI workflow
- Secrets required for the step including slack auth token and channel id are added as secrets

e.g. 
![image](https://github.com/user-attachments/assets/685be697-3eca-4958-87fe-6ed447381df3)


## ✔️ How to Test



## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**