### PR TITLE
Change types of interfaces create options slices to be pointers

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -132,7 +132,7 @@ type PublicInterfaceCreateOptions struct {
 }
 
 type PublicInterfaceIPv4CreateOptions struct {
-	Addresses []PublicInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
+	Addresses *[]PublicInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
 }
 
 type PublicInterfaceIPv4AddressCreateOptions struct {
@@ -141,7 +141,7 @@ type PublicInterfaceIPv4AddressCreateOptions struct {
 }
 
 type PublicInterfaceIPv6CreateOptions struct {
-	Ranges []PublicInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
+	Ranges *[]PublicInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
 }
 
 type PublicInterfaceIPv6RangeCreateOptions struct {
@@ -155,8 +155,8 @@ type VPCInterfaceCreateOptions struct {
 }
 
 type VPCInterfaceIPv4CreateOptions struct {
-	Addresses []VPCInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
-	Ranges    []VPCInterfaceIPv4RangeCreateOptions   `json:"ranges,omitempty"`
+	Addresses *[]VPCInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
+	Ranges    *[]VPCInterfaceIPv4RangeCreateOptions   `json:"ranges,omitempty"`
 }
 
 type VPCInterfaceIPv4AddressCreateOptions struct {
@@ -172,9 +172,9 @@ type VPCInterfaceIPv4RangeCreateOptions struct {
 // VPCInterfaceIPv6CreateOptions specifies IPv6 configuration parameters for VPC creation.
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type VPCInterfaceIPv6CreateOptions struct {
-	SLAAC    []VPCInterfaceIPv6SLAACCreateOptions `json:"slaac,omitempty"`
-	Ranges   []VPCInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
-	IsPublic bool                                 `json:"is_public"`
+	SLAAC    *[]VPCInterfaceIPv6SLAACCreateOptions `json:"slaac,omitempty"`
+	Ranges   *[]VPCInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
+	IsPublic bool                                  `json:"is_public"`
 }
 
 // VPCInterfaceIPv6SLAACCreateOptions defines the IPv6 SLAAC configuration parameters for VPC creation.

--- a/test/integration/instance_interfaces_test.go
+++ b/test/integration/instance_interfaces_test.go
@@ -102,7 +102,7 @@ func TestInstance_CreateWithLinodeInterfaces(
 				FirewallID: linodego.DoublePointer(firewallID),
 				Public: &linodego.PublicInterfaceCreateOptions{
 					IPv4: &linodego.PublicInterfaceIPv4CreateOptions{
-						Addresses: []linodego.PublicInterfaceIPv4AddressCreateOptions{
+						Addresses: &[]linodego.PublicInterfaceIPv4AddressCreateOptions{
 							{
 								Address: linodego.Pointer("auto"),
 								Primary: linodego.Pointer(true),
@@ -117,7 +117,7 @@ func TestInstance_CreateWithLinodeInterfaces(
 				VPC: &linodego.VPCInterfaceCreateOptions{
 					SubnetID: vpcSubnet.ID,
 					IPv4: &linodego.VPCInterfaceIPv4CreateOptions{
-						Addresses: []linodego.VPCInterfaceIPv4AddressCreateOptions{
+						Addresses: &[]linodego.VPCInterfaceIPv4AddressCreateOptions{
 							{
 								Address:        linodego.Pointer("auto"),
 								Primary:        linodego.Pointer(true),

--- a/test/unit/interface_test.go
+++ b/test/unit/interface_test.go
@@ -159,7 +159,7 @@ func TestInterface_CreatePublic(t *testing.T) {
 	opts := linodego.LinodeInterfaceCreateOptions{
 		Public: &linodego.PublicInterfaceCreateOptions{
 			IPv4: &linodego.PublicInterfaceIPv4CreateOptions{
-				Addresses: []linodego.PublicInterfaceIPv4AddressCreateOptions{
+				Addresses: &[]linodego.PublicInterfaceIPv4AddressCreateOptions{
 					{
 						Address: linodego.Pointer("auto"),
 						Primary: linodego.Pointer(true),
@@ -228,13 +228,13 @@ func TestInterface_UpdateVPC(t *testing.T) {
 		},
 		VPC: &linodego.VPCInterfaceCreateOptions{
 			IPv4: &linodego.VPCInterfaceIPv4CreateOptions{
-				Addresses: []linodego.VPCInterfaceIPv4AddressCreateOptions{
+				Addresses: &[]linodego.VPCInterfaceIPv4AddressCreateOptions{
 					{
 						Address: linodego.Pointer("192.168.23.4"),
 						Primary: linodego.Pointer(true),
 					},
 				},
-				Ranges: []linodego.VPCInterfaceIPv4RangeCreateOptions{
+				Ranges: &[]linodego.VPCInterfaceIPv4RangeCreateOptions{
 					{
 						Range: "192.168.23.16/28",
 					},
@@ -244,12 +244,12 @@ func TestInterface_UpdateVPC(t *testing.T) {
 				},
 			},
 			IPv6: &linodego.VPCInterfaceIPv6CreateOptions{
-				SLAAC: []linodego.VPCInterfaceIPv6SLAACCreateOptions{
+				SLAAC: &[]linodego.VPCInterfaceIPv6SLAACCreateOptions{
 					{
 						Range: "1235::/64",
 					},
 				},
-				Ranges: []linodego.VPCInterfaceIPv6RangeCreateOptions{
+				Ranges: &[]linodego.VPCInterfaceIPv6RangeCreateOptions{
 					{
 						"4322::/64",
 					},


### PR DESCRIPTION
## 📝 Description

I previously thought the `omitempty` tag would only omit `nil` slice, which is different from an empty slice, but apparently it's not the case and it would omit both empty and `nil` slices. It's required to have an explicit empty slice passed to the API (not omitted) to create an IPv6 only interface (see [API doc](https://techdocs.akamai.com/linode-api/reference/post-linode-interface) for details). Changing these slices to be pointers of slices is then necessary because `omitempty` tag for a pointer of slice would only omit the `nil` pointer.

## ✔️ How to Test
```bash
make test-unit && make test-int
```