### PR TITLE
Add future breaking change notice for ConfigID in VPC IP

### DIFF
--- a/instance_ips.go
+++ b/instance_ips.go
@@ -48,8 +48,10 @@ type VPCIP struct {
 	NAT1To1      *string `json:"nat_1_1"`
 	VPCID        int     `json:"vpc_id"`
 	SubnetID     int     `json:"subnet_id"`
-	ConfigID     int     `json:"config_id"`
 	InterfaceID  int     `json:"interface_id"`
+
+	// Scheduled breaking change: ConfigID is now nullable from the API and will become a pointer in the next major version.
+	ConfigID int `json:"config_id"`
 }
 
 // InstanceIPv6Response contains the IPv6 addresses and ranges for an Instance

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -50,7 +50,7 @@ type VPCIP struct {
 	SubnetID     int     `json:"subnet_id"`
 	InterfaceID  int     `json:"interface_id"`
 
-	// Scheduled breaking change: ConfigID is now nullable from the API and will become a pointer in the next major version.
+	// The type of this field will be made a pointer in the next major release of linodego.
 	ConfigID int `json:"config_id"`
 }
 


### PR DESCRIPTION
## 📝 Description

ConfigID is now nullable from the API, and needs to be changed to a pointer in the next major version. So adding a notice here.

The lint error reported by the CI is irrelevant, and should be fixed from the main branch.