### PR TITLE
Checking for DefaultTransport in NewClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -882,7 +882,7 @@ func generateListCacheURL(endpoint string, opts *ListOptions) (string, error) {
 }
 
 func hasCustomTransport(hc *http.Client) bool {
-	if hc == nil {
+	if hc == nil || hc.Transport == nil {
 		return false
 	}
 	if hc.Transport != http.DefaultTransport.(*http.Transport) {

--- a/client.go
+++ b/client.go
@@ -885,7 +885,7 @@ func hasCustomTransport(hc *http.Client) bool {
 	if hc == nil || hc.Transport == nil {
 		return false
 	}
-	if hc.Transport != http.DefaultTransport.(*http.Transport) {
+	if _, ok := hc.Transport.(*http.Transport); !ok {
 		log.Println("[WARN] Custom transport is not allowed with a custom root CA.")
 		return true
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -597,17 +597,12 @@ func TestClient_CustomRootCAWithoutCustomRoundTripper(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if test.name != "set CA, use timeout" {
-			continue
-		}
 		t.Run(test.name, func(t *testing.T) {
 			if test.setCA {
 				t.Setenv(APIHostCert, caFile.Name())
 			}
 
 			client := NewClient(test.httpClient)
-			t.Logf("YALLO: %v", test.httpClient.Transport == http.DefaultTransport)
-
 			transport, err := client.resty.Transport()
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
An earlier PR - #593 (later adjusted in #635) - introduced a new check for `client.Transport`, but it turns out it does not behave as expected. While our tests cover the cases of `http.Client == nil` and `http.Client{Transport: custom}`, they don't cover the case of `http.Client{Timeout: foo}` (or any other non-transport setting). In such a case, `Transport` is set to `DefaultTransport`, BUT this value is not comparable to `http.DefaultTransport`.

~~I've added new tests to uncover this case, but I have yet to develop a correct implementation of this logic.~~

My solution is to not compare against `http.DefaultTransport`. We just check if the transport is the upstream `http.Transport` and if not, we assume this was reimplemented and thus its TLS stack won't be reconfigurable by Resty (see https://github.com/go-resty/resty/blob/1e19d6bc6a102df59e1997a09850d0c0532e7f9a/client.go#L860-L864 - this is where Resty fails if `client.Transport` is not `http.Transport` - but it only logs, no errors are propagated :sigh:)

I tested linodego with and without this PR and it has fixed an issue for us when we have `LINODE_CA=... && http.Client == http.Client{Timeout: foo}` (also one of the new test cases).

tl;dr: `client.Transport == http.DefaultTransport` is always `false`, this comparison has never worked, so any non-nil `http.Client` will fail this and trigger incorrect handling of `LINODE_CA`