### PR TITLE
Added missing options for POST and PUT methods

### DIFF
--- a/account_child.go
+++ b/account_child.go
@@ -39,7 +39,7 @@ func (c *Client) GetChildAccount(ctx context.Context, euuid string) (*ChildAccou
 // The attributes of this token are not currently configurable.
 // NOTE: Parent/Child related features may not be generally available.
 func (c *Client) CreateChildAccountToken(ctx context.Context, euuid string) (*ChildAccountToken, error) {
-	return doPOSTRequest[ChildAccountToken, any](
+	return doPOSTRequestNoRequestBody[ChildAccountToken](
 		ctx,
 		c,
 		formatAPIPath("account/child-accounts/%s/token", euuid),

--- a/account_invoices.go
+++ b/account_invoices.go
@@ -39,11 +39,6 @@ type InvoiceItem struct {
 	Total     float32    `json:"total"`
 }
 
-// ListInvoices gets a paginated list of Invoices against the Account
-func (c *Client) ListInvoices(ctx context.Context, opts *ListOptions) ([]Invoice, error) {
-	return getPaginatedResults[Invoice](ctx, c, "account/invoices", opts)
-}
-
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Invoice) UnmarshalJSON(b []byte) error {
 	type Mask Invoice
@@ -84,6 +79,11 @@ func (i *InvoiceItem) UnmarshalJSON(b []byte) error {
 	i.To = (*time.Time)(p.To)
 
 	return nil
+}
+
+// ListInvoices gets a paginated list of Invoices against the Account
+func (c *Client) ListInvoices(ctx context.Context, opts *ListOptions) ([]Invoice, error) {
+	return getPaginatedResults[Invoice](ctx, c, "account/invoices", opts)
 }
 
 // GetInvoice gets a single Invoice matching the provided ID

--- a/account_logins.go
+++ b/account_logins.go
@@ -17,10 +17,6 @@ type Login struct {
 	Status     string     `json:"status"`
 }
 
-func (c *Client) ListLogins(ctx context.Context, opts *ListOptions) ([]Login, error) {
-	return getPaginatedResults[Login](ctx, c, "account/logins", opts)
-}
-
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Login) UnmarshalJSON(b []byte) error {
 	type Mask Login
@@ -39,6 +35,10 @@ func (i *Login) UnmarshalJSON(b []byte) error {
 	i.Datetime = (*time.Time)(l.Datetime)
 
 	return nil
+}
+
+func (c *Client) ListLogins(ctx context.Context, opts *ListOptions) ([]Login, error) {
+	return getPaginatedResults[Login](ctx, c, "account/logins", opts)
 }
 
 func (c *Client) GetLogin(ctx context.Context, loginID int) (*Login, error) {

--- a/account_notifications.go
+++ b/account_notifications.go
@@ -56,15 +56,6 @@ const (
 	NotificationMaintenance        NotificationType = "maintenance"
 )
 
-// ListNotifications gets a collection of Notification objects representing important,
-// often time-sensitive items related to the Account. An account cannot interact directly with
-// Notifications, and a Notification will disappear when the circumstances causing it
-// have been resolved. For example, if the account has an important Ticket open, a response
-// to the Ticket will dismiss the Notification.
-func (c *Client) ListNotifications(ctx context.Context, opts *ListOptions) ([]Notification, error) {
-	return getPaginatedResults[Notification](ctx, c, "account/notifications", opts)
-}
-
 // UnmarshalJSON implements the json.Unmarshaler interface
 func (i *Notification) UnmarshalJSON(b []byte) error {
 	type Mask Notification
@@ -85,4 +76,13 @@ func (i *Notification) UnmarshalJSON(b []byte) error {
 	i.When = (*time.Time)(p.When)
 
 	return nil
+}
+
+// ListNotifications gets a collection of Notification objects representing important,
+// often time-sensitive items related to the Account. An account cannot interact directly with
+// Notifications, and a Notification will disappear when the circumstances causing it
+// have been resolved. For example, if the account has an important Ticket open, a response
+// to the Ticket will dismiss the Notification.
+func (c *Client) ListNotifications(ctx context.Context, opts *ListOptions) ([]Notification, error) {
+	return getPaginatedResults[Notification](ctx, c, "account/notifications", opts)
 }

--- a/account_oauth_client.go
+++ b/account_oauth_client.go
@@ -111,5 +111,5 @@ func (c *Client) DeleteOAuthClient(ctx context.Context, clientID string) error {
 // ResetOAuthClientSecret resets the OAuth Client secret for a client with a specified id
 func (c *Client) ResetOAuthClientSecret(ctx context.Context, clientID string) (*OAuthClient, error) {
 	e := formatAPIPath("account/oauth-clients/%s/reset-secret", clientID)
-	return doPOSTRequest[OAuthClient, any](ctx, c, e)
+	return doPOSTRequestNoRequestBody[OAuthClient](ctx, c, e)
 }

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -65,11 +65,14 @@ type InstanceDiskUpdateOptions struct {
 	Label string `json:"label"`
 }
 
-type InstanceDiskCloneOptions struct{}
+// InstanceDiskResizeOptions are InstanceDisk settings that can be used in resizes
+type InstanceDiskResizeOptions struct {
+	Size int `json:"size"`
+}
 
-// ListInstanceDisks lists InstanceDisks
-func (c *Client) ListInstanceDisks(ctx context.Context, linodeID int, opts *ListOptions) ([]InstanceDisk, error) {
-	return getPaginatedResults[InstanceDisk](ctx, c, formatAPIPath("linode/instances/%d/disks", linodeID), opts)
+// InstanceDiskPasswordResetOptions are InstanceDisk settings that can be used in password resets
+type InstanceDiskPasswordResetOptions struct {
+	Password string `json:"password"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface
@@ -92,6 +95,11 @@ func (i *InstanceDisk) UnmarshalJSON(b []byte) error {
 	i.Updated = (*time.Time)(p.Updated)
 
 	return nil
+}
+
+// ListInstanceDisks lists InstanceDisks
+func (c *Client) ListInstanceDisks(ctx context.Context, linodeID int, opts *ListOptions) ([]InstanceDisk, error) {
+	return getPaginatedResults[InstanceDisk](ctx, c, formatAPIPath("linode/instances/%d/disks", linodeID), opts)
 }
 
 // GetInstanceDisk gets the template with the provided ID
@@ -118,21 +126,13 @@ func (c *Client) RenameInstanceDisk(ctx context.Context, linodeID int, diskID in
 }
 
 // ResizeInstanceDisk resizes the size of the Instance disk
-func (c *Client) ResizeInstanceDisk(ctx context.Context, linodeID int, diskID int, size int) error {
-	opts := map[string]any{
-		"size": size,
-	}
-
+func (c *Client) ResizeInstanceDisk(ctx context.Context, linodeID int, diskID int, opts InstanceDiskResizeOptions) error {
 	e := formatAPIPath("linode/instances/%d/disks/%d/resize", linodeID, diskID)
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 
 // PasswordResetInstanceDisk resets the "root" account password on the Instance disk
-func (c *Client) PasswordResetInstanceDisk(ctx context.Context, linodeID int, diskID int, password string) error {
-	opts := map[string]any{
-		"password": password,
-	}
-
+func (c *Client) PasswordResetInstanceDisk(ctx context.Context, linodeID int, diskID int, opts InstanceDiskPasswordResetOptions) error {
 	e := formatAPIPath("linode/instances/%d/disks/%d/password", linodeID, diskID)
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
@@ -144,7 +144,7 @@ func (c *Client) DeleteInstanceDisk(ctx context.Context, linodeID int, diskID in
 }
 
 // CloneInstanceDisk clones the given InstanceDisk for the given Instance
-func (c *Client) CloneInstanceDisk(ctx context.Context, linodeID, diskID int, opts InstanceDiskCloneOptions) (*InstanceDisk, error) {
+func (c *Client) CloneInstanceDisk(ctx context.Context, linodeID, diskID int) (*InstanceDisk, error) {
 	e := formatAPIPath("linode/instances/%d/disks/%d/clone", linodeID, diskID)
-	return doPOSTRequest[InstanceDisk](ctx, c, e, opts)
+	return doPOSTRequestNoRequestBody[InstanceDisk](ctx, c, e)
 }

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -85,6 +85,11 @@ type InstanceReserveIPOptions struct {
 	Address string `json:"address"`
 }
 
+type InstanceIPAddOptions struct {
+	Type   string `json:"type"`
+	Public bool   `json:"public"`
+}
+
 // InstanceIPType constants start with IPType and include Linode Instance IP Types
 type InstanceIPType string
 
@@ -109,14 +114,10 @@ func (c *Client) GetInstanceIPAddress(ctx context.Context, linodeID int, ipaddre
 }
 
 // AddInstanceIPAddress adds a public or private IP to a Linode instance
-func (c *Client) AddInstanceIPAddress(ctx context.Context, linodeID int, public bool) (*InstanceIP, error) {
-	instanceipRequest := struct {
-		Type   string `json:"type"`
-		Public bool   `json:"public"`
-	}{"ipv4", public}
-
+func (c *Client) AddInstanceIPAddress(ctx context.Context, linodeID int, opts InstanceIPAddOptions) (*InstanceIP, error) {
+	opts.Type = "ipv4"
 	e := formatAPIPath("linode/instances/%d/ips", linodeID)
-	return doPOSTRequest[InstanceIP](ctx, c, e, instanceipRequest)
+	return doPOSTRequest[InstanceIP](ctx, c, e, opts)
 }
 
 // UpdateInstanceIPAddress updates the IPAddress with the specified instance id and IP address

--- a/instance_snapshots.go
+++ b/instance_snapshots.go
@@ -26,6 +26,10 @@ type RestoreInstanceOptions struct {
 	Overwrite bool `json:"overwrite"`
 }
 
+type InstanceSnapshotCreateOptions struct {
+	Label string `json:"label"`
+}
+
 // InstanceSnapshot represents a linode backup snapshot
 type InstanceSnapshot struct {
 	ID        int                     `json:"id"`
@@ -92,9 +96,7 @@ func (c *Client) GetInstanceSnapshot(ctx context.Context, linodeID int, snapshot
 }
 
 // CreateInstanceSnapshot Creates or Replaces the snapshot Backup of a Linode. If a previous snapshot exists for this Linode, it will be deleted.
-func (c *Client) CreateInstanceSnapshot(ctx context.Context, linodeID int, label string) (*InstanceSnapshot, error) {
-	opts := map[string]string{"label": label}
-
+func (c *Client) CreateInstanceSnapshot(ctx context.Context, linodeID int, opts InstanceSnapshotCreateOptions) (*InstanceSnapshot, error) {
 	e := formatAPIPath("linode/instances/%d/backups", linodeID)
 	return doPOSTRequest[InstanceSnapshot](ctx, c, e, opts)
 }

--- a/instances.go
+++ b/instances.go
@@ -277,6 +277,14 @@ type InstanceResizeOptions struct {
 	AllowAutoDiskResize *bool `json:"allow_auto_disk_resize,omitempty"`
 }
 
+type InstanceBootOptions struct {
+	ConfigID int `json:"config_id"`
+}
+
+type InstanceRebootOptions struct {
+	ConfigID int `json:"config_id"`
+}
+
 // InstanceMigrateOptions is an options struct used when migrating an instance
 type InstanceMigrateOptions struct {
 	Type    *InstanceMigrationType `json:"type,omitempty"`
@@ -333,15 +341,17 @@ func (c *Client) DeleteInstance(ctx context.Context, linodeID int) error {
 
 // BootInstance will boot a Linode instance
 // A configID of 0 will cause Linode to choose the last/best config
-func (c *Client) BootInstance(ctx context.Context, linodeID int, configID int) error {
-	opts := make(map[string]int)
+func (c *Client) BootInstance(ctx context.Context, linodeID int, opts InstanceBootOptions) error {
+	var payload InstanceBootOptions
 
-	if configID != 0 {
-		opts = map[string]int{"config_id": configID}
+	if opts.ConfigID != 0 {
+		payload = opts // Use the struct when ConfigID is set
+	} else {
+		payload = InstanceBootOptions{} // Send an empty JSON object when ConfigID is 0
 	}
 
 	e := formatAPIPath("linode/instances/%d/boot", linodeID)
-	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
+	return doPOSTRequestNoResponseBody(ctx, c, e, payload)
 }
 
 // CloneInstance clone an existing Instances Disks and Configuration profiles to another Linode Instance
@@ -358,15 +368,17 @@ func (c *Client) ResetInstancePassword(ctx context.Context, linodeID int, opts I
 
 // RebootInstance reboots a Linode instance
 // A configID of 0 will cause Linode to choose the last/best config
-func (c *Client) RebootInstance(ctx context.Context, linodeID int, configID int) error {
-	opts := make(map[string]int)
+func (c *Client) RebootInstance(ctx context.Context, linodeID int, opts InstanceRebootOptions) error {
+	var payload InstanceRebootOptions
 
-	if configID != 0 {
-		opts = map[string]int{"config_id": configID}
+	if opts.ConfigID != 0 {
+		payload = opts // Use the struct when ConfigID is set
+	} else {
+		payload = InstanceRebootOptions{} // Send an empty JSON object when ConfigID is 0
 	}
 
 	e := formatAPIPath("linode/instances/%d/reboot", linodeID)
-	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
+	return doPOSTRequestNoResponseBody(ctx, c, e, payload)
 }
 
 // InstanceRebuildOptions is a struct representing the options to send to the rebuild linode endpoint

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -159,6 +159,16 @@ func doPOSTRequestNoResponseBody[T any](
 	return err
 }
 
+// doPOSTRequestNoRequestBody runs a POST request using the given client and API endpoint.
+// It does not expect a request body but does expect a response from the endpoint.
+func doPOSTRequestNoRequestBody[T any](
+	ctx context.Context,
+	client *Client,
+	endpoint string,
+) (*T, error) {
+	return doPOSTRequest[T, any](ctx, client, endpoint)
+}
+
 // doPOSTRequestNoRequestResponseBody runs a POST request where no request body is needed and no response body
 // is expected from the endpoints.
 func doPOSTRequestNoRequestResponseBody(

--- a/test/integration/example_nodebalancers_test.go
+++ b/test/integration/example_nodebalancers_test.go
@@ -165,7 +165,10 @@ func ExampleClient_CreateNodeBalancerNode() {
 		log.Fatal(err)
 	}
 
-	ip, err := linodeClient.AddInstanceIPAddress(context.Background(), instance.ID, false)
+	opts := linodego.InstanceIPAddOptions{
+		Public: false,
+	}
+	ip, err := linodeClient.AddInstanceIPAddress(context.Background(), instance.ID, opts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/integration/instance_snapshots_test.go
+++ b/test/integration/instance_snapshots_test.go
@@ -118,7 +118,11 @@ func setupInstanceBackup(t *testing.T, fixturesYaml string) (*linodego.Client, *
 		t.Errorf("Error enabling Instance Backups: %v", err)
 	}
 
-	snapshot, err := client.CreateInstanceSnapshot(context.Background(), instance.ID, testSnapshotLabel)
+	opts := linodego.InstanceSnapshotCreateOptions{
+		Label: testSnapshotLabel,
+	}
+
+	snapshot, err := client.CreateInstanceSnapshot(context.Background(), instance.ID, opts)
 	if err != nil {
 		t.Errorf("Error creating instance snapshot: %v", err)
 	}

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -395,7 +395,11 @@ func TestInstance_Disk_Resize(t *testing.T) {
 		t.Errorf("Error waiting for disk readiness for resize: %s", err)
 	}
 
-	err = client.ResizeInstanceDisk(context.Background(), instance.ID, disk.ID, 4000)
+	opts := linodego.InstanceDiskResizeOptions{
+		Size: 4000,
+	}
+
+	err = client.ResizeInstanceDisk(context.Background(), instance.ID, disk.ID, opts)
 	if err != nil {
 		t.Errorf("Error resizing instance disk: %s", err)
 	}
@@ -408,7 +412,11 @@ func TestInstance_Disk_ListMultiple(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = client.BootInstance(context.Background(), instance1.ID, 0)
+
+	opts := linodego.InstanceBootOptions{
+		ConfigID: 0,
+	}
+	err = client.BootInstance(context.Background(), instance1.ID, opts)
 	if err != nil {
 		t.Error(err)
 	}
@@ -510,9 +518,7 @@ func TestInstance_Disk_Clone(t *testing.T) {
 		t.Errorf("Error waiting for disk readiness for disk clone: %s", err)
 	}
 
-	opts := linodego.InstanceDiskCloneOptions{}
-
-	_, err = client.CloneInstanceDisk(context.Background(), instance.ID, disk.ID, opts)
+	_, err = client.CloneInstanceDisk(context.Background(), instance.ID, disk.ID)
 	if err != nil {
 		t.Errorf("Error cloning instance disk: %s", err)
 	}
@@ -550,7 +556,10 @@ func TestInstance_Disk_ResetPassword(t *testing.T) {
 		t.Errorf("Error waiting for disk readiness for password reset: %s", err)
 	}
 
-	err = client.PasswordResetInstanceDisk(context.Background(), instance.ID, disk.ID, "r34!_b4d_p455")
+	opts := linodego.InstanceDiskPasswordResetOptions{
+		Password: "r34!_b4d_p455",
+	}
+	err = client.PasswordResetInstanceDisk(context.Background(), instance.ID, disk.ID, opts)
 	if err != nil {
 		t.Errorf("Error reseting password on instance disk: %s", err)
 	}

--- a/test/integration/network_ips_test.go
+++ b/test/integration/network_ips_test.go
@@ -376,7 +376,10 @@ func TestIPAddress_Instance_Delete(t *testing.T) {
 		t.Error(err)
 	}
 
-	ip, err := client.AddInstanceIPAddress(context.TODO(), instance.ID, true)
+	opts := linodego.InstanceIPAddOptions{
+		Public: true,
+	}
+	ip, err := client.AddInstanceIPAddress(context.TODO(), instance.ID, opts)
 	if err != nil {
 		t.Fatalf("failed to allocate public IPv4 for instance (%d): %s", instance.ID, err)
 	}
@@ -485,7 +488,10 @@ func TestIPAddress_Instance_Share(t *testing.T) {
 		t.Error(err)
 	}
 
-	ip, err := client.AddInstanceIPAddress(context.Background(), newInstance.ID, true)
+	opts := linodego.InstanceIPAddOptions{
+		Public: true,
+	}
+	ip, err := client.AddInstanceIPAddress(context.Background(), newInstance.ID, opts)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/nodebalancer_config_nodes_test.go
+++ b/test/integration/nodebalancer_config_nodes_test.go
@@ -170,7 +170,10 @@ func setupNodeBalancerNode(t *testing.T, fixturesYaml string) (*linodego.Client,
 		t.Errorf("failed to create test instance: %s", err)
 	}
 
-	instanceIP, err := client.AddInstanceIPAddress(context.Background(), instance.ID, false)
+	opts := linodego.InstanceIPAddOptions{
+		Public: false,
+	}
+	instanceIP, err := client.AddInstanceIPAddress(context.Background(), instance.ID, opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -76,7 +76,10 @@ func TestVolume_Resize(t *testing.T) {
 		t.Errorf("Error waiting for volume to be active, %s", err)
 	}
 
-	if err := client.ResizeVolume(context.Background(), volume.ID, volume.Size+1); err != nil {
+	opts := linodego.VolumeResizeOptions{
+		Size: volume.Size + 1,
+	}
+	if err := client.ResizeVolume(context.Background(), volume.ID, opts); err != nil {
 		t.Errorf("Error resizing volume, %s", err)
 	}
 }

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -48,7 +48,10 @@ func TestEventPoller_InstancePower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := client.BootInstance(context.Background(), instance.ID, 0); err != nil {
+	opts := linodego.InstanceBootOptions{
+		ConfigID: 0,
+	}
+	if err := client.BootInstance(context.Background(), instance.ID, opts); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/unit/instance_disks_test.go
+++ b/test/unit/instance_disks_test.go
@@ -18,9 +18,7 @@ func TestInstance_Disks_Clone(t *testing.T) {
 
 	base.MockPost("linode/instances/12345/disks/123/clone", fixtureData)
 
-	opts := linodego.InstanceDiskCloneOptions{}
-
-	disk, err := base.Client.CloneInstanceDisk(context.Background(), 12345, 123, opts)
+	disk, err := base.Client.CloneInstanceDisk(context.Background(), 12345, 123)
 	assert.NoError(t, err)
 
 	assert.Equal(t, linodego.DiskFilesystem("ext4"), disk.Filesystem)

--- a/test/unit/volume_test.go
+++ b/test/unit/volume_test.go
@@ -179,6 +179,10 @@ func TestResizeVolume(t *testing.T) {
 	volumeID := 123
 	base.MockPost(fmt.Sprintf("volumes/%d/resize", volumeID), nil)
 
-	err := base.Client.ResizeVolume(context.Background(), volumeID, 50)
+	opts := linodego.VolumeResizeOptions{
+		Size: 50,
+	}
+
+	err := base.Client.ResizeVolume(context.Background(), volumeID, opts)
 	assert.NoError(t, err, "Expected no error when resizing volume")
 }

--- a/volumes.go
+++ b/volumes.go
@@ -64,6 +64,14 @@ type VolumeUpdateOptions struct {
 	Tags  []string `json:"tags,omitempty"`
 }
 
+type VolumeCloneOptions struct {
+	Label string `json:"label"`
+}
+
+type VolumeResizeOptions struct {
+	Size int `json:"size"`
+}
+
 // VolumeAttachOptions fields are those accepted by AttachVolume
 type VolumeAttachOptions struct {
 	LinodeID           int   `json:"linode_id"`
@@ -141,11 +149,7 @@ func (c *Client) UpdateVolume(ctx context.Context, volumeID int, opts VolumeUpda
 }
 
 // CloneVolume clones a Linode volume
-func (c *Client) CloneVolume(ctx context.Context, volumeID int, label string) (*Volume, error) {
-	opts := map[string]any{
-		"label": label,
-	}
-
+func (c *Client) CloneVolume(ctx context.Context, volumeID int, opts VolumeCloneOptions) (*Volume, error) {
 	e := formatAPIPath("volumes/%d/clone", volumeID)
 	return doPOSTRequest[Volume](ctx, c, e, opts)
 }
@@ -157,11 +161,7 @@ func (c *Client) DetachVolume(ctx context.Context, volumeID int) error {
 }
 
 // ResizeVolume resizes an instance to new Linode type
-func (c *Client) ResizeVolume(ctx context.Context, volumeID int, size int) error {
-	opts := map[string]int{
-		"size": size,
-	}
-
+func (c *Client) ResizeVolume(ctx context.Context, volumeID int, opts VolumeResizeOptions) error {
 	e := formatAPIPath("volumes/%d/resize", volumeID)
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }


### PR DESCRIPTION
## 📝 Description

Updated POST/PUT endpoint methods that were not using options arguments to use them for consistency across the project.

## ✔️ How to Test

### Unit Tests
`make test-unit`

### Integration Tests
`make test-int`