### PR TITLE
test: Update obj smoke test remove deprecated Cluster variable

### DIFF
--- a/test/integration/fixtures/TestObjectStorageBuckets_List.yaml
+++ b/test/integration/fixtures/TestObjectStorageBuckets_List.yaml
@@ -42,7 +42,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 08 Jan 2025 06:03:18 GMT
+      - Thu, 30 Jan 2025 19:34:04 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -78,10 +78,50 @@ interactions:
     url: https://api.linode.com/v4beta/object-storage/buckets?page=1
     method: GET
   response:
-    body: '{"data": [{"hostname": "go-bucket-test-def.us-east-1.linodeobjects.com",
+    body: '{"data": [{"hostname": "bucket-1736798274052633022.gb-lon-1.linodeobjects.com",
+      "label": "bucket-1736798274052633022", "created": "2018-01-02T03:04:05", "region":
+      "gb-lon", "cluster": "", "size": 0, "objects": 0, "endpoint_type": "E3", "s3_endpoint":
+      "gb-lon-1.linodeobjects.com"}, {"hostname": "bucket-1738000793614673680.gb-lon-1.linodeobjects.com",
+      "label": "bucket-1738000793614673680", "created": "2018-01-02T03:04:05", "region":
+      "gb-lon", "cluster": "", "size": 0, "objects": 0, "endpoint_type": "E3", "s3_endpoint":
+      "gb-lon-1.linodeobjects.com"}, {"hostname": "go-bucket-test-def.us-east-1.linodeobjects.com",
       "label": "go-bucket-test-def", "created": "2018-01-02T03:04:05", "region": "us-east",
       "cluster": "us-east-1", "size": 0, "objects": 0, "endpoint_type": "E0", "s3_endpoint":
-      "us-east-1.linodeobjects.com"}], "page": 1, "pages": 1, "results": 1}'
+      "us-east-1.linodeobjects.com"}, {"hostname": "tf-test-1543819153442410267.sg-sin-1.linodeobjects.com",
+      "label": "tf-test-1543819153442410267", "created": "2018-01-02T03:04:05", "region":
+      "sg-sin-2", "cluster": "", "size": 0, "objects": 0, "endpoint_type": "E2", "s3_endpoint":
+      "sg-sin-1.linodeobjects.com"}, {"hostname": "tf-test-2484676038142344857.it-mil-1.linodeobjects.com",
+      "label": "tf-test-2484676038142344857", "created": "2018-01-02T03:04:05", "region":
+      "it-mil", "cluster": "it-mil-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "it-mil-1.linodeobjects.com"}, {"hostname": "tf-test-3502349996573909406.us-iad-1.linodeobjects.com",
+      "label": "tf-test-3502349996573909406", "created": "2018-01-02T03:04:05", "region":
+      "us-iad", "cluster": "us-iad-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"}, {"hostname": "tf-test-3632911602253826896.gb-lon-1.linodeobjects.com",
+      "label": "tf-test-3632911602253826896", "created": "2018-01-02T03:04:05", "region":
+      "gb-lon", "cluster": "", "size": 0, "objects": 0, "endpoint_type": "E3", "s3_endpoint":
+      "gb-lon-1.linodeobjects.com"}, {"hostname": "tf-test-3691810287020261631.us-iad-1.linodeobjects.com",
+      "label": "tf-test-3691810287020261631", "created": "2018-01-02T03:04:05", "region":
+      "us-iad", "cluster": "us-iad-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"}, {"hostname": "tf-test-3847259615974034792.us-iad-1.linodeobjects.com",
+      "label": "tf-test-3847259615974034792", "created": "2018-01-02T03:04:05", "region":
+      "us-iad", "cluster": "us-iad-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"}, {"hostname": "tf-test-5629732048996817677.us-iad-1.linodeobjects.com",
+      "label": "tf-test-5629732048996817677", "created": "2018-01-02T03:04:05", "region":
+      "us-iad", "cluster": "us-iad-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"}, {"hostname": "tf-test-6566002079784759866.us-iad-1.linodeobjects.com",
+      "label": "tf-test-6566002079784759866", "created": "2018-01-02T03:04:05", "region":
+      "us-iad", "cluster": "us-iad-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"}, {"hostname": "tf-test-6680232593917341773.us-iad-1.linodeobjects.com",
+      "label": "tf-test-6680232593917341773", "created": "2018-01-02T03:04:05", "region":
+      "us-iad", "cluster": "us-iad-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"}, {"hostname": "tf-test-6921913936824551527.id-cgk-1.linodeobjects.com",
+      "label": "tf-test-6921913936824551527", "created": "2018-01-02T03:04:05", "region":
+      "id-cgk", "cluster": "id-cgk-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "id-cgk-1.linodeobjects.com"}, {"hostname": "tf-test-8637208670123446138.us-iad-1.linodeobjects.com",
+      "label": "tf-test-8637208670123446138", "created": "2018-01-02T03:04:05", "region":
+      "us-iad", "cluster": "us-iad-1", "size": 0, "objects": 0, "endpoint_type": "E1",
+      "s3_endpoint": "us-iad-1.linodeobjects.com"}], "page": 1, "pages": 1, "results":
+      14}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -99,14 +139,12 @@ interactions:
       - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
-      Content-Length:
-      - "315"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Wed, 08 Jan 2025 06:03:20 GMT
+      - Thu, 30 Jan 2025 19:34:09 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -114,6 +152,7 @@ interactions:
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - object_storage:read_only
       X-Content-Type-Options:
@@ -168,7 +207,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Wed, 08 Jan 2025 06:03:26 GMT
+      - Thu, 30 Jan 2025 19:34:13 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/object_storage_buckets_test.go
+++ b/test/integration/object_storage_buckets_test.go
@@ -137,15 +137,24 @@ func TestObjectStorageBuckets_List_smoke(t *testing.T) {
 		"fixtures/TestObjectStorageBuckets_List", nil, nil, nil)
 	defer teardown()
 
-	i, err := client.ListObjectStorageBuckets(context.Background(), nil)
 	if err != nil {
-		t.Errorf("Error listing ObjectStorageBuckets, expected struct, got error %v", err)
+		t.Fatalf("Failed to set up test: %v", err)
 	}
-	if len(i) == 0 {
-		t.Errorf("Expected a list of ObjectStorageBuckets, but got none %v", i)
-	} else if i[0].Label == "" ||
-		i[0].Cluster == "" {
-		t.Errorf("Listed Object Storage Bucket did not have attribuets %v", i)
+
+	buckets, err := client.ListObjectStorageBuckets(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Error listing Object Storage Buckets: %v", err)
+	}
+
+	if len(buckets) == 0 {
+		t.Fatalf("Expected at least one Object Storage Bucket, but got none.")
+	}
+
+	for index, bucket := range buckets {
+		if bucket.Label == "" {
+			t.Errorf("Bucket at index %d is missing attributes: Label=%q, Full Bucket Data: %+v",
+				index, bucket.Label, bucket)
+		}
 	}
 }
 
@@ -163,7 +172,7 @@ func TestObjectStorageBucketsInCluster_List(t *testing.T) {
 		t.Errorf("Expected a list of ObjectStorageBucketsInCluster, but got none %v", i)
 	} else if i[0].Label == "" ||
 		i[0].Cluster == "" {
-		t.Errorf("Listed Object Storage Bucket in Cluster did not have attribuets %v", i)
+		t.Errorf("Listed Object Storage Bucket in Cluster did not have attributes %v", i)
 	}
 }
 


### PR DESCRIPTION
## 📝 Description

Addressing smoke test failure `TestObjectStorageBuckets_List_smoke` which caused by deprecated Cluster variable in response

Seen in - https://github.com/linode/linodego/actions/runs/13042850685/job/36388224503
 
## ✔️ How to Test

`make TEST_ARGS="-run TestObjectStorageBuckets_List_smoke" fixtures`

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**