### PR TITLE
Fix Lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - nilerr
     - nlreturn
     - noctx
+    - noinlineerr
     - nolintlint
     - nonamedreturns
     - perfsprint

--- a/account.go
+++ b/account.go
@@ -72,6 +72,7 @@ func (i *Account) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		ActiveSince *parseabletime.ParseableTime `json:"active_since"`
 	}{
 		Mask: (*Mask)(i),

--- a/account_betas.go
+++ b/account_betas.go
@@ -31,6 +31,7 @@ func (cBeta *AccountBetaProgram) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Started  *parseabletime.ParseableTime `json:"started"`
 		Ended    *parseabletime.ParseableTime `json:"ended"`
 		Enrolled *parseabletime.ParseableTime `json:"enrolled"`

--- a/account_events.go
+++ b/account_events.go
@@ -221,7 +221,7 @@ const (
 // EntityType constants start with Entity and include Linode API Event Entity Types
 type EntityType string
 
-// EntityType contants are the entities an Event can be related to.
+// EntityType constants are the entities an Event can be related to.
 const (
 	EntityAccount        EntityType = "account"
 	EntityBackups        EntityType = "backups"
@@ -281,6 +281,7 @@ func (i *Event) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created       *parseabletime.ParseableTime `json:"created"`
 		TimeRemaining json.RawMessage              `json:"time_remaining"`
 	}{

--- a/account_invoices.go
+++ b/account_invoices.go
@@ -50,6 +50,7 @@ func (i *Invoice) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Date *parseabletime.ParseableTime `json:"date"`
 	}{
 		Mask: (*Mask)(i),
@@ -70,6 +71,7 @@ func (i *InvoiceItem) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		From *parseabletime.ParseableTime `json:"from"`
 		To   *parseabletime.ParseableTime `json:"to"`
 	}{

--- a/account_logins.go
+++ b/account_logins.go
@@ -27,6 +27,7 @@ func (i *Login) UnmarshalJSON(b []byte) error {
 
 	l := struct {
 		*Mask
+
 		Datetime *parseabletime.ParseableTime `json:"datetime"`
 	}{
 		Mask: (*Mask)(i),

--- a/account_maintenance.go
+++ b/account_maintenance.go
@@ -31,6 +31,7 @@ func (accountMaintenance *AccountMaintenance) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		When *parseabletime.ParseableTime `json:"when"`
 	}{
 		Mask: (*Mask)(accountMaintenance),

--- a/account_notifications.go
+++ b/account_notifications.go
@@ -71,6 +71,7 @@ func (i *Notification) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Until *parseabletime.ParseableTime `json:"until"`
 		When  *parseabletime.ParseableTime `json:"when"`
 	}{

--- a/account_payment_methods.go
+++ b/account_payment_methods.go
@@ -96,6 +96,7 @@ func (i *PaymentMethod) UnmarshalJSON(b []byte) error {
 
 	pm := &struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Data    json.RawMessage              `json:"data"`
 	}{
@@ -113,24 +114,28 @@ func (i *PaymentMethod) UnmarshalJSON(b []byte) error {
 		if err := json.Unmarshal(pm.Data, &creditCardData); err != nil {
 			return err
 		}
+
 		i.Data = creditCardData
 	case "google_pay":
 		var googlePayData PaymentMethodDataGooglePay
 		if err := json.Unmarshal(pm.Data, &googlePayData); err != nil {
 			return err
 		}
+
 		i.Data = googlePayData
 	case "paypal":
 		var paypalData PaymentMethodDataPaypal
 		if err := json.Unmarshal(pm.Data, &paypalData); err != nil {
 			return err
 		}
+
 		i.Data = paypalData
 	default:
 		return fmt.Errorf("unknown payment method type: %s", i.Type)
 	}
 
 	i.Created = (*time.Time)(pm.Created)
+
 	return nil
 }
 

--- a/account_payments.go
+++ b/account_payments.go
@@ -35,6 +35,7 @@ func (i *Payment) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Date *parseabletime.ParseableTime `json:"date"`
 	}{
 		Mask: (*Mask)(i),

--- a/account_promo_credits.go
+++ b/account_promo_credits.go
@@ -47,6 +47,7 @@ func (i *Promotion) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		ExpirationDate *parseabletime.ParseableTime `json:"date"`
 	}{
 		Mask: (*Mask)(i),

--- a/account_service_transfer.go
+++ b/account_service_transfer.go
@@ -50,6 +50,7 @@ func (ast *AccountServiceTransfer) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Expiry  *parseabletime.ParseableTime `json:"expiry"`
 		Updated *parseabletime.ParseableTime `json:"updated"`

--- a/account_users.go
+++ b/account_users.go
@@ -56,6 +56,7 @@ func (ll *LastLogin) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		LoginDatetime *parseabletime.ParseableTime `json:"login_datetime"`
 	}{
 		Mask: (*Mask)(ll),
@@ -76,6 +77,7 @@ func (i *User) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		PasswordCreated *parseabletime.ParseableTime `json:"password_created"`
 	}{
 		Mask: (*Mask)(i),

--- a/betas.go
+++ b/betas.go
@@ -35,6 +35,7 @@ func (beta *BetaProgram) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Started *parseabletime.ParseableTime `json:"started"`
 		Ended   *parseabletime.ParseableTime `json:"ended"`
 	}{

--- a/client.go
+++ b/client.go
@@ -141,6 +141,7 @@ func NewClient(hc *http.Client) (client Client) {
 	if baseURLExists {
 		client.SetBaseURL(baseURL)
 	}
+
 	apiVersion, apiVersionExists := os.LookupEnv(APIVersionVar)
 	if apiVersionExists {
 		client.SetAPIVersion(apiVersion)
@@ -211,6 +212,7 @@ func NewClientFromEnv(hc *http.Client) (*Client, error) {
 	}
 
 	err = client.preLoadConfig(configPath)
+
 	return &client, err
 }
 
@@ -259,16 +261,20 @@ func (c *httpClient) doRequest(ctx context.Context, method, url string, params R
 					err = closeErr
 				}
 			}()
+
 			if err = c.checkHTTPError(resp); err != nil {
 				return err
 			}
+
 			if c.debug && c.logger != nil {
 				var logErr error
+
 				resp, logErr = c.logResponse(resp)
 				if logErr != nil {
 					return logErr
 				}
 			}
+
 			if params.Response != nil {
 				if err = c.decodeResponseBody(resp, params.Response); err != nil {
 					return err
@@ -315,13 +321,16 @@ func (c *httpClient) shouldRetry(resp *http.Response, err error) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
 // nolint:unused
 func (c *httpClient) createRequest(ctx context.Context, method, url string, params RequestParams) (*http.Request, *bytes.Buffer, error) {
-	var bodyReader io.Reader
-	var bodyBuffer *bytes.Buffer
+	var (
+		bodyReader io.Reader
+		bodyBuffer *bytes.Buffer
+	)
 
 	if params.Body != nil {
 		bodyBuffer = new(bytes.Buffer)
@@ -329,8 +338,10 @@ func (c *httpClient) createRequest(ctx context.Context, method, url string, para
 			if c.debug && c.logger != nil {
 				c.logger.Errorf("failed to encode body: %v", err)
 			}
+
 			return nil, nil, fmt.Errorf("failed to encode body: %w", err)
 		}
+
 		bodyReader = bodyBuffer
 	}
 
@@ -339,11 +350,13 @@ func (c *httpClient) createRequest(ctx context.Context, method, url string, para
 		if c.debug && c.logger != nil {
 			c.logger.Errorf("failed to create request: %v", err)
 		}
+
 		return nil, nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+
 	if c.userAgent != "" {
 		req.Header.Set("User-Agent", c.userAgent)
 	}
@@ -358,9 +371,11 @@ func (c *httpClient) applyBeforeRequest(req *http.Request) error {
 			if c.debug && c.logger != nil {
 				c.logger.Errorf("failed to mutate before request: %v", err)
 			}
+
 			return fmt.Errorf("failed to mutate before request: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -371,9 +386,11 @@ func (c *httpClient) applyAfterResponse(resp *http.Response) error {
 			if c.debug && c.logger != nil {
 				c.logger.Errorf("failed to mutate after response: %v", err)
 			}
+
 			return fmt.Errorf("failed to mutate after response: %w", err)
 		}
 	}
+
 	return nil
 }
 
@@ -387,6 +404,7 @@ func (c *httpClient) logRequest(req *http.Request, method, url string, bodyBuffe
 	}
 
 	var logBuf bytes.Buffer
+
 	err := reqLogTemplate.Execute(&logBuf, map[string]interface{}{
 		"Method":  method,
 		"URL":     url,
@@ -405,8 +423,10 @@ func (c *httpClient) sendRequest(req *http.Request) (*http.Response, error) {
 		if c.debug && c.logger != nil {
 			c.logger.Errorf("failed to send request: %v", err)
 		}
+
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
+
 	return resp, nil
 }
 
@@ -417,8 +437,10 @@ func (c *httpClient) checkHTTPError(resp *http.Response) error {
 		if c.debug && c.logger != nil {
 			c.logger.Errorf("received HTTP error: %v", err)
 		}
+
 		return err
 	}
+
 	return nil
 }
 
@@ -430,6 +452,7 @@ func (c *httpClient) logResponse(resp *http.Response) (*http.Response, error) {
 	}
 
 	var logBuf bytes.Buffer
+
 	err := respLogTemplate.Execute(&logBuf, map[string]interface{}{
 		"Status":  resp.Status,
 		"Headers": resp.Header,
@@ -440,6 +463,7 @@ func (c *httpClient) logResponse(resp *http.Response) (*http.Response, error) {
 	}
 
 	resp.Body = io.NopCloser(bytes.NewReader(respBody.Bytes()))
+
 	return resp, nil
 }
 
@@ -449,8 +473,10 @@ func (c *httpClient) decodeResponseBody(resp *http.Response, response interface{
 		if c.debug && c.logger != nil {
 			c.logger.Errorf("failed to decode response: %v", err)
 		}
+
 		return fmt.Errorf("failed to decode response: %w", err)
 	}
+
 	return nil
 }
 
@@ -531,6 +557,7 @@ func (c *Client) UseURL(apiURL string) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
 	}
+
 	if parsedURL.Scheme == "" || parsedURL.Host == "" {
 		return nil, fmt.Errorf("need both scheme and host in API URL, got %q", apiURL)
 	}
@@ -600,6 +627,7 @@ func (c *Client) SetRetries() *Client {
 		addRetryConditional(requestNGINXRetryCondition).
 		SetRetryMaxWaitTime(APIRetryMaxWaitTime)
 	configureRetries(c)
+
 	return c
 }
 
@@ -734,6 +762,7 @@ func (c *Client) getCachedResponse(endpoint string) any {
 	// This is necessary as we take write
 	// access if the entry has expired.
 	rLocked := true
+
 	defer func() {
 		if rLocked {
 			c.cachedEntryLock.RUnlock()
@@ -756,12 +785,14 @@ func (c *Client) getCachedResponse(endpoint string) any {
 	if hasExpired {
 		// We need to give up our read access and request read-write access
 		c.cachedEntryLock.RUnlock()
+
 		rLocked = false
 
 		c.cachedEntryLock.Lock()
 		defer c.cachedEntryLock.Unlock()
 
 		delete(c.cachedEntries, endpoint)
+
 		return nil
 	}
 
@@ -888,9 +919,11 @@ func hasCustomTransport(hc *http.Client) bool {
 	if hc == nil || hc.Transport == nil {
 		return false
 	}
+
 	if _, ok := hc.Transport.(*http.Transport); !ok {
 		log.Println("[WARN] Custom transport is not allowed with a custom root CA.")
 		return true
 	}
+
 	return false
 }

--- a/databases.go
+++ b/databases.go
@@ -170,6 +170,7 @@ func (d *Database) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created           *parseabletime.ParseableTime `json:"created"`
 		Updated           *parseabletime.ParseableTime `json:"updated"`
 		OldestRestoreTime *parseabletime.ParseableTime `json:"oldest_restore_time"`
@@ -184,6 +185,7 @@ func (d *Database) UnmarshalJSON(b []byte) error {
 	d.Created = (*time.Time)(p.Created)
 	d.Updated = (*time.Time)(p.Updated)
 	d.OldestRestoreTime = (*time.Time)(p.OldestRestoreTime)
+
 	return nil
 }
 
@@ -192,6 +194,7 @@ func (d *DatabaseFork) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		RestoreTime *parseabletime.ParseableTime `json:"restore_time"`
 	}{
 		Mask: (*Mask)(d),
@@ -202,6 +205,7 @@ func (d *DatabaseFork) UnmarshalJSON(b []byte) error {
 	}
 
 	d.RestoreTime = (*time.Time)(p.RestoreTime)
+
 	return nil
 }
 
@@ -210,6 +214,7 @@ func (d *DatabaseMaintenanceWindowPending) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Deadline   *parseabletime.ParseableTime `json:"deadline"`
 		PlannedFor *parseabletime.ParseableTime `json:"planned_for"`
 	}{
@@ -222,6 +227,7 @@ func (d *DatabaseMaintenanceWindowPending) UnmarshalJSON(b []byte) error {
 
 	d.Deadline = (*time.Time)(p.Deadline)
 	d.PlannedFor = (*time.Time)(p.PlannedFor)
+
 	return nil
 }
 

--- a/domain_records.go
+++ b/domain_records.go
@@ -56,7 +56,7 @@ type DomainRecordUpdateOptions struct {
 // DomainRecordType constants start with RecordType and include Linode API Domain Record Types
 type DomainRecordType string
 
-// DomainRecordType contants are the DNS record types a DomainRecord can assign
+// DomainRecordType constants are the DNS record types a DomainRecord can assign
 const (
 	RecordTypeA     DomainRecordType = "A"
 	RecordTypeAAAA  DomainRecordType = "AAAA"
@@ -75,6 +75,7 @@ func (d *DomainRecord) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{
@@ -87,6 +88,7 @@ func (d *DomainRecord) UnmarshalJSON(b []byte) error {
 
 	d.Created = (*time.Time)(p.Created)
 	d.Updated = (*time.Time)(p.Updated)
+
 	return nil
 }
 

--- a/errors.go
+++ b/errors.go
@@ -225,11 +225,13 @@ func ErrHasStatus(err error, code ...int) bool {
 	if !errors.As(err, &e) {
 		return false
 	}
+
 	ec := e.StatusCode()
 	for _, c := range code {
 		if ec == c {
 			return true
 		}
 	}
+
 	return false
 }

--- a/firewall_devices.go
+++ b/firewall_devices.go
@@ -37,6 +37,7 @@ func (device *FirewallDevice) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{
@@ -49,6 +50,7 @@ func (device *FirewallDevice) UnmarshalJSON(b []byte) error {
 
 	device.Created = (*time.Time)(p.Created)
 	device.Updated = (*time.Time)(p.Updated)
+
 	return nil
 }
 

--- a/firewalls.go
+++ b/firewalls.go
@@ -65,6 +65,7 @@ func (f *Firewall) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{
@@ -77,6 +78,7 @@ func (f *Firewall) UnmarshalJSON(b []byte) error {
 
 	f.Created = (*time.Time)(p.Created)
 	f.Updated = (*time.Time)(p.Updated)
+
 	return nil
 }
 

--- a/images.go
+++ b/images.go
@@ -116,6 +116,7 @@ func (i *Image) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Updated *parseabletime.ParseableTime `json:"updated"`
 		Created *parseabletime.ParseableTime `json:"created"`
 		Expiry  *parseabletime.ParseableTime `json:"expiry"`
@@ -140,6 +141,7 @@ func (i *Image) UnmarshalJSON(b []byte) error {
 func (i Image) GetUpdateOptions() (iu ImageUpdateOptions) {
 	iu.Label = i.Label
 	iu.Description = copyString(&i.Description)
+
 	return
 }
 

--- a/instance_config_interfaces.go
+++ b/instance_config_interfaces.go
@@ -50,6 +50,7 @@ func getInstanceConfigInterfacesCreateOptionsList(
 	for index, configInterface := range interfaces {
 		interfaceOptsList[index] = configInterface.GetCreateOptions()
 	}
+
 	return interfaceOptsList
 }
 
@@ -123,6 +124,7 @@ func (c *Client) GetInstanceConfigInterface(
 		configID,
 		interfaceID,
 	)
+
 	return doGETRequest[InstanceConfigInterface](ctx, c, e)
 }
 
@@ -136,6 +138,7 @@ func (c *Client) ListInstanceConfigInterfaces(
 		linodeID,
 		configID,
 	)
+
 	response, err := doGETRequest[[]InstanceConfigInterface](ctx, c, e)
 	if err != nil {
 		return nil, err
@@ -157,6 +160,7 @@ func (c *Client) UpdateInstanceConfigInterface(
 		configID,
 		interfaceID,
 	)
+
 	return doPUTRequest[InstanceConfigInterface](ctx, c, e, opts)
 }
 
@@ -172,6 +176,7 @@ func (c *Client) DeleteInstanceConfigInterface(
 		configID,
 		interfaceID,
 	)
+
 	return doDELETERequest(ctx, c, e)
 }
 
@@ -186,5 +191,6 @@ func (c *Client) ReorderInstanceConfigInterfaces(
 		linodeID,
 		configID,
 	)
+
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }

--- a/instance_configs.go
+++ b/instance_configs.go
@@ -100,6 +100,7 @@ func (i *InstanceConfig) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{
@@ -122,6 +123,7 @@ func (i InstanceConfig) GetCreateOptions() InstanceConfigCreateOptions {
 	if i.InitRD != nil {
 		initrd = *i.InitRD
 	}
+
 	return InstanceConfigCreateOptions{
 		Label:       i.Label,
 		Comments:    i.Comments,

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -78,6 +78,7 @@ func (i *InstanceDisk) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{
@@ -124,6 +125,7 @@ func (c *Client) ResizeInstanceDisk(ctx context.Context, linodeID int, diskID in
 	}
 
 	e := formatAPIPath("linode/instances/%d/disks/%d/resize", linodeID, diskID)
+
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 
@@ -134,6 +136,7 @@ func (c *Client) PasswordResetInstanceDisk(ctx context.Context, linodeID int, di
 	}
 
 	e := formatAPIPath("linode/instances/%d/disks/%d/password", linodeID, diskID)
+
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -116,6 +116,7 @@ func (c *Client) AddInstanceIPAddress(ctx context.Context, linodeID int, public 
 	}{"ipv4", public}
 
 	e := formatAPIPath("linode/instances/%d/ips", linodeID)
+
 	return doPOSTRequest[InstanceIP](ctx, c, e, instanceipRequest)
 }
 

--- a/instance_snapshots.go
+++ b/instance_snapshots.go
@@ -67,6 +67,7 @@ func (i *InstanceSnapshot) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created  *parseabletime.ParseableTime `json:"created"`
 		Updated  *parseabletime.ParseableTime `json:"updated"`
 		Finished *parseabletime.ParseableTime `json:"finished"`
@@ -96,6 +97,7 @@ func (c *Client) CreateInstanceSnapshot(ctx context.Context, linodeID int, label
 	opts := map[string]string{"label": label}
 
 	e := formatAPIPath("linode/instances/%d/backups", linodeID)
+
 	return doPOSTRequest[InstanceSnapshot](ctx, c, e, opts)
 }
 

--- a/instances.go
+++ b/instances.go
@@ -225,6 +225,7 @@ func (i *Instance) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{
@@ -247,6 +248,7 @@ func (backup *InstanceBackup) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		LastSuccessful *parseabletime.ParseableTime `json:"last_successful"`
 	}{
 		Mask: (*Mask)(backup),
@@ -371,6 +373,7 @@ func (c *Client) BootInstance(ctx context.Context, linodeID int, configID int) e
 	}
 
 	e := formatAPIPath("linode/instances/%d/boot", linodeID)
+
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 
@@ -396,6 +399,7 @@ func (c *Client) RebootInstance(ctx context.Context, linodeID int, configID int)
 	}
 
 	e := formatAPIPath("linode/instances/%d/reboot", linodeID)
+
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 

--- a/internal/testutil/mock.go
+++ b/internal/testutil/mock.go
@@ -87,6 +87,7 @@ func CreateMockClient[T any](t *testing.T, createFunc func(*http.Client) T) *T {
 	})
 
 	result := createFunc(client)
+
 	return &result
 }
 
@@ -124,5 +125,6 @@ func (l *TestLogger) outputf(format string, v ...interface{}) {
 		l.L.Print(format)
 		return
 	}
+
 	l.L.Printf(format, v...)
 }

--- a/kernels.go
+++ b/kernels.go
@@ -27,6 +27,7 @@ func (i *LinodeKernel) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Built *parseabletime.ParseableTime `json:"built"`
 	}{
 		Mask: (*Mask)(i),

--- a/lke_clusters.go
+++ b/lke_clusters.go
@@ -109,6 +109,7 @@ func (i *LKECluster) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{

--- a/lke_node_pools.go
+++ b/lke_node_pools.go
@@ -127,6 +127,7 @@ func (l LKENodePool) GetCreateOptions() (o LKENodePoolCreateOptions) {
 	o.Autoscaler = &l.Autoscaler
 	o.K8sVersion = l.K8sVersion
 	o.UpdateStrategy = l.UpdateStrategy
+
 	return
 }
 
@@ -139,6 +140,7 @@ func (l LKENodePool) GetUpdateOptions() (o LKENodePoolUpdateOptions) {
 	o.Autoscaler = &l.Autoscaler
 	o.K8sVersion = l.K8sVersion
 	o.UpdateStrategy = l.UpdateStrategy
+
 	return
 }
 

--- a/logger.go
+++ b/logger.go
@@ -47,5 +47,6 @@ func (l *logger) output(format string, v ...interface{}) { //nolint:goprintffunc
 		l.l.Print(format)
 		return
 	}
+
 	l.l.Printf(format, v...)
 }

--- a/longview.go
+++ b/longview.go
@@ -93,6 +93,7 @@ func (i *LongviewClient) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{

--- a/monitor_dashboards.go
+++ b/monitor_dashboards.go
@@ -98,6 +98,7 @@ func (i *MonitorDashboard) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{

--- a/mysql.go
+++ b/mysql.go
@@ -377,6 +377,7 @@ func (d *MySQLDatabase) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created           *parseabletime.ParseableTime `json:"created"`
 		Updated           *parseabletime.ParseableTime `json:"updated"`
 		OldestRestoreTime *parseabletime.ParseableTime `json:"oldest_restore_time"`
@@ -391,6 +392,7 @@ func (d *MySQLDatabase) UnmarshalJSON(b []byte) error {
 	d.Created = (*time.Time)(p.Created)
 	d.Updated = (*time.Time)(p.Updated)
 	d.OldestRestoreTime = (*time.Time)(p.OldestRestoreTime)
+
 	return nil
 }
 
@@ -448,6 +450,7 @@ func (d *MySQLDatabaseBackup) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 	}{
 		Mask: (*Mask)(d),
@@ -458,6 +461,7 @@ func (d *MySQLDatabaseBackup) UnmarshalJSON(b []byte) error {
 	}
 
 	d.Created = (*time.Time)(p.Created)
+
 	return nil
 }
 

--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -100,6 +100,7 @@ func (i *NodeBalancer) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{

--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -67,6 +67,7 @@ func (i *ObjectStorageBucket) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 	}{
 		Mask: (*Mask)(i),
@@ -175,14 +176,17 @@ func (c *Client) ListObjectStorageBucketContents(ctx context.Context, clusterOrR
 	basePath := formatAPIPath("object-storage/buckets/%s/%s/object-list", clusterOrRegionID, label)
 
 	queryString := ""
+
 	if params != nil {
 		values, err := query.Values(params)
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode query params: %w", err)
 		}
+
 		queryString = "?" + values.Encode()
 	}
 
 	e := basePath + queryString
+
 	return doGETRequest[ObjectStorageBucketContent](ctx, c, e)
 }

--- a/pagination.go
+++ b/pagination.go
@@ -102,6 +102,7 @@ func flattenQueryStruct(val any) (map[string]string, error) {
 		if reflectVal.IsNil() {
 			return nil, fmt.Errorf("QueryParams is a nil pointer")
 		}
+
 		reflectVal = reflect.Indirect(reflectVal)
 	}
 
@@ -164,5 +165,6 @@ func queryFieldToString(value reflect.Value) (string, error) {
 
 type legacyPagedResponse[T any] struct {
 	*PageOptions
+
 	Data []T `json:"data"`
 }

--- a/postgres.go
+++ b/postgres.go
@@ -575,6 +575,7 @@ func (d *PostgresDatabase) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created           *parseabletime.ParseableTime `json:"created"`
 		Updated           *parseabletime.ParseableTime `json:"updated"`
 		OldestRestoreTime *parseabletime.ParseableTime `json:"oldest_restore_time"`
@@ -589,6 +590,7 @@ func (d *PostgresDatabase) UnmarshalJSON(b []byte) error {
 	d.Created = (*time.Time)(p.Created)
 	d.Updated = (*time.Time)(p.Updated)
 	d.OldestRestoreTime = (*time.Time)(p.OldestRestoreTime)
+
 	return nil
 }
 
@@ -657,6 +659,7 @@ func (d *PostgresDatabaseBackup) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 	}{
 		Mask: (*Mask)(d),
@@ -667,6 +670,7 @@ func (d *PostgresDatabaseBackup) UnmarshalJSON(b []byte) error {
 	}
 
 	d.Created = (*time.Time)(p.Created)
+
 	return nil
 }
 

--- a/profile_apps.go
+++ b/profile_apps.go
@@ -38,6 +38,7 @@ func (pa *ProfileApp) UnmarshalJSON(b []byte) error {
 
 	l := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Expiry  *parseabletime.ParseableTime `json:"expiry"`
 	}{

--- a/profile_devices.go
+++ b/profile_devices.go
@@ -35,6 +35,7 @@ func (pd *ProfileDevice) UnmarshalJSON(b []byte) error {
 
 	l := struct {
 		*Mask
+
 		Created           *parseabletime.ParseableTime `json:"created"`
 		Expiry            *parseabletime.ParseableTime `json:"expiry"`
 		LastAuthenticated *parseabletime.ParseableTime `json:"last_authenticated"`

--- a/profile_logins.go
+++ b/profile_logins.go
@@ -24,6 +24,7 @@ func (i *ProfileLogin) UnmarshalJSON(b []byte) error {
 
 	l := struct {
 		*Mask
+
 		Datetime *parseabletime.ParseableTime `json:"datetime"`
 	}{
 		Mask: (*Mask)(i),

--- a/profile_preferences.go
+++ b/profile_preferences.go
@@ -18,6 +18,7 @@ func (p *ProfilePreferences) UnmarshalJSON(b []byte) error {
 	}
 
 	*p = data
+
 	return nil
 }
 

--- a/profile_sshkeys.go
+++ b/profile_sshkeys.go
@@ -33,6 +33,7 @@ func (i *SSHKey) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 	}{
 		Mask: (*Mask)(i),
@@ -51,6 +52,7 @@ func (i *SSHKey) UnmarshalJSON(b []byte) error {
 func (i SSHKey) GetCreateOptions() (o SSHKeyCreateOptions) {
 	o.Label = i.Label
 	o.SSHKey = i.SSHKey
+
 	return
 }
 

--- a/profile_tfa.go
+++ b/profile_tfa.go
@@ -29,6 +29,7 @@ func (s *TwoFactorSecret) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Expiry *parseabletime.ParseableTime `json:"expiry"`
 	}{
 		Mask: (*Mask)(s),

--- a/profile_tokens.go
+++ b/profile_tokens.go
@@ -54,6 +54,7 @@ func (i *Token) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Expiry  *parseabletime.ParseableTime `json:"expiry"`
 	}{
@@ -75,6 +76,7 @@ func (i Token) GetCreateOptions() (o TokenCreateOptions) {
 	o.Label = i.Label
 	o.Expiry = copyTime(i.Expiry)
 	o.Scopes = i.Scopes
+
 	return
 }
 
@@ -104,6 +106,7 @@ func (c *Client) CreateToken(ctx context.Context, opts TokenCreateOptions) (*Tok
 		Expiry *string `json:"expiry"`
 	}{}
 	createOptsFixed.Label = opts.Label
+
 	createOptsFixed.Scopes = opts.Scopes
 	if opts.Expiry != nil {
 		iso8601Expiry := opts.Expiry.UTC().Format("2006-01-02T15:04:05")

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -65,6 +65,7 @@ func getPaginatedResults[T any](
 		opts.Results = response.Results
 
 		result = append(result, response.Data...)
+
 		return nil
 	}
 
@@ -107,6 +108,7 @@ func doGETRequest[T any](
 	var resultType T
 
 	req := client.R(ctx).SetResult(&resultType)
+
 	r, err := coupleAPIErrors(req.Get(endpoint))
 	if err != nil {
 		return nil, err
@@ -138,6 +140,7 @@ func doPOSTRequest[T, O any](
 		if err != nil {
 			return nil, err
 		}
+
 		req.SetBody(string(body))
 	}
 
@@ -194,6 +197,7 @@ func doPUTRequest[T, O any](
 		if err != nil {
 			return nil, err
 		}
+
 		req.SetBody(string(body))
 	}
 
@@ -214,6 +218,7 @@ func doDELETERequest(
 ) error {
 	req := client.R(ctx)
 	_, err := coupleAPIErrors(req.Delete(endpoint))
+
 	return err
 }
 
@@ -238,5 +243,6 @@ func isNil(i interface{}) bool {
 
 	// Check for nil pointers
 	v := reflect.ValueOf(i)
+
 	return v.Kind() == reflect.Ptr && v.IsNil()
 }

--- a/retries.go
+++ b/retries.go
@@ -43,6 +43,7 @@ func checkRetryConditionals(c *Client) func(*resty.Response, error) bool {
 				return true
 			}
 		}
+
 		return false
 	}
 }
@@ -53,6 +54,7 @@ func linodeBusyRetryCondition(r *resty.Response, _ error) bool {
 	apiError, ok := r.Error().(*APIError)
 	linodeBusy := ok && apiError.Error() == "Linode busy."
 	retry := r.StatusCode() == http.StatusBadRequest && linodeBusy
+
 	return retry
 }
 
@@ -101,5 +103,6 @@ func respectRetryAfter(client *resty.Client, resp *resty.Response) (time.Duratio
 
 	duration := time.Duration(retryAfter) * time.Second
 	log.Printf("[INFO] Respecting Retry-After Header of %d (%s) (max %s)", retryAfter, duration, client.RetryMaxWaitTime)
+
 	return duration, nil
 }

--- a/retries_http.go
+++ b/retries_http.go
@@ -47,6 +47,7 @@ func httpcheckRetryConditionals(c *httpClient) httpRetryConditional {
 				return true
 			}
 		}
+
 		return false
 	}
 }
@@ -65,6 +66,7 @@ func httpRespectRetryAfter(resp *http.Response) (time.Duration, error) {
 
 	duration := time.Duration(retryAfter) * time.Second
 	log.Printf("[INFO] Respecting Retry-After Header of %d (%s)", retryAfter, duration)
+
 	return duration, nil
 }
 
@@ -75,6 +77,7 @@ func httpLinodeBusyRetryCondition(resp *http.Response, _ error) bool {
 	apiError, ok := getAPIError(resp)
 	linodeBusy := ok && apiError.Error() == "Linode busy."
 	retry := resp.StatusCode == http.StatusBadRequest && linodeBusy
+
 	return retry
 }
 
@@ -119,9 +122,11 @@ func httpRequestNGINXRetryCondition(resp *http.Response, _ error) bool {
 // nolint:unused
 func getAPIError(resp *http.Response) (*APIError, bool) {
 	var apiError APIError
+
 	err := json.NewDecoder(resp.Body).Decode(&apiError)
 	if err != nil {
 		return nil, false
 	}
+
 	return &apiError, true
 }

--- a/stackscripts.go
+++ b/stackscripts.go
@@ -69,6 +69,7 @@ func (i *Stackscript) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{

--- a/tags.go
+++ b/tags.go
@@ -63,30 +63,35 @@ func (i *TaggedObject) fixData() (*TaggedObject, error) {
 		if err := json.Unmarshal(i.RawData, &obj); err != nil {
 			return nil, err
 		}
+
 		i.Data = obj
 	case "lke_cluster":
 		obj := LKECluster{}
 		if err := json.Unmarshal(i.RawData, &obj); err != nil {
 			return nil, err
 		}
+
 		i.Data = obj
 	case "nodebalancer":
 		obj := NodeBalancer{}
 		if err := json.Unmarshal(i.RawData, &obj); err != nil {
 			return nil, err
 		}
+
 		i.Data = obj
 	case "domain":
 		obj := Domain{}
 		if err := json.Unmarshal(i.RawData, &obj); err != nil {
 			return nil, err
 		}
+
 		i.Data = obj
 	case "volume":
 		obj := Volume{}
 		if err := json.Unmarshal(i.RawData, &obj); err != nil {
 			return nil, err
 		}
+
 		i.Data = obj
 	}
 
@@ -105,6 +110,7 @@ func (c *Client) ListTaggedObjects(ctx context.Context, label string, opts *List
 			return nil, err
 		}
 	}
+
 	return response, nil
 }
 
@@ -146,6 +152,7 @@ func (t TaggedObjectList) SortedObjects() (SortedObjects, error) {
 			}
 		}
 	}
+
 	return so, nil
 }
 

--- a/test/integration/fixtures/TestInstance_GetMonthlyTransfer.yaml
+++ b/test/integration/fixtures/TestInstance_GetMonthlyTransfer.yaml
@@ -21,261 +21,274 @@ interactions:
       "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
       "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "ca-central", "label": "Toronto, CA", "country":
-      "ca", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups",
-      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
-      Storage Migrations", "Managed Databases", "Metadata", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "ca-central",
+      "label": "Toronto, CA", "country": "ca", "capabilities": ["Linodes", "LA Disk
+      Encryption", "Disk Encryption", "Backups", "NodeBalancers", "Block Storage",
+      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed
+      Databases", "Metadata", "Placement Group", "StackScripts", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
       "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "ap-southeast", "label": "Sydney, AU", "country":
-      "au", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups",
-      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
-      Storage Migrations", "Managed Databases", "Metadata", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "ap-southeast",
+      "label": "Sydney, AU", "country": "au", "capabilities": ["Linodes", "LA Disk
+      Encryption", "Disk Encryption", "Backups", "NodeBalancers", "Block Storage",
+      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed
+      Databases", "Metadata", "Placement Group", "StackScripts", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
       "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "us-iad", "label": "Washington, DC", "country":
-      "us", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "139.144.192.62,139.144.192.60,139.144.192.61,139.144.192.53,139.144.192.54,139.144.192.67,139.144.192.69,139.144.192.66,139.144.192.52,139.144.192.68",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "us-ord", "label": "Chicago, IL", "country":
-      "us", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans",
-      "VPCs", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
-      "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.232.0.17,172.232.0.16,172.232.0.21,172.232.0.13,172.232.0.22,172.232.0.9,172.232.0.19,172.232.0.20,172.232.0.15,172.232.0.18",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "fr-par", "label": "Paris, FR", "country":
-      "fr", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans",
-      "VPCs", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
-      "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.232.32.21,172.232.32.23,172.232.32.17,172.232.32.18,172.232.32.16,172.232.32.22,172.232.32.20,172.232.32.14,172.232.32.11,172.232.32.12",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "us-sea", "label": "Seattle, WA", "country":
-      "us", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans",
-      "VPCs", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
-      "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.232.160.19,172.232.160.21,172.232.160.17,172.232.160.15,172.232.160.18,172.232.160.8,172.232.160.12,172.232.160.11,172.232.160.14,172.232.160.16",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "br-gru", "label": "Sao Paulo, BR", "country":
-      "br", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.233.0.4,172.233.0.9,172.233.0.7,172.233.0.12,172.233.0.5,172.233.0.13,172.233.0.10,172.233.0.6,172.233.0.8,172.233.0.11",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "nl-ams", "label": "Amsterdam, NL", "country":
-      "nl", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.233.33.36,172.233.33.38,172.233.33.35,172.233.33.39,172.233.33.34,172.233.33.33,172.233.33.31,172.233.33.30,172.233.33.37,172.233.33.32",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "se-sto", "label": "Stockholm, SE", "country":
-      "se", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.232.128.24,172.232.128.26,172.232.128.20,172.232.128.22,172.232.128.25,172.232.128.19,172.232.128.23,172.232.128.18,172.232.128.21,172.232.128.27",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "es-mad", "label": "Madrid, ES", "country":
-      "es", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.233.111.6,172.233.111.17,172.233.111.21,172.233.111.25,172.233.111.19,172.233.111.12,172.233.111.26,172.233.111.16,172.233.111.18,172.233.111.9",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "in-maa", "label": "Chennai, IN", "country":
-      "in", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "NETINT Quadra T1U", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.232.96.17,172.232.96.26,172.232.96.19,172.232.96.20,172.232.96.25,172.232.96.21,172.232.96.18,172.232.96.22,172.232.96.23,172.232.96.24",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "jp-osa", "label": "Osaka, JP", "country":
-      "jp", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans",
-      "VPCs", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
-      "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.233.64.44,172.233.64.43,172.233.64.37,172.233.64.40,172.233.64.46,172.233.64.41,172.233.64.39,172.233.64.42,172.233.64.45,172.233.64.38",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "it-mil", "label": "Milan, IT", "country":
-      "it", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.232.192.19,172.232.192.18,172.232.192.16,172.232.192.20,172.232.192.24,172.232.192.21,172.232.192.22,172.232.192.17,172.232.192.15,172.232.192.23",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "us-mia", "label": "Miami, FL", "country":
-      "us", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "NETINT Quadra T1U", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.233.160.34,172.233.160.27,172.233.160.30,172.233.160.29,172.233.160.32,172.233.160.28,172.233.160.33,172.233.160.26,172.233.160.25,172.233.160.31",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "id-cgk", "label": "Jakarta, ID", "country":
-      "id", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.232.224.23,172.232.224.32,172.232.224.26,172.232.224.27,172.232.224.21,172.232.224.24,172.232.224.22,172.232.224.20,172.232.224.31,172.232.224.28",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "us-lax", "label": "Los Angeles, CA", "country":
-      "us", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "NETINT Quadra T1U", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.233.128.45,172.233.128.38,172.233.128.53,172.233.128.37,172.233.128.34,172.233.128.36,172.233.128.33,172.233.128.39,172.233.128.43,172.233.128.44",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "nz-akl-1", "label": "Auckland, NZ", "country":
-      "nz", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans",
-      "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4":
-      "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "us-den-1", "label": "Denver, CO", "country":
-      "us", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans",
-      "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4":
-      "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "de-ham-1", "label": "Hamburg, DE",
-      "country": "de", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall",
-      "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers":
-      {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "fr-mrs-1", "label": "Marseille, FR",
-      "country": "fr", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall",
-      "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers":
-      {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "za-jnb-1", "label": "Johannesburg,
-      ZA", "country": "za", "capabilities": ["Linodes", "Disk Encryption", "Cloud
-      Firewall", "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok",
-      "resolvers": {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "my-kul-1", "label": "Kuala Lumpur,
-      MY", "country": "my", "capabilities": ["Linodes", "Disk Encryption", "Cloud
-      Firewall", "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok",
-      "resolvers": {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "co-bog-1", "label": "Bogot\u00e1, CO",
-      "country": "co", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall",
-      "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers":
-      {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "mx-qro-1", "label": "Quer\u00e9taro,
-      MX", "country": "mx", "capabilities": ["Linodes", "Disk Encryption", "Cloud
-      Firewall", "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok",
-      "resolvers": {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "us-hou-1", "label": "Houston, TX",
-      "country": "us", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall",
-      "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers":
-      {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "cl-scl-1", "label": "Santiago, CL",
-      "country": "cl", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall",
-      "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers":
-      {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "gb-lon", "label": "London 2, UK", "country":
-      "gb", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed
-      Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.236.0.46,172.236.0.50,172.236.0.47,172.236.0.53,172.236.0.52,172.236.0.45,172.236.0.49,172.236.0.51,172.236.0.54,172.236.0.48",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "au-mel", "label": "Melbourne, AU", "country":
-      "au", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata",
-      "Premium Plans", "Placement Group", "StackScripts", "NETINT Quadra T1U", "Linode
-      Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.236.32.23,172.236.32.35,172.236.32.30,172.236.32.28,172.236.32.32,172.236.32.33,172.236.32.27,172.236.32.37,172.236.32.29,172.236.32.34",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "in-bom-2", "label": "Mumbai 2, IN", "country":
-      "in", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "GPU Linodes",
-      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans", "Placement Group",
-      "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.236.171.41,172.236.171.42,172.236.171.25,172.236.171.44,172.236.171.26,172.236.171.45,172.236.171.24,172.236.171.43,172.236.171.27,172.236.171.28",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "de-fra-2", "label": "Frankfurt 2, DE", "country":
-      "de", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "GPU Linodes",
-      "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans",
-      "Placement Group", "StackScripts", "NETINT Quadra T1U", "Linode Interfaces"],
-      "status": "ok", "resolvers": {"ipv4": "172.236.203.9,172.236.203.16,172.236.203.19,172.236.203.15,172.236.203.17,172.236.203.11,172.236.203.18,172.236.203.14,172.236.203.13,172.236.203.12",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "sg-sin-2", "label": "Singapore 2, SG", "country":
-      "sg", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans",
-      "VPCs", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
-      "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "172.236.129.8,172.236.129.42,172.236.129.41,172.236.129.19,172.236.129.46,172.236.129.23,172.236.129.48,172.236.129.20,172.236.129.21,172.236.129.47",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "jp-tyo-3", "label": "Tokyo 3, JP", "country":
-      "jp", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Premium Plans",
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "us-iad",
+      "label": "Washington, DC", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
       "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
-      {"ipv4": "172.237.4.15,172.237.4.19,172.237.4.17,172.237.4.21,172.237.4.16,172.237.4.18,172.237.4.23,172.237.4.24,172.237.4.20,172.237.4.14",
+      {"ipv4": "139.144.192.62,139.144.192.60,139.144.192.61,139.144.192.53,139.144.192.54,139.144.192.67,139.144.192.69,139.144.192.66,139.144.192.52,139.144.192.68",
       "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "de-ber-1", "label": "Berlin, DE", "country":
-      "de", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans",
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "us-ord",
+      "label": "Chicago, IL", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata",
+      "Premium Plans", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
+      "ok", "resolvers": {"ipv4": "172.232.0.17,172.232.0.16,172.232.0.21,172.232.0.13,172.232.0.22,172.232.0.9,172.232.0.19,172.232.0.20,172.232.0.15,172.232.0.18",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "fr-par",
+      "label": "Paris, FR", "country": "fr", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata",
+      "Premium Plans", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
+      "ok", "resolvers": {"ipv4": "172.232.32.21,172.232.32.23,172.232.32.17,172.232.32.18,172.232.32.16,172.232.32.22,172.232.32.20,172.232.32.14,172.232.32.11,172.232.32.12",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "us-sea",
+      "label": "Seattle, WA", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata",
+      "Premium Plans", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
+      "ok", "resolvers": {"ipv4": "172.232.160.19,172.232.160.21,172.232.160.17,172.232.160.15,172.232.160.18,172.232.160.8,172.232.160.12,172.232.160.11,172.232.160.14,172.232.160.16",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "br-gru",
+      "label": "Sao Paulo, BR", "country": "br", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "172.233.0.4,172.233.0.9,172.233.0.7,172.233.0.12,172.233.0.5,172.233.0.13,172.233.0.10,172.233.0.6,172.233.0.8,172.233.0.11",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "nl-ams",
+      "label": "Amsterdam, NL", "country": "nl", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "172.233.33.36,172.233.33.38,172.233.33.35,172.233.33.39,172.233.33.34,172.233.33.33,172.233.33.31,172.233.33.30,172.233.33.37,172.233.33.32",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "se-sto",
+      "label": "Stockholm, SE", "country": "se", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.128.24,172.232.128.26,172.232.128.20,172.232.128.22,172.232.128.25,172.232.128.19,172.232.128.23,172.232.128.18,172.232.128.21,172.232.128.27",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "es-mad",
+      "label": "Madrid, ES", "country": "es", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "172.233.111.6,172.233.111.17,172.233.111.21,172.233.111.25,172.233.111.19,172.233.111.12,172.233.111.26,172.233.111.16,172.233.111.18,172.233.111.9",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "in-maa",
+      "label": "Chennai, IN", "country": "in", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "NETINT Quadra T1U", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "172.232.96.17,172.232.96.26,172.232.96.19,172.232.96.20,172.232.96.25,172.232.96.21,172.232.96.18,172.232.96.22,172.232.96.23,172.232.96.24",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "jp-osa",
+      "label": "Osaka, JP", "country": "jp", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata",
+      "Premium Plans", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
+      "ok", "resolvers": {"ipv4": "172.233.64.44,172.233.64.43,172.233.64.37,172.233.64.40,172.233.64.46,172.233.64.41,172.233.64.39,172.233.64.42,172.233.64.45,172.233.64.38",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "it-mil",
+      "label": "Milan, IT", "country": "it", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.192.19,172.232.192.18,172.232.192.16,172.232.192.20,172.232.192.24,172.232.192.21,172.232.192.22,172.232.192.17,172.232.192.15,172.232.192.23",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "us-mia",
+      "label": "Miami, FL", "country": "us", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "NETINT Quadra T1U", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "172.233.160.34,172.233.160.27,172.233.160.30,172.233.160.29,172.233.160.32,172.233.160.28,172.233.160.33,172.233.160.26,172.233.160.25,172.233.160.31",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "id-cgk",
+      "label": "Jakarta, ID", "country": "id", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "172.232.224.23,172.232.224.32,172.232.224.26,172.232.224.27,172.232.224.21,172.232.224.24,172.232.224.22,172.232.224.20,172.232.224.31,172.232.224.28",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "us-lax",
+      "label": "Los Angeles, CA", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Kubernetes Enterprise", "Cloud
+      Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "NETINT Quadra T1U", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "172.233.128.45,172.233.128.38,172.233.128.53,172.233.128.37,172.233.128.34,172.233.128.36,172.233.128.33,172.233.128.39,172.233.128.43,172.233.128.44",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "nz-akl-1",
+      "label": "Auckland, NZ", "country": "nz", "capabilities": ["Linodes", "Disk
+      Encryption", "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Distributed Plans"],
+      "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53", "ipv6":
+      "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "us-den-1", "label": "Denver, CO", "country": "us", "capabilities":
+      ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs", "Metadata",
+      "Distributed Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "de-ham-1", "label": "Hamburg, DE", "country": "de",
+      "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "fr-mrs-1", "label": "Marseille, FR", "country": "fr",
+      "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "za-jnb-1", "label": "Johannesburg, ZA", "country": "za",
+      "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "my-kul-1", "label": "Kuala Lumpur, MY", "country": "my",
+      "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "co-bog-1", "label": "Bogot\u00e1, CO", "country": "co",
+      "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "mx-qro-1", "label": "Quer\u00e9taro, MX", "country":
+      "mx", "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans",
       "VPCs", "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4":
       "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
-      0}, "site_type": "distributed"}, {"id": "us-central", "label": "Dallas, TX",
-      "country": "us", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption",
-      "Backups", "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall",
-      "Vlans", "Block Storage Migrations", "Managed Databases", "Metadata", "Placement
-      Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
-      "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "us-hou-1", "label": "Houston, TX", "country": "us", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Distributed
+      Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "cl-scl-1", "label": "Santiago, CL", "country": "cl",
+      "capabilities": ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Distributed Plans"], "status": "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53",
+      "ipv6": "1234::5678,1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer":
+      0, "maximum_linodes_per_pg": 0, "maximum_linodes_per_flexible_pg": 0}, "site_type":
+      "distributed"}, {"id": "gb-lon", "label": "London 2, UK", "country": "gb", "capabilities":
+      ["Linodes", "Block Storage Encryption", "LA Disk Encryption", "Disk Encryption",
+      "Backups", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed Databases",
+      "Metadata", "Premium Plans", "Placement Group", "StackScripts", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "172.236.0.46,172.236.0.50,172.236.0.47,172.236.0.53,172.236.0.52,172.236.0.45,172.236.0.49,172.236.0.51,172.236.0.54,172.236.0.48",
       "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "us-west", "label": "Fremont, CA", "country":
-      "us", "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed Databases",
-      "Metadata", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
-      "ok", "resolvers": {"ipv4": "173.230.145.5, 173.230.147.5, 173.230.155.5, 173.255.212.5,
-      173.255.219.5, 173.255.241.5, 173.255.243.5, 173.255.244.5, 74.207.241.5, 74.207.242.5",
-      "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "placement_group_limits":
-      {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg": 5}, "site_type":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "au-mel",
+      "label": "Melbourne, AU", "country": "au", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "NETINT Quadra T1U", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "172.236.32.23,172.236.32.35,172.236.32.30,172.236.32.28,172.236.32.32,172.236.32.33,172.236.32.27,172.236.32.37,172.236.32.29,172.236.32.34",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "in-bom-2",
+      "label": "Mumbai 2, IN", "country": "in", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Premium Plans", "Placement Group", "StackScripts", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "172.236.171.41,172.236.171.42,172.236.171.25,172.236.171.44,172.236.171.26,172.236.171.45,172.236.171.24,172.236.171.43,172.236.171.27,172.236.171.28",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "de-fra-2",
+      "label": "Frankfurt 2, DE", "country": "de", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs",
+      "Metadata", "Premium Plans", "Placement Group", "StackScripts", "NETINT Quadra
+      T1U", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.236.203.9,172.236.203.16,172.236.203.19,172.236.203.15,172.236.203.17,172.236.203.11,172.236.203.18,172.236.203.14,172.236.203.13,172.236.203.12",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "sg-sin-2",
+      "label": "Singapore 2, SG", "country": "sg", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Managed Databases", "Metadata",
+      "Premium Plans", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
+      "ok", "resolvers": {"ipv4": "172.236.129.8,172.236.129.42,172.236.129.41,172.236.129.19,172.236.129.46,172.236.129.23,172.236.129.48,172.236.129.20,172.236.129.21,172.236.129.47",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "jp-tyo-3",
+      "label": "Tokyo 3, JP", "country": "jp", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "Metadata", "Premium Plans", "Placement Group", "StackScripts", "Linode
+      Interfaces"], "status": "ok", "resolvers": {"ipv4": "172.237.4.15,172.237.4.19,172.237.4.17,172.237.4.21,172.237.4.16,172.237.4.18,172.237.4.23,172.237.4.24,172.237.4.20,172.237.4.14",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "de-ber-1",
+      "label": "Berlin, DE", "country": "de", "capabilities": ["Linodes", "Disk Encryption",
+      "Cloud Firewall", "Vlans", "VPCs", "Metadata", "Distributed Plans"], "status":
+      "ok", "resolvers": {"ipv4": "173.223.100.53,173.223.101.53", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "us-central", "label": "Dallas, TX", "country": "us", "capabilities": ["Linodes",
+      "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers", "Block
+      Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases", "Metadata", "Placement Group", "StackScripts", "Linode
+      Interfaces"], "status": "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "us-west",
+      "label": "Fremont, CA", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases", "Metadata", "Placement Group", "StackScripts", "Linode
+      Interfaces"], "status": "ok", "resolvers": {"ipv4": "173.230.145.5, 173.230.147.5,
+      173.230.155.5, 173.255.212.5, 173.255.219.5, 173.255.241.5, 173.255.243.5, 173.255.244.5,
+      74.207.241.5, 74.207.242.5", "ipv6": "1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer": null,
+      "maximum_linodes_per_pg": 5, "maximum_linodes_per_flexible_pg": 5}, "site_type":
       "core"}, {"id": "us-southeast", "label": "Atlanta, GA", "country": "us", "capabilities":
       ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
       "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
@@ -284,47 +297,50 @@ interactions:
       "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
       "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "us-east", "label": "Newark, NJ", "country":
-      "us", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups",
-      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed Databases",
-      "Metadata", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
-      "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,173.255.225.5,66.228.35.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "eu-west", "label": "London, UK", "country":
-      "gb", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups",
-      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
-      Storage Migrations", "Metadata", "Placement Group", "StackScripts", "Linode
-      Interfaces"], "status": "ok", "resolvers": {"ipv4": "178.79.182.5, 176.58.107.5,
-      176.58.116.5, 176.58.121.5, 151.236.220.5, 212.71.252.5, 212.71.253.5, 109.74.192.20,
-      109.74.193.20, 109.74.194.20", "ipv6": "1234::5678, 1234::5678, 1234::5678,
-      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
-      1234::5678"}, "placement_group_limits": {"maximum_pgs_per_customer": null,
-      "maximum_linodes_per_pg": 5}, "site_type": "core"}, {"id": "ap-south", "label":
-      "Singapore, SG", "country": "sg", "capabilities": ["Linodes", "LA Disk Encryption",
-      "Disk Encryption", "Backups", "NodeBalancers", "Block Storage", "Object Storage",
-      "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
-      "Metadata", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
-      "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "eu-central", "label": "Frankfurt, DE", "country":
-      "de", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups",
-      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
-      "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed Databases",
-      "Metadata", "Placement Group", "StackScripts", "Linode Interfaces"], "status":
-      "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
-      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
-      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}, {"id": "ap-northeast", "label": "Tokyo 2, JP", "country":
-      "jp", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups",
-      "NodeBalancers", "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "us-east",
+      "label": "Newark, NJ", "country": "us", "capabilities": ["Linodes", "LA Disk
+      Encryption", "Disk Encryption", "Backups", "NodeBalancers", "Block Storage",
+      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block
       Storage Migrations", "Managed Databases", "Metadata", "Placement Group", "StackScripts",
-      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,173.255.225.5,66.228.35.5",
       "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
       "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
-      5}, "site_type": "core"}], "page": 1, "pages": 1, "results": 42}'
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "eu-west",
+      "label": "London, UK", "country": "gb", "capabilities": ["Linodes", "LA Disk
+      Encryption", "Disk Encryption", "Backups", "NodeBalancers", "Block Storage",
+      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Metadata",
+      "Placement Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers":
+      {"ipv4": "178.79.182.5, 176.58.107.5, 176.58.116.5, 176.58.121.5, 151.236.220.5,
+      212.71.252.5, 212.71.253.5, 109.74.192.20, 109.74.193.20, 109.74.194.20", "ipv6":
+      "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "placement_group_limits":
+      {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg": 5, "maximum_linodes_per_flexible_pg":
+      5}, "site_type": "core"}, {"id": "ap-south", "label": "Singapore, SG", "country":
+      "sg", "capabilities": ["Linodes", "LA Disk Encryption", "Disk Encryption", "Backups",
+      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
+      "Cloud Firewall", "Vlans", "Block Storage Migrations", "Metadata", "Placement
+      Group", "StackScripts", "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4":
+      "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "eu-central",
+      "label": "Frankfurt, DE", "country": "de", "capabilities": ["Linodes", "LA Disk
+      Encryption", "Disk Encryption", "Backups", "NodeBalancers", "Block Storage",
+      "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      Storage Migrations", "Managed Databases", "Metadata", "Placement Group", "StackScripts",
+      "Linode Interfaces"], "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}, {"id": "ap-northeast",
+      "label": "Tokyo 2, JP", "country": "jp", "capabilities": ["Linodes", "LA Disk
+      Encryption", "Disk Encryption", "Backups", "NodeBalancers", "Block Storage",
+      "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations", "Managed
+      Databases", "Metadata", "Placement Group", "StackScripts", "Linode Interfaces"],
+      "status": "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 5}, "site_type": "core"}], "page": 1,
+      "pages": 1, "results": 42}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -347,7 +363,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Mon, 02 Jun 2025 17:53:52 GMT
+      - Wed, 02 Jul 2025 18:17:15 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -366,14 +382,14 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
+      - "1840"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"region":"ap-west","type":"g6-nanode-1","label":"go-test-ins-wo-disk-jra84c8go997","firewall_id":2737268,"booted":false}'
+    body: '{"region":"ap-west","type":"g6-nanode-1","label":"go-test-ins-wo-disk-u99x91gpkm36","firewall_id":2950211,"booted":false}'
     form: {}
     headers:
       Accept:
@@ -385,15 +401,15 @@ interactions:
     url: https://api.linode.com/v4beta/linode/instances
     method: POST
   response:
-    body: '{"id": 77976107, "label": "go-test-ins-wo-disk-jra84c8go997", "group":
+    body: '{"id": 79583040, "label": "go-test-ins-wo-disk-u99x91gpkm36", "group":
       "", "status": "provisioning", "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
-      "type": "g6-nanode-1", "ipv4": ["192.46.212.239"], "ipv6": "1234::5678/128",
+      "type": "g6-nanode-1", "ipv4": ["172.105.54.15"], "ipv6": "1234::5678/128",
       "image": null, "region": "ap-west", "site_type": "core", "specs": {"disk": 25600,
       "memory": 1024, "vcpus": 1, "gpus": 0, "transfer": 1000, "accelerated_devices":
       0}, "alerts": {"cpu": 90, "network_in": 10, "network_out": 10, "transfer_quota":
       80, "io": 10000}, "backups": {"enabled": false, "available": false, "schedule":
       {"day": null, "window": null}, "last_successful": null}, "hypervisor": "kvm",
-      "watchdog_enabled": true, "tags": [], "host_uuid": "cf06d6e1fd3fcd5eb9c72b18e554f026aaa5e21a",
+      "watchdog_enabled": true, "tags": [], "host_uuid": "93ea492a1b8b86194a1f6af109c86d1ecc81de42",
       "has_user_data": false, "placement_group": null, "disk_encryption": "enabled",
       "lke_cluster_id": null, "capabilities": ["SMTP Enabled"], "interface_generation":
       "legacy_config"}'
@@ -419,7 +435,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Mon, 02 Jun 2025 17:53:54 GMT
+      - Wed, 02 Jul 2025 18:17:16 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -444,7 +460,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"label":"go-test-conf-028ty60szxm6","devices":{},"interfaces":null}'
+    body: '{"label":"go-test-conf-6no1krb025n3","devices":{},"interfaces":null}'
     form: {}
     headers:
       Accept:
@@ -453,10 +469,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/77976107/configs
+    url: https://api.linode.com/v4beta/linode/instances/79583040/configs
     method: POST
   response:
-    body: '{"id": 81410035, "label": "go-test-conf-028ty60szxm6", "helpers": {"updatedb_disabled":
+    body: '{"id": 83037022, "label": "go-test-conf-6no1krb025n3", "helpers": {"updatedb_disabled":
       true, "distro": true, "modules_dep": true, "network": false, "devtmpfs_automount":
       true}, "kernel": "linode/latest-64bit", "comments": "", "memory_limit": 0, "created":
       "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "root_device": "/dev/sda",
@@ -487,7 +503,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Mon, 02 Jun 2025 17:53:54 GMT
+      - Wed, 02 Jul 2025 18:17:16 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -504,7 +520,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
+      - "1840"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -520,7 +536,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/77976107/transfer/2025/6
+    url: https://api.linode.com/v4beta/linode/instances/79583040/transfer/2025/7
     method: GET
   response:
     body: '{"bytes_in": 0, "bytes_out": 0, "bytes_total": 0}'
@@ -548,7 +564,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Mon, 02 Jun 2025 17:53:54 GMT
+      - Wed, 02 Jul 2025 18:17:16 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -566,7 +582,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
+      - "1840"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -582,7 +598,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/77976107/transfer/2025/6
+    url: https://api.linode.com/v4beta/linode/instances/79583040/transfer/2025/7
     method: GET
   response:
     body: '{"bytes_in": 0, "bytes_out": 0, "bytes_total": 0}'
@@ -610,7 +626,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Mon, 02 Jun 2025 17:53:54 GMT
+      - Wed, 02 Jul 2025 18:17:16 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -628,7 +644,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
+      - "1840"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK
@@ -644,7 +660,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/linode/instances/77976107
+    url: https://api.linode.com/v4beta/linode/instances/79583040
     method: DELETE
   response:
     body: '{}'
@@ -672,7 +688,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Mon, 02 Jun 2025 17:53:56 GMT
+      - Wed, 02 Jul 2025 18:17:18 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -689,7 +705,7 @@ interactions:
       X-Oauth-Scopes:
       - '*'
       X-Ratelimit-Limit:
-      - "1600"
+      - "1840"
       X-Xss-Protection:
       - 1; mode=block
     status: 200 OK

--- a/types.go
+++ b/types.go
@@ -51,7 +51,7 @@ type LinodeRegionPrice struct {
 // LinodeTypeClass constants start with Class and include Linode API Instance Type Classes
 type LinodeTypeClass string
 
-// LinodeTypeClass contants are the Instance Type Classes that an Instance Type can be assigned
+// LinodeTypeClass constants are the Instance Type Classes that an Instance Type can be assigned
 const (
 	ClassNanode    LinodeTypeClass = "nanode"
 	ClassStandard  LinodeTypeClass = "standard"

--- a/version.go
+++ b/version.go
@@ -24,7 +24,9 @@ func init() {
 				if dep.Replace != nil {
 					Version = dep.Replace.Version
 				}
+
 				Version = dep.Version
+
 				break
 			}
 		}

--- a/vlans.go
+++ b/vlans.go
@@ -22,6 +22,7 @@ func (v *VLAN) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 	}{
 		Mask: (*Mask)(v),
@@ -32,6 +33,7 @@ func (v *VLAN) UnmarshalJSON(b []byte) error {
 	}
 
 	v.Created = (*time.Time)(p.Created)
+
 	return nil
 }
 
@@ -44,6 +46,7 @@ func (c *Client) ListVLANs(ctx context.Context, opts *ListOptions) ([]VLAN, erro
 func (c *Client) GetVLANIPAMAddress(ctx context.Context, linodeID int, vlanLabel string) (string, error) {
 	f := Filter{}
 	f.AddField(Eq, "interfaces", vlanLabel)
+
 	vlanFilter, err := f.MarshalJSON()
 	if err != nil {
 		return "", fmt.Errorf("Unable to convert VLAN label: %s to a filterable object: %w", vlanLabel, err)

--- a/volumes.go
+++ b/volumes.go
@@ -77,6 +77,7 @@ func (v *Volume) UnmarshalJSON(b []byte) error {
 
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{
@@ -97,6 +98,7 @@ func (v *Volume) UnmarshalJSON(b []byte) error {
 func (v Volume) GetUpdateOptions() (updateOpts VolumeUpdateOptions) {
 	updateOpts.Label = v.Label
 	updateOpts.Tags = &v.Tags
+
 	return
 }
 
@@ -105,10 +107,12 @@ func (v Volume) GetCreateOptions() (createOpts VolumeCreateOptions) {
 	createOpts.Label = v.Label
 	createOpts.Tags = v.Tags
 	createOpts.Region = v.Region
+
 	createOpts.Size = v.Size
 	if v.LinodeID != nil && *v.LinodeID > 0 {
 		createOpts.LinodeID = *v.LinodeID
 	}
+
 	return
 }
 
@@ -147,6 +151,7 @@ func (c *Client) CloneVolume(ctx context.Context, volumeID int, label string) (*
 	}
 
 	e := formatAPIPath("volumes/%d/clone", volumeID)
+
 	return doPOSTRequest[Volume](ctx, c, e, opts)
 }
 
@@ -163,6 +168,7 @@ func (c *Client) ResizeVolume(ctx context.Context, volumeID int, size int) error
 	}
 
 	e := formatAPIPath("volumes/%d/resize", volumeID)
+
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 

--- a/vpc.go
+++ b/vpc.go
@@ -53,8 +53,10 @@ func (v VPC) GetUpdateOptions() VPCUpdateOptions {
 
 func (v *VPC) UnmarshalJSON(b []byte) error {
 	type Mask VPC
+
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{

--- a/vpc_subnet.go
+++ b/vpc_subnet.go
@@ -41,8 +41,10 @@ type VPCSubnetUpdateOptions struct {
 
 func (v *VPCSubnet) UnmarshalJSON(b []byte) error {
 	type Mask VPCSubnet
+
 	p := struct {
 		*Mask
+
 		Created *parseabletime.ParseableTime `json:"created"`
 		Updated *parseabletime.ParseableTime `json:"updated"`
 	}{

--- a/waitfor.go
+++ b/waitfor.go
@@ -45,6 +45,7 @@ func (client Client) WaitForInstanceStatus(ctx context.Context, instanceID int, 
 			if err != nil {
 				return instance, err
 			}
+
 			complete := (instance.Status == status)
 
 			if complete {
@@ -107,6 +108,7 @@ func (client Client) WaitForVolumeStatus(ctx context.Context, volumeID int, stat
 			if err != nil {
 				return volume, err
 			}
+
 			complete := (volume.Status == status)
 
 			if complete {
@@ -134,6 +136,7 @@ func (client Client) WaitForSnapshotStatus(ctx context.Context, instanceID int, 
 			if err != nil {
 				return snapshot, err
 			}
+
 			complete := (snapshot.Status == status)
 
 			if complete {
@@ -194,6 +197,7 @@ func (client Client) WaitForLKEClusterStatus(ctx context.Context, clusterID int,
 			if err != nil {
 				return cluster, err
 			}
+
 			complete := (cluster.Status == status)
 
 			if complete {
@@ -259,6 +263,7 @@ func (client Client) WaitForLKEClusterConditions(
 				result, err := condition(ctx, conditionOptions)
 				if err != nil {
 					log.Printf("[WARN] Ignoring WaitForLKEClusterConditions conditional error: %s", err)
+
 					if !options.Retry {
 						return err
 					}
@@ -273,6 +278,7 @@ func (client Client) WaitForLKEClusterConditions(
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -431,6 +437,7 @@ func (client Client) WaitForImageStatus(ctx context.Context, imageID string, sta
 			if err != nil {
 				return image, err
 			}
+
 			complete := image.Status == status
 
 			if complete {


### PR DESCRIPTION
- Disable `noinlineerr` linter because inline error check is a common practice in our code base
- Run `golangci-lint run --fix` to fix other lint issues