### PR TITLE
test: Update default test image to reflect the deprecation of Debian 9 support

### DIFF
--- a/test/integration/domains_test.go
+++ b/test/integration/domains_test.go
@@ -2,8 +2,6 @@ package integration
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/linode/linodego"
@@ -94,7 +92,7 @@ func setupDomain(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 
 	createOpts := testDomainCreateOpts
-	createOpts.Domain = fmt.Sprintf("linodego-%s-test.com", fmt.Sprintf("%s%d", generateRandomString(5), rand.Intn(1000)))
+	createOpts.Domain = "linodego-blue-test.com"
 
 	domain, err := client.CreateDomain(context.Background(), createOpts)
 	if err != nil {
@@ -108,13 +106,4 @@ func setupDomain(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego
 		fixtureTeardown()
 	}
 	return client, domain, teardown, err
-}
-
-func generateRandomString(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
-	}
-	return string(b)
 }

--- a/test/integration/domains_test.go
+++ b/test/integration/domains_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/linode/linodego"
@@ -92,7 +94,7 @@ func setupDomain(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego
 	client, fixtureTeardown := createTestClient(t, fixturesYaml)
 
 	createOpts := testDomainCreateOpts
-	createOpts.Domain = "linodego-blue-test.com"
+	createOpts.Domain = fmt.Sprintf("linodego-%s-test.com", fmt.Sprintf("%s%d", generateRandomString(5), rand.Intn(1000)))
 
 	domain, err := client.CreateDomain(context.Background(), createOpts)
 	if err != nil {
@@ -106,4 +108,13 @@ func setupDomain(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego
 		fixtureTeardown()
 	}
 	return client, domain, teardown, err
+}
+
+func generateRandomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
 }

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -907,7 +907,7 @@ func createInstance(t *testing.T, client *linodego.Client, enableCloudFirewall b
 		RootPass: randPassword(),
 		Region:   getRegionsWithCaps(t, client, []string{"linodes"})[0],
 		Type:     "g6-nanode-1",
-		Image:    "linode/debian9",
+		Image:    "linode/debian12",
 		Booted:   linodego.Pointer(false),
 	}
 


### PR DESCRIPTION
## 📝 Description

There has been some deprecation for supported images lately (e.g. alpine 3.16, debian9) which is causing failures in integration tests. This PR addresses this and update the default test image.

## ✔️ How to Test

`make smoketest`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**