### PR TITLE
Feat: add support for instanceFirewallUpdate

### DIFF
--- a/instance_firewalls.go
+++ b/instance_firewalls.go
@@ -8,3 +8,13 @@ import (
 func (c *Client) ListInstanceFirewalls(ctx context.Context, linodeID int, opts *ListOptions) ([]Firewall, error) {
 	return getPaginatedResults[Firewall](ctx, c, formatAPIPath("linode/instances/%d/firewalls", linodeID), opts)
 }
+
+type InstanceFirewallUpdateOptions struct {
+	FirewallIDs []int `json:"firewall_ids"`
+}
+
+// UpdateInstanceFirewalls updates the Cloud Firewalls for a Linode instance
+// Followup this call with `ListInstanceFirewalls` to verify the changes if necessary.
+func (c *Client) UpdateInstanceFirewalls(ctx context.Context, linodeID int, opts InstanceFirewallUpdateOptions) ([]Firewall, error) {
+	return putPaginatedResults[Firewall, InstanceFirewallUpdateOptions](ctx, c, formatAPIPath("linode/instances/%d/firewalls", linodeID), nil, opts)
+}

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -17,17 +17,17 @@ type paginatedResponse[T any] struct {
 	Data    []T `json:"data"`
 }
 
-// getPaginatedResults aggregates results from the given
-// paginated endpoint using the provided ListOptions.
+// handlePaginatedResults aggregates results from the given
+// paginated endpoint using the provided ListOptions and HTTP method.
 // nolint:funlen
-func getPaginatedResults[T any](
+func handlePaginatedResults[T any, O any](
 	ctx context.Context,
 	client *Client,
 	endpoint string,
 	opts *ListOptions,
+	method string,
+	options ...O,
 ) ([]T, error) {
-	var resultType paginatedResponse[T]
-
 	result := make([]T, 0)
 
 	if opts == nil {
@@ -38,38 +38,76 @@ func getPaginatedResults[T any](
 		opts.PageOptions = &PageOptions{Page: 0}
 	}
 
-	// Makes a request to a particular page and
-	// appends the response to the result
+	// Validate options
+	numOpts := len(options)
+	if numOpts > 1 {
+		return nil, fmt.Errorf("invalid number of options: expected 0 or 1, got %d", numOpts)
+	}
+
+	// Prepare request body if options are provided
+	var reqBody string
+
+	if numOpts > 0 && !isNil(options[0]) {
+		body, err := json.Marshal(options[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+
+		reqBody = string(body)
+	}
+
+	// Makes a request to a particular page and appends the response to the result
 	handlePage := func(page int) error {
+		var resultType paginatedResponse[T]
+
 		// Override the page to be applied in applyListOptionsToRequest(...)
 		opts.Page = page
 
 		// This request object cannot be reused for each page request
 		// because it can lead to possible data corruption
-		req := client.R(ctx).SetResult(resultType)
+		req := client.R(ctx).SetResult(&resultType)
 
 		// Apply all user-provided list options to the request
 		if err := applyListOptionsToRequest(opts, req); err != nil {
 			return err
 		}
 
-		res, err := coupleAPIErrors(req.Get(endpoint))
-		if err != nil {
-			return err
+		// Set request body if provided
+		if reqBody != "" {
+			req.SetBody(reqBody)
 		}
 
-		response := res.Result().(*paginatedResponse[T])
+		var response *paginatedResponse[T]
+		// Execute the appropriate HTTP method
+		switch method {
+		case "GET":
+			res, err := coupleAPIErrors(req.Get(endpoint))
+			if err != nil {
+				return err
+			}
 
+			response = res.Result().(*paginatedResponse[T])
+		case "PUT":
+			res, err := coupleAPIErrors(req.Put(endpoint))
+			if err != nil {
+				return err
+			}
+
+			response = res.Result().(*paginatedResponse[T])
+		default:
+			return fmt.Errorf("unsupported HTTP method: %s", method)
+		}
+
+		// Update pagination metadata
 		opts.Page = page
 		opts.Pages = response.Pages
 		opts.Results = response.Results
-
 		result = append(result, response.Data...)
 
 		return nil
 	}
 
-	// This helps simplify the logic below
+	// Determine starting page
 	startingPage := 1
 	pageDefined := opts.Page > 0
 
@@ -96,6 +134,29 @@ func getPaginatedResults[T any](
 	}
 
 	return result, nil
+}
+
+// getPaginatedResults aggregates results from the given
+// paginated endpoint using the provided ListOptions.
+func getPaginatedResults[T any](
+	ctx context.Context,
+	client *Client,
+	endpoint string,
+	opts *ListOptions,
+) ([]T, error) {
+	return handlePaginatedResults[T, any](ctx, client, endpoint, opts, "GET")
+}
+
+// putPaginatedResults sends a PUT request and aggregates the results from the given
+// paginated endpoint using the provided ListOptions.
+func putPaginatedResults[T, O any](
+	ctx context.Context,
+	client *Client,
+	endpoint string,
+	opts *ListOptions,
+	options ...O,
+) ([]T, error) {
+	return handlePaginatedResults[T, O](ctx, client, endpoint, opts, "PUT", options...)
 }
 
 // doGETRequest runs a GET request using the given client and API endpoint,

--- a/test/unit/fixtures/instance_firewall_update.json
+++ b/test/unit/fixtures/instance_firewall_update.json
@@ -1,0 +1,16 @@
+{
+    "data": [
+      {
+        "id": 789,
+        "label": "firewall-1",
+        "status": "enabled",
+        "rules": {
+          "inbound": [],
+          "outbound": []
+        }
+      }
+    ],
+    "page": 1,
+    "pages": 1,
+    "results": 1
+}

--- a/test/unit/instance_firewall_test.go
+++ b/test/unit/instance_firewall_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,4 +27,25 @@ func TestInstanceFirewalls_List(t *testing.T) {
 
 	assert.Equal(t, 789, firewalls[1].ID)
 	assert.Equal(t, "firewall-2", firewalls[1].Label)
+}
+
+func TestInstanceFirewalls_Update(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("instance_firewall_update")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockGet("linode/instances/123/firewalls", fixtureData)
+	base.MockPut("linode/instances/123/firewalls", fixtureData)
+	updateOpts := linodego.InstanceFirewallUpdateOptions{
+		FirewallIDs: []int{789},
+	}
+
+	firewalls, err := base.Client.UpdateInstanceFirewalls(context.Background(), 123, updateOpts)
+	assert.NoError(t, err)
+	assert.NotNil(t, firewalls)
+	assert.Len(t, firewalls, 1)
+	assert.Equal(t, 789, firewalls[0].ID)
 }


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**
This PR adds support for updating a linode's firewalls - https://techdocs.akamai.com/linode-api/reference/put-linode-firewalls. This also adds a helper to handle PUT requests that respond with a paginated response.

## ✔️ How to Test
* Create an instance and two firewalls
* Switch the firewall attached to the instance using this new function - snippet
```
func main() {
        ... client setup ...
	firewalls, err := client.ListInstanceFirewalls(context.Background(), instance.ID, nil)
	if err != nil {
		panic(err)
	}

	for _, firewall := range firewalls {
		fmt.Printf("Firewall ID: %d\n", firewall.ID)
	}

	updFirewalls, err := client.UpdateInstanceFirewalls(context.Background(), instance.ID, linodego.InstanceFirewallUpdateOptions{
		FirewallIDs: []int{YOUR_OTHER_FIREWALL},
	})
	if err != nil {
		panic(err)
	}
	if updFirewalls != nil {
		spew.Dump(updFirewalls)
	}

	firewalls, err = client.ListInstanceFirewalls(context.Background(), instance.ID, nil)
	if err != nil {
		panic(err)
	}

	for _, firewall := range firewalls {
		fmt.Printf("Firewall ID: %d\n", firewall.ID)
	}
}
```

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**
`make test` 

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**