### PR TITLE
Support for Entities and IAM endpoints

### DIFF
--- a/entities.go
+++ b/entities.go
@@ -1,0 +1,13 @@
+package linodego
+
+import "context"
+
+type LinodeEntity struct {
+	ID    int    `json:"id"`
+	Label string `json:"label"`
+	Type  string `json:"type"`
+}
+
+func (c *Client) ListEntities(ctx context.Context, opts *ListOptions) ([]LinodeEntity, error) {
+	return getPaginatedResults[LinodeEntity](ctx, c, "entities", opts)
+}

--- a/iam.go
+++ b/iam.go
@@ -7,6 +7,13 @@ type UserRolePermissions struct {
 	EntityAccess  []UserAccess `json:"entity_access"`
 }
 
+func (p *UserRolePermissions) GetUpdateOptions() UserRolePermissionsUpdateOptions {
+	return UserRolePermissionsUpdateOptions{
+		AccountAccess: p.AccountAccess,
+		EntityAccess:  p.EntityAccess,
+	}
+}
+
 type UserRolePermissionsUpdateOptions struct {
 	AccountAccess []string     `json:"account_access"`
 	EntityAccess  []UserAccess `json:"entity_access"`
@@ -24,7 +31,6 @@ type AccountRolePermissions struct {
 }
 
 type AccountAccess struct {
-	ID    int    `json:"id"`
 	Type  string `json:"type"`
 	Roles []Role `json:"roles"`
 }
@@ -47,8 +53,6 @@ func (c *Client) UpdateUserRolePermissions(ctx context.Context, username string,
 		opts,
 	)
 }
-
-// TODO: GET UPDATE USER ROLE OPTIONS
 
 func (c *Client) GetAccountRolePermissions(ctx context.Context) (*AccountRolePermissions, error) {
 	return doGETRequest[AccountRolePermissions](ctx, c, "iam/role-permissions")

--- a/iam.go
+++ b/iam.go
@@ -1,0 +1,55 @@
+package linodego
+
+import "context"
+
+type UserRolePermissions struct {
+	AccountAccess []string     `json:"account_access"`
+	EntityAccess  []UserAccess `json:"entity_access"`
+}
+
+type UserRolePermissionsUpdateOptions struct {
+	AccountAccess []string     `json:"account_access"`
+	EntityAccess  []UserAccess `json:"entity_access"`
+}
+
+type UserAccess struct {
+	ID    int      `json:"id"`
+	Type  string   `json:"type"`
+	Roles []string `json:"roles"`
+}
+
+type AccountRolePermissions struct {
+	AccountAccess []AccountAccess `json:"account_access"`
+	EntityAccess  []AccountAccess `json:"entity_access"`
+}
+
+type AccountAccess struct {
+	ID    int    `json:"id"`
+	Type  string `json:"type"`
+	Roles []Role `json:"roles"`
+}
+
+type Role struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Permissions []string `json:"permissions"`
+}
+
+func (c *Client) GetUserRolePermissions(ctx context.Context, username string) (*UserRolePermissions, error) {
+	return doGETRequest[UserRolePermissions](ctx, c,
+		formatAPIPath("iam/users/%s/role-permissions", username),
+	)
+}
+
+func (c *Client) UpdateUserRolePermissions(ctx context.Context, username string, opts UserRolePermissionsUpdateOptions) (*UserRolePermissions, error) {
+	return doPUTRequest[UserRolePermissions](ctx, c,
+		formatAPIPath("iam/users/%s/role-permissions", username),
+		opts,
+	)
+}
+
+// TODO: GET UPDATE USER ROLE OPTIONS
+
+func (c *Client) GetAccountRolePermissions(ctx context.Context) (*AccountRolePermissions, error) {
+	return doGETRequest[AccountRolePermissions](ctx, c, "iam/role-permissions")
+}

--- a/test/unit/entities_test.go
+++ b/test/unit/entities_test.go
@@ -1,0 +1,25 @@
+package unit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntities_List(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("entities_list")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockGet(formatMockAPIPath("entities"), fixtureData)
+
+	entities, err := base.Client.ListEntities(context.Background(), &linodego.ListOptions{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, 123, entities[0].ID)
+}

--- a/test/unit/entities_test.go
+++ b/test/unit/entities_test.go
@@ -21,5 +21,5 @@ func TestEntities_List(t *testing.T) {
 	entities, err := base.Client.ListEntities(context.Background(), &linodego.ListOptions{})
 	assert.NoError(t, err)
 
-	assert.Equal(t, 123, entities[0].ID)
+	assert.Equal(t, 7, entities[0].ID)
 }

--- a/test/unit/fixtures/entities_list.json
+++ b/test/unit/fixtures/entities_list.json
@@ -1,0 +1,27 @@
+{
+    "data": [
+        {
+            "id": 7,
+            "label": "linode7",
+            "type": "linode"
+        },
+        {
+            "id": 10,
+            "label": "linode10",
+            "type": "linode"
+        },
+        {
+            "id": 1,
+            "label": "no_devices",
+            "type": "firewall"
+        },
+        {
+            "id": 2,
+            "label": "active_with_nodebalancer",
+            "type": "firewall"
+        }
+    ],
+    "page": 1,
+    "pages": 1,
+    "results": 4
+}

--- a/test/unit/fixtures/iam_account_get.json
+++ b/test/unit/fixtures/iam_account_get.json
@@ -1,0 +1,81 @@
+{
+    "account_access": [
+        {
+            "type": "account",
+            "roles": [
+                {
+                    "name": "account_admin",
+                    "description": "Access to perform any supported action on all entities of the account",
+                    "permissions": [
+                        "create_linode",
+                        "update_linode",
+                        "update_firewall"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "linode",
+            "roles": [
+                {
+                    "name": "account_linode_admin",
+                    "description": "Access to perform any supported action on all linode instances of the account",
+                    "permissions": [
+                        "create_linode",
+                        "update_linode",
+                        "delete_linode"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "firewall",
+            "roles": [
+                {
+                    "name": "firewall_creator",
+                    "description": "Access to create a firewall instance",
+                    "permissions": [
+                        "update_linode",
+                        "view_linode"
+                    ]
+                }
+            ]
+        }
+    ],
+    "entity_access": [
+        {
+            "type": "linode",
+            "roles": [
+                {
+                    "name": "linode_contributor",
+                    "description": "Access to update a linode instance",
+                    "permissions": [
+                        "update_linode",
+                        "view_linode"
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "firewall",
+            "roles": [
+                {
+                    "name": "firewall_viewer",
+                    "description": "Access to view a firewall instance",
+                    "permissions": [
+                        "update_linode",
+                        "view_linode"
+                    ]
+                },
+                {
+                    "name": "firewall_admin",
+                    "description": "Access to perform any supported action on a firewall instance",
+                    "permissions": [
+                        "update_linode",
+                        "view_linode"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/test/unit/fixtures/iam_user_get.json
+++ b/test/unit/fixtures/iam_user_get.json
@@ -1,0 +1,23 @@
+{
+    "account_access": [
+        "account_linode_admin",
+        "linode_creator",
+        "firewall_creator"
+    ],
+    "entity_access": [
+        {
+            "id": 1,
+            "type": "linode",
+            "roles": [
+                "linode_contributor"
+            ]
+        },
+        {
+            "id": 1,
+            "type": "firewall",
+            "roles": [
+                "firewall_admin"
+            ]
+        }
+    ]
+}

--- a/test/unit/fixtures/iam_user_update.json
+++ b/test/unit/fixtures/iam_user_update.json
@@ -1,0 +1,24 @@
+{
+    "account_access": [
+        "account_linode_admin",
+        "linode_creator",
+        "firewall_creator",
+        "test_admin"
+    ],
+    "entity_access": [
+        {
+            "id": 1,
+            "type": "linode",
+            "roles": [
+                "linode_contributor"
+            ]
+        },
+        {
+            "id": 1,
+            "type": "firewall",
+            "roles": [
+                "firewall_admin"
+            ]
+        }
+    ]
+}

--- a/test/unit/iam_test.go
+++ b/test/unit/iam_test.go
@@ -1,0 +1,44 @@
+package unit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserRolePermissions_Get(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("iam_user_get")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockGet(formatMockAPIPath("iam/users/Linode/role-permissions"), fixtureData)
+
+	perms, err := base.Client.GetUserRolePermissions(context.Background(), "Linode")
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, perms.EntityAccess[0].ID)
+}
+
+func TestUserRolePermissions_Update(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("iam_user_update")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	// TODO: get update role options
+	opts := linodego.UserRolePermissionsUpdateOptions{}
+
+	base.MockPut(formatMockAPIPath("iam/users/Linode/role-permissions"), fixtureData)
+
+	perms, err := base.Client.UpdateUserRolePermissions(context.Background(), "Linode", opts)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, perms.EntityAccess[0].ID)
+}


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Implements:
- **GET** /entities
- **GET** /iam/role-permissions
- **GET** /iam/users/{username}/role-permissions
- **PUT** /iam/users/{username}/role-permissions

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

```bash
make TEST_ARGS='-run TestIAM' test-unit
```
```bash
make TEST_ARGS='-run TestEntities' test-unit
```
