### PR TITLE
Make `address` of interface ipv4 optional

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -112,8 +112,8 @@ type PublicInterfaceIPv4CreateOptions struct {
 }
 
 type PublicInterfaceIPv4AddressCreateOptions struct {
-	Address string `json:"address"`
-	Primary *bool  `json:"primary,omitempty"`
+	Address *string `json:"address,omitempty"`
+	Primary *bool   `json:"primary,omitempty"`
 }
 
 type PublicInterfaceIPv6CreateOptions struct {
@@ -135,7 +135,7 @@ type VPCInterfaceIPv4CreateOptions struct {
 }
 
 type VPCInterfaceIPv4AddressCreateOptions struct {
-	Address        string  `json:"address"`
+	Address        *string `json:"address"`
 	Primary        *bool   `json:"primary,omitempty"`
 	NAT1To1Address *string `json:"nat_1_1_address,omitempty"`
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -135,7 +135,7 @@ type VPCInterfaceIPv4CreateOptions struct {
 }
 
 type VPCInterfaceIPv4AddressCreateOptions struct {
-	Address        *string `json:"address"`
+	Address        *string `json:"address,omitempty"`
 	Primary        *bool   `json:"primary,omitempty"`
 	NAT1To1Address *string `json:"nat_1_1_address,omitempty"`
 }

--- a/test/integration/instance_interfaces_test.go
+++ b/test/integration/instance_interfaces_test.go
@@ -104,7 +104,7 @@ func TestInstance_CreateWithLinodeInterfaces(
 					IPv4: &linodego.PublicInterfaceIPv4CreateOptions{
 						Addresses: []linodego.PublicInterfaceIPv4AddressCreateOptions{
 							{
-								Address: "auto",
+								Address: linodego.Pointer("auto"),
 								Primary: linodego.Pointer(true),
 							},
 						},
@@ -119,7 +119,7 @@ func TestInstance_CreateWithLinodeInterfaces(
 					IPv4: &linodego.VPCInterfaceIPv4CreateOptions{
 						Addresses: []linodego.VPCInterfaceIPv4AddressCreateOptions{
 							{
-								Address:        "auto",
+								Address:        linodego.Pointer("auto"),
 								Primary:        linodego.Pointer(true),
 								NAT1To1Address: linodego.Pointer("auto"),
 							},


### PR DESCRIPTION
## 📝 Description
Mark some fields as optional following the API behaviors.