### PR TITLE
Create negative test cases for Pulse Metrics

### DIFF
--- a/test/integration/fixtures/TestMonitorInvalidDashboard_Get.yaml
+++ b/test/integration/fixtures/TestMonitorInvalidDashboard_Get.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/monitor/dashboards/999999
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Not found"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "37"
+      Content-Type:
+      - application/json
+      Server:
+      - nginx/1.18.0
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - monitor:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 404 NOT FOUND
+    code: 404
+    duration: ""

--- a/test/integration/fixtures/TestMonitorNotAllowedServiceType_Get.yaml
+++ b/test/integration/fixtures/TestMonitorNotAllowedServiceType_Get.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/monitor/services/saas?page=1
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Not found"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "37"
+      Content-Type:
+      - application/json
+      Server:
+      - nginx/1.18.0
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - monitor:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 404 NOT FOUND
+    code: 404
+    duration: ""

--- a/test/integration/fixtures/TestServiceTokenInvalidEntity_POST.yaml
+++ b/test/integration/fixtures/TestServiceTokenInvalidEntity_POST.yaml
@@ -1,0 +1,48 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"entity_ids":[999999999]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/monitor/services/dbaas/token
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "The following entity_ids are not valid - [999999999]",
+      "field": "entity_ids"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "103"
+      Content-Type:
+      - application/json
+      Server:
+      - nginx/1.18.0
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Accepted-Oauth-Scopes:
+      - databases:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+    status: 403 FORBIDDEN
+    code: 403
+    duration: ""

--- a/test/integration/monitor_dashboards_test.go
+++ b/test/integration/monitor_dashboards_test.go
@@ -60,7 +60,7 @@ func TestMonitorDashboards_Get_smoke(t *testing.T) {
 }
 
 func TestMonitorDashboards_GetNotExistingDashboardID(t *testing.T) {
-	client, teardown := createTestClient(t, "fixtures/TestMonitorDashboards_Get")
+	client, teardown := createTestClient(t, "fixtures/TestMonitorInvalidDashboard_Get")
 	defer teardown()
 
 	_, getErr := client.GetMonitorDashboard(context.Background(), 999999)

--- a/test/integration/monitor_dashboards_test.go
+++ b/test/integration/monitor_dashboards_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,6 +57,15 @@ func TestMonitorDashboards_Get_smoke(t *testing.T) {
 	if !found_st {
 		t.Errorf("Monitor dashboard not found in list.")
 	}
+}
+
+func TestMonitorDashboards_GetNotExistingDashboardID(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestMonitorDashboards_Get")
+	defer teardown()
+
+	_, getErr := client.GetMonitorDashboard(context.Background(), 999999)
+	require.Error(t, getErr)
+	assert.Contains(t, getErr.Error(), "[404] Not found")
 }
 
 func validateDashboards(

--- a/test/integration/monitor_services_test.go
+++ b/test/integration/monitor_services_test.go
@@ -43,7 +43,7 @@ func TestMonitorServices_Get_smoke(t *testing.T) {
 }
 
 func TestMonitorServices_GetNotAllowedServiceType(t *testing.T) {
-	client, teardown := createTestClient(t, "fixtures/TestMonitorServices_Get")
+	client, teardown := createTestClient(t, "fixtures/TestMonitorNotAllowedServiceType_Get")
 	defer teardown()
 
 	_, getErr := client.ListMonitorServiceByType(context.Background(), "saas", nil)

--- a/test/integration/monitor_services_test.go
+++ b/test/integration/monitor_services_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,15 @@ func TestMonitorServices_Get_smoke(t *testing.T) {
 	if !found {
 		t.Errorf("Monitor service not found in list.")
 	}
+}
+
+func TestMonitorServices_GetNotAllowedServiceType(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestMonitorServices_Get")
+	defer teardown()
+
+	_, getErr := client.ListMonitorServiceByType(context.Background(), "saas", nil)
+	require.Error(t, getErr)
+	assert.Contains(t, getErr.Error(), "[404] Not found")
 }
 
 func validateServiceTypes(

--- a/test/integration/monitor_services_token_creation_test.go
+++ b/test/integration/monitor_services_token_creation_test.go
@@ -51,7 +51,7 @@ func TestMonitorServicesTokenCreation_TryCreateTokenWithInvalidEntityID(t *testi
 	var entityIDs []any
 	entityIDs = append(entityIDs, 999999999)
 
-	client, teardown := createTestClient(t, "fixtures/TestServiceToken_POST")
+	client, teardown := createTestClient(t, "fixtures/TestServiceTokenInvalidEntity_POST")
 	defer teardown()
 	createOptsWithInvalidID := linodego.MonitorTokenCreateOptions{
 		EntityIDs: entityIDs,

--- a/test/integration/monitor_services_token_creation_test.go
+++ b/test/integration/monitor_services_token_creation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +45,21 @@ func TestMonitorServicesTokenCreation_Get_smoke(t *testing.T) {
 
 	// Validate the token
 	validateToken(t, *token)
+}
+
+func TestMonitorServicesTokenCreation_TryCreateTokenWithInvalidEntityID(t *testing.T) {
+	var entityIDs []any
+	entityIDs = append(entityIDs, 999999999)
+
+	client, teardown := createTestClient(t, "fixtures/TestServiceToken_POST")
+	defer teardown()
+	createOptsWithInvalidID := linodego.MonitorTokenCreateOptions{
+		EntityIDs: entityIDs,
+	}
+	_, createErr := client.CreateMonitorServiceTokenForServiceType(context.Background(), "dbaas", createOptsWithInvalidID)
+	require.Error(t, createErr)
+	assert.Contains(t, createErr.Error(), "[403]")
+	assert.Contains(t, createErr.Error(), "The following entity_ids are not valid - [999999999]")
 }
 
 func validateToken(


### PR DESCRIPTION
## 📝 Description

Adds negative test cases for Pulse Metrics.

## ✔️ How to Test

go test -run TestMonitorDashboards_GetNotExistingDashboardID
go test -run TestMonitorServices_GetNotAllowedServiceType
go test -run TestMonitorServicesTokenCreation_TryCreateTokenWithInvalidEntityID