### PR TITLE
change isPublic to be a pointer on new IPv6/linode interface config to be in line with other isPublic values

### DIFF
--- a/instance_config_interfaces.go
+++ b/instance_config_interfaces.go
@@ -27,7 +27,7 @@ type InstanceConfigInterface struct {
 type InstanceConfigInterfaceIPv6 struct {
 	SLAAC    []InstanceConfigInterfaceIPv6SLAAC `json:"slaac"`
 	Ranges   []InstanceConfigInterfaceIPv6Range `json:"ranges"`
-	IsPublic bool                               `json:"is_public"`
+	IsPublic *bool                              `json:"is_public"`
 }
 
 // InstanceConfigInterfaceIPv6SLAAC represents a single IPv6 SLAAC under
@@ -173,7 +173,7 @@ func (i InstanceConfigInterface) GetCreateOptions() InstanceConfigInterfaceCreat
 					}
 				},
 			),
-			IsPublic: copyValue(&ipv6.IsPublic),
+			IsPublic: copyValue(ipv6.IsPublic),
 		}
 	}
 
@@ -219,7 +219,7 @@ func (i InstanceConfigInterface) GetUpdateOptions() InstanceConfigInterfaceUpdat
 			opts.IPv6 = &InstanceConfigInterfaceUpdateOptionsIPv6{
 				SLAAC:    &newSLAAC,
 				Ranges:   &newRanges,
-				IsPublic: copyValue(&ipv6.IsPublic),
+				IsPublic: copyValue(ipv6.IsPublic),
 			}
 		}
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -90,7 +90,7 @@ type VPCInterfaceIPv4Range struct {
 type VPCInterfaceIPv6 struct {
 	SLAAC    []VPCInterfaceIPv6SLAAC `json:"slaac"`
 	Ranges   []VPCInterfaceIPv6Range `json:"ranges"`
-	IsPublic bool                    `json:"is_public"`
+	IsPublic *bool                   `json:"is_public"`
 }
 
 // VPCInterfaceIPv6SLAAC contains the information for a single IPv6 SLAAC under a VPC.
@@ -174,7 +174,7 @@ type VPCInterfaceIPv4RangeCreateOptions struct {
 type VPCInterfaceIPv6CreateOptions struct {
 	SLAAC    []VPCInterfaceIPv6SLAACCreateOptions `json:"slaac,omitempty"`
 	Ranges   []VPCInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
-	IsPublic bool                                 `json:"is_public"`
+	IsPublic *bool                                `json:"is_public"`
 }
 
 // VPCInterfaceIPv6SLAACCreateOptions defines the IPv6 SLAAC configuration parameters for VPC creation.

--- a/test/unit/instance_config_interfaces_test.go
+++ b/test/unit/instance_config_interfaces_test.go
@@ -31,7 +31,7 @@ func TestInstanceConfigInterface_List(t *testing.T) {
 	assert.Equal(t, "1234::5678/64", interfaces[0].IPv6.SLAAC[0].Range)
 	assert.Equal(t, "1234::5678", interfaces[0].IPv6.SLAAC[0].Address)
 	assert.Equal(t, "1234::5678/64", interfaces[0].IPv6.Ranges[0].Range)
-	assert.True(t, interfaces[0].IPv6.IsPublic)
+	assert.True(t, *interfaces[0].IPv6.IsPublic)
 }
 
 func TestInstanceConfigInterface_Get(t *testing.T) {
@@ -56,7 +56,7 @@ func TestInstanceConfigInterface_Get(t *testing.T) {
 	assert.Equal(t, "1234::5678/64", iface.IPv6.SLAAC[0].Range)
 	assert.Equal(t, "1234::5678", iface.IPv6.SLAAC[0].Address)
 	assert.Equal(t, "1234::5678/64", iface.IPv6.Ranges[0].Range)
-	assert.True(t, iface.IPv6.IsPublic)
+	assert.True(t, *iface.IPv6.IsPublic)
 }
 
 func TestInstanceConfigInterface_Create(t *testing.T) {
@@ -95,7 +95,7 @@ func TestInstanceConfigInterface_Create(t *testing.T) {
 	assert.Equal(t, "1234::5678/64", iface.IPv6.SLAAC[0].Range)
 	assert.Equal(t, "1234::5678", iface.IPv6.SLAAC[0].Address)
 	assert.Equal(t, "1234::5678/64", iface.IPv6.Ranges[0].Range)
-	assert.True(t, iface.IPv6.IsPublic)
+	assert.True(t, *iface.IPv6.IsPublic)
 }
 
 func TestInstanceConfigInterface_Update(t *testing.T) {
@@ -130,7 +130,7 @@ func TestInstanceConfigInterface_Update(t *testing.T) {
 	assert.Equal(t, "1234::5678/64", iface.IPv6.SLAAC[0].Range)
 	assert.Equal(t, "1234::5678", iface.IPv6.SLAAC[0].Address)
 	assert.Equal(t, "1234::5678/64", iface.IPv6.Ranges[0].Range)
-	assert.True(t, iface.IPv6.IsPublic)
+	assert.True(t, *iface.IPv6.IsPublic)
 }
 
 func TestInstanceConfigInterface_Delete(t *testing.T) {

--- a/test/unit/instance_config_test.go
+++ b/test/unit/instance_config_test.go
@@ -43,7 +43,7 @@ func TestInstanceConfig_List(t *testing.T) {
 	assert.Len(t, iface.IPv6.Ranges, 1)
 	assert.Equal(t, "1234::5678/64", iface.IPv6.Ranges[0].Range)
 
-	assert.Equal(t, true, iface.IPv6.IsPublic)
+	assert.Equal(t, true, *iface.IPv6.IsPublic)
 
 	assert.ElementsMatch(t, []string{"192.168.1.0/24"}, iface.IPRanges)
 }
@@ -85,7 +85,7 @@ func TestInstanceConfig_Get(t *testing.T) {
 	assert.Len(t, iface.IPv6.Ranges, 1)
 	assert.Equal(t, "1234::5678/64", iface.IPv6.Ranges[0].Range)
 
-	assert.Equal(t, true, iface.IPv6.IsPublic)
+	assert.Equal(t, true, *iface.IPv6.IsPublic)
 
 	assert.ElementsMatch(t, []string{"192.168.1.0/24"}, iface.IPRanges)
 }
@@ -134,7 +134,7 @@ func TestInstanceConfig_Create(t *testing.T) {
 	assert.Len(t, iface.IPv6.Ranges, 1)
 	assert.Equal(t, "1234::5678/64", iface.IPv6.Ranges[0].Range)
 
-	assert.Equal(t, true, iface.IPv6.IsPublic)
+	assert.Equal(t, true, *iface.IPv6.IsPublic)
 
 	assert.ElementsMatch(t, []string{"192.168.1.0/24"}, iface.IPRanges)
 }
@@ -180,7 +180,7 @@ func TestInstanceConfig_Update(t *testing.T) {
 	assert.Len(t, iface.IPv6.Ranges, 1)
 	assert.Equal(t, "1234::5678/64", iface.IPv6.Ranges[0].Range)
 
-	assert.Equal(t, true, iface.IPv6.IsPublic)
+	assert.Equal(t, true, *iface.IPv6.IsPublic)
 
 	assert.ElementsMatch(t, []string{"192.168.1.0/24"}, iface.IPRanges)
 }

--- a/test/unit/interface_test.go
+++ b/test/unit/interface_test.go
@@ -138,7 +138,7 @@ func TestInterface_GetVPC(t *testing.T) {
 
 	assert.Equal(t, "4321::/64", iface.VPC.IPv6.Ranges[0].Range)
 
-	assert.Equal(t, true, iface.VPC.IPv6.IsPublic)
+	assert.Equal(t, true, *iface.VPC.IPv6.IsPublic)
 }
 
 func TestInterface_CreatePublic(t *testing.T) {
@@ -277,7 +277,7 @@ func TestInterface_UpdateVPC(t *testing.T) {
 
 	assert.Equal(t, "4322::/64", iface.VPC.IPv6.Ranges[0].Range)
 
-	assert.Equal(t, false, iface.VPC.IPv6.IsPublic)
+	assert.Equal(t, false, *iface.VPC.IPv6.IsPublic)
 }
 
 func TestInterface_Upgrade(t *testing.T) {


### PR DESCRIPTION

## 📝 Description

**What does this PR do and why is this change necessary?**
This PR changes the newer isPublic fields in beta objects to be `*bool` from `bool` to be in line with other GA APIs

## ✔️ How to Test

**What are the steps to reproduce the issue or verify the changes?**

**How do I run the relevant unit/integration tests?**

## 📷 Preview

**If applicable, include a screenshot or code snippet of this change. Otherwise, please remove this section.**