### PR TITLE
Nullable default firewall ids

### DIFF
--- a/firewalls.go
+++ b/firewalls.go
@@ -66,7 +66,7 @@ type DefaultFirewallIDs struct {
 
 // FirewallSettingsUpdateOptions is an options struct used when Updating FirewallSettings
 type FirewallSettingsUpdateOptions struct {
-	DefaultFirewallIDs DefaultFirewallIDsOptions `json:"default_firewall_ids"`
+	DefaultFirewallIDs *DefaultFirewallIDsOptions `json:"default_firewall_ids,omitempty"`
 }
 
 type DefaultFirewallIDsOptions struct {

--- a/test/integration/firewalls_test.go
+++ b/test/integration/firewalls_test.go
@@ -223,7 +223,7 @@ func TestFirewallSettings_UpdateAllFields(t *testing.T) {
 
 	t.Cleanup(func() {
 		restoreOpts := linodego.FirewallSettingsUpdateOptions{
-			DefaultFirewallIDs: linodego.DefaultFirewallIDsOptions{
+			DefaultFirewallIDs: &linodego.DefaultFirewallIDsOptions{
 				Linode:          linodego.Pointer(originalSettings.DefaultFirewallIDs.Linode),
 				NodeBalancer:    linodego.Pointer(originalSettings.DefaultFirewallIDs.NodeBalancer),
 				PublicInterface: linodego.Pointer(originalSettings.DefaultFirewallIDs.PublicInterface),
@@ -238,7 +238,7 @@ func TestFirewallSettings_UpdateAllFields(t *testing.T) {
 
 	// Update all default firewall settings to the test firewall
 	updateOpts := linodego.FirewallSettingsUpdateOptions{
-		DefaultFirewallIDs: linodego.DefaultFirewallIDsOptions{
+		DefaultFirewallIDs: &linodego.DefaultFirewallIDsOptions{
 			Linode:          linodego.DoublePointer(firewall.ID),
 			NodeBalancer:    linodego.DoublePointer(firewall.ID),
 			PublicInterface: linodego.DoublePointer(firewall.ID),
@@ -291,7 +291,7 @@ func TestFirewallSettings_UpdatePartial(t *testing.T) {
 	// Restore original settings after test
 	t.Cleanup(func() {
 		restoreOpts := linodego.FirewallSettingsUpdateOptions{
-			DefaultFirewallIDs: linodego.DefaultFirewallIDsOptions{
+			DefaultFirewallIDs: &linodego.DefaultFirewallIDsOptions{
 				Linode:          linodego.Pointer(originalSettings.DefaultFirewallIDs.Linode),
 				NodeBalancer:    linodego.Pointer(originalSettings.DefaultFirewallIDs.NodeBalancer),
 				PublicInterface: linodego.Pointer(originalSettings.DefaultFirewallIDs.PublicInterface),
@@ -306,7 +306,7 @@ func TestFirewallSettings_UpdatePartial(t *testing.T) {
 
 	// Update only the Linode default firewall ID
 	opts := linodego.FirewallSettingsUpdateOptions{
-		DefaultFirewallIDs: linodego.DefaultFirewallIDsOptions{
+		DefaultFirewallIDs: &linodego.DefaultFirewallIDsOptions{
 			Linode: linodego.DoublePointer(firewall.ID),
 		},
 	}

--- a/test/unit/firewalls_test.go
+++ b/test/unit/firewalls_test.go
@@ -286,7 +286,7 @@ func TestDefaultFirewall_Update(t *testing.T) {
 	base.MockPut(formatMockAPIPath("networking/firewalls/settings"), fixtureData)
 
 	requestData := linodego.FirewallSettingsUpdateOptions{
-		DefaultFirewallIDs: linodego.DefaultFirewallIDsOptions{
+		DefaultFirewallIDs: &linodego.DefaultFirewallIDsOptions{
 			Linode:          linodego.DoublePointer(1),
 			NodeBalancer:    linodego.DoublePointer(1),
 			VPCInterface:    linodego.DoublePointer(1),


### PR DESCRIPTION
## 📝 Description

Making `DefaultFirewallIDs` field a pointer, so we can omit it in the future if other firewall settings are added.

## ✔️ How to Test
`make test-int`