### PR TITLE
Disallow configuring a custom root CA with a custom RoundTripper

### DIFF
--- a/client.go
+++ b/client.go
@@ -743,6 +743,11 @@ func NewClient(hc *http.Client) (client Client) {
 			log.Fatalf("[ERROR] Error when reading cert at %s: %s\n", certPath, err.Error())
 		}
 
+		if hc.Transport != http.DefaultTransport.(*http.Transport) {
+			log.Println("[WARN] Custom transport is not allowed with a custom root CA.")
+			return
+		}
+
 		client.SetRootCertificate(certPath)
 
 		if envDebug {

--- a/client.go
+++ b/client.go
@@ -32,7 +32,8 @@ const (
 	APIHost = "api.linode.com"
 	// APIHostVar environment var to check for alternate API URL
 	APIHostVar = "LINODE_URL"
-	// APIHostCert environment var containing path to CA cert to validate against
+	// APIHostCert environment var containing path to CA cert to validate against.
+	// Note that the custom CA cannot be configured together with a custom HTTP Transport.
 	APIHostCert = "LINODE_CA"
 	// APIVersion Linode API version
 	APIVersion = "v4"

--- a/client.go
+++ b/client.go
@@ -738,15 +738,10 @@ func NewClient(hc *http.Client) (client Client) {
 
 	certPath, certPathExists := os.LookupEnv(APIHostCert)
 
-	if certPathExists {
+	if certPathExists && !isCustomTransport(hc.Transport) {
 		cert, err := os.ReadFile(filepath.Clean(certPath))
 		if err != nil {
 			log.Fatalf("[ERROR] Error when reading cert at %s: %s\n", certPath, err.Error())
-		}
-
-		if hc.Transport != http.DefaultTransport.(*http.Transport) {
-			log.Println("[WARN] Custom transport is not allowed with a custom root CA.")
-			return
 		}
 
 		client.SetRootCertificate(certPath)
@@ -884,4 +879,12 @@ func generateListCacheURL(endpoint string, opts *ListOptions) (string, error) {
 	}
 
 	return fmt.Sprintf("%s:%s", endpoint, hashedOpts), nil
+}
+
+func isCustomTransport(transport http.RoundTripper) bool {
+	if transport != http.DefaultTransport.(*http.Transport) {
+		log.Println("[WARN] Custom transport is not allowed with a custom root CA.")
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## 📝 Description

Disallow that presenting custom root CA and custom http transport together. Print a warning and return when this happens.

## ✔️ How to Test

```
make testunit
```
