### PR TITLE
test: Skip LDE tests and remove LDE capability in test region

### DIFF
--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -177,7 +177,9 @@ func TestInstance_Disks_List(t *testing.T) {
 	}
 }
 
+// TODO:: Un-skip this test once diskencryption is enabled
 func TestInstance_Disks_List_WithEncryption(t *testing.T) {
+	t.Skip("Skip disk encryption tests until it is enabled in region")
 	client, instance, teardown, err := setupInstance(t, "fixtures/TestInstance_Disks_List_WithEncryption", true, func(c *linodego.Client, ico *linodego.InstanceCreateOptions) {
 		ico.Region = getRegionsWithCaps(t, c, []string{"Disk Encryption"})[0]
 	})
@@ -452,7 +454,9 @@ func TestInstance_Rebuild(t *testing.T) {
 	}
 }
 
+// TODO:: Un-skip this test once diskencryption is enabled
 func TestInstance_RebuildWithEncryption(t *testing.T) {
+	t.Skip("Skip disk encryption tests until it is enabled in region")
 	client, instance, _, teardown, err := setupInstanceWithoutDisks(
 		t,
 		"fixtures/TestInstance_RebuildWithEncryption",

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -287,9 +287,10 @@ func setupLKECluster(t *testing.T, clusterModifiers []clusterModifier, fixturesY
 	var fixtureTeardown func()
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 
+	// TODO:: Add "Disk Encryption" to Region once disk encryption is enabled
 	createOpts := linodego.LKEClusterCreateOptions{
 		Label:      label,
-		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes", "Disk Encryption"})[0],
+		Region:     getRegionsWithCaps(t, client, []string{"Kubernetes"})[0],
 		K8sVersion: "1.29",
 		Tags:       []string{"testing"},
 		NodePools:  []linodego.LKENodePoolCreateOptions{{Count: 1, Type: "g6-standard-2", Tags: []string{"test"}}},


### PR DESCRIPTION
## 📝 Description

Currently LDE capability is disabled in all region, hence removing the capability in testRegion and skipping related tests.

## ✔️ How to Test

```
make fixtures ARGS="-run TestInstance_Disks_List_WithEncryption"
make fixtures ARGS="-run TestLKECluster_GetFound_smoke"  
```

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**