### PR TITLE
Fix `LinodeInterfaceUpdateOptions`

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -122,8 +122,7 @@ type LinodeInterfaceCreateOptions struct {
 type LinodeInterfaceUpdateOptions struct {
 	DefaultRoute *InterfaceDefaultRoute        `json:"default_route,omitempty"`
 	Public       *PublicInterfaceCreateOptions `json:"public,omitempty"`
-	VPC          *VPCInterfaceCreateOptions    `json:"vpc,omitempty"`
-	VLAN         *VLANInterface                `json:"vlan,omitempty"`
+	VPC          *VPCInterfaceUpdateOptions    `json:"vpc,omitempty"`
 }
 
 type PublicInterfaceCreateOptions struct {
@@ -187,6 +186,11 @@ type VPCInterfaceIPv6SLAACCreateOptions struct {
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type VPCInterfaceIPv6RangeCreateOptions struct {
 	Range string `json:"range"`
+}
+
+type VPCInterfaceUpdateOptions struct {
+	IPv4 *VPCInterfaceIPv4CreateOptions `json:"ipv4,omitempty"`
+	IPv6 *VPCInterfaceIPv6CreateOptions `json:"ipv6,omitempty"`
 }
 
 type LinodeInterfacesUpgrade struct {

--- a/test/unit/interface_test.go
+++ b/test/unit/interface_test.go
@@ -225,7 +225,7 @@ func TestInterface_UpdateVPC(t *testing.T) {
 			IPv4: linodego.Pointer(true),
 			IPv6: linodego.Pointer(true),
 		},
-		VPC: &linodego.VPCInterfaceCreateOptions{
+		VPC: &linodego.VPCInterfaceUpdateOptions{
 			IPv4: &linodego.VPCInterfaceIPv4CreateOptions{
 				Addresses: []linodego.VPCInterfaceIPv4AddressCreateOptions{
 					{


### PR DESCRIPTION
## 📝 Description
1. The `subnet_id` cannot be updated, but it always appears in requests built with `VPCInterfaceCreateOptions`. To address this, create a dedicated VPCInterfaceUpdateOptions for updates.
3. VLAN interfaces cannot be updated at all, so remove them from the update options.

