### PR TITLE
Disable `recvcheck` linter, remove EOL linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
   enable-all: true
   disable:
     # deprecated linters
-    - execinquery
     - exportloopref
     ####################
 
@@ -60,7 +59,6 @@ linters:
     - wsl
     - varnamelen
     - tagliatelle
-    - gomnd
     - nlreturn
     - wrapcheck
     - wastedassign
@@ -73,4 +71,5 @@ linters:
     - tagalign
     - inamedparam
     - perfsprint
+    - recvcheck
   fast: false


### PR DESCRIPTION
## 📝 Description

[`recvcheck` requires receiver type of each method of the same struct to be the same](https://github.com/raeperd/recvcheck#motivtation), which is not realistic for our SDK.

Also removed some EOL linters.