### PR TITLE
Remove LKE ACL LA notices

### DIFF
--- a/lke_clusters_control_plane.go
+++ b/lke_clusters_control_plane.go
@@ -16,7 +16,6 @@ type LKEClusterControlPlaneACLAddresses struct {
 
 // LKEClusterControlPlaneACL describes the ACL configuration
 // for an LKE cluster's control plane.
-// NOTE: Control Plane ACLs may not currently be available to all users.
 type LKEClusterControlPlaneACL struct {
 	Enabled    bool                                `json:"enabled"`
 	Addresses  *LKEClusterControlPlaneACLAddresses `json:"addresses"`
@@ -32,7 +31,6 @@ type LKEClusterControlPlaneACLAddressesOptions struct {
 
 // LKEClusterControlPlaneACLOptions represents the options used when
 // configuring an LKE cluster's control plane ACL policy.
-// NOTE: Control Plane ACLs may not currently be available to all users.
 type LKEClusterControlPlaneACLOptions struct {
 	Enabled    *bool                                      `json:"enabled,omitempty"`
 	Addresses  *LKEClusterControlPlaneACLAddressesOptions `json:"addresses,omitempty"`
@@ -49,7 +47,6 @@ type LKEClusterControlPlaneOptions struct {
 // LKEClusterControlPlaneACLUpdateOptions represents the options
 // available when updating the ACL configuration of an LKE cluster's
 // control plane.
-// NOTE: Control Plane ACLs may not currently be available to all users.
 type LKEClusterControlPlaneACLUpdateOptions struct {
 	ACL LKEClusterControlPlaneACLOptions `json:"acl"`
 }
@@ -62,7 +59,6 @@ type LKEClusterControlPlaneACLResponse struct {
 
 // GetLKEClusterControlPlaneACL gets the ACL configuration for the
 // given cluster's control plane.
-// NOTE: Control Plane ACLs may not currently be available to all users.
 func (c *Client) GetLKEClusterControlPlaneACL(ctx context.Context, clusterID int) (*LKEClusterControlPlaneACLResponse, error) {
 	return doGETRequest[LKEClusterControlPlaneACLResponse](
 		ctx,
@@ -73,7 +69,6 @@ func (c *Client) GetLKEClusterControlPlaneACL(ctx context.Context, clusterID int
 
 // UpdateLKEClusterControlPlaneACL updates the ACL configuration for the
 // given cluster's control plane.
-// NOTE: Control Plane ACLs may not currently be available to all users.
 func (c *Client) UpdateLKEClusterControlPlaneACL(
 	ctx context.Context,
 	clusterID int,


### PR DESCRIPTION
## 📝 Description

This pull request removes all limited availability notices relating to LKE control plane ACLs.