### PR TITLE
TPT-4277: Implement support for Reserved IP for IPv4

### DIFF
--- a/instance_ips.go
+++ b/instance_ips.go
@@ -33,6 +33,7 @@ type InstanceIP struct {
 	Region      string             `json:"region"`
 	VPCNAT1To1  *InstanceIPNAT1To1 `json:"vpc_nat_1_1"`
 	Reserved    bool               `json:"reserved"`
+	Tags        []string           `json:"tags"`
 }
 
 // VPCIP represents a private IP address in a VPC subnet with additional networking details

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -21,19 +21,20 @@ type InstanceIPv4Response struct {
 
 // InstanceIP represents an Instance IP with additional DNS and networking details
 type InstanceIP struct {
-	Address     string             `json:"address"`
-	Gateway     string             `json:"gateway"`
-	SubnetMask  string             `json:"subnet_mask"`
-	Prefix      int                `json:"prefix"`
-	Type        InstanceIPType     `json:"type"`
-	Public      bool               `json:"public"`
-	RDNS        string             `json:"rdns"`
-	LinodeID    int                `json:"linode_id"`
-	InterfaceID *int               `json:"interface_id"`
-	Region      string             `json:"region"`
-	VPCNAT1To1  *InstanceIPNAT1To1 `json:"vpc_nat_1_1"`
-	Reserved    bool               `json:"reserved"`
-	Tags        []string           `json:"tags"`
+	Address        string                    `json:"address"`
+	Gateway        string                    `json:"gateway"`
+	SubnetMask     string                    `json:"subnet_mask"`
+	Prefix         int                       `json:"prefix"`
+	Type           InstanceIPType            `json:"type"`
+	Public         bool                      `json:"public"`
+	RDNS           string                    `json:"rdns"`
+	LinodeID       int                       `json:"linode_id"`
+	InterfaceID    *int                      `json:"interface_id"`
+	Region         string                    `json:"region"`
+	VPCNAT1To1     *InstanceIPNAT1To1        `json:"vpc_nat_1_1"`
+	Reserved       bool                      `json:"reserved"`
+	Tags           []string                  `json:"tags"`
+	AssignedEntity *ReservedIPAssignedEntity `json:"assigned_entity"`
 }
 
 // VPCIP represents a private IP address in a VPC subnet with additional networking details

--- a/network_reserved_ips.go
+++ b/network_reserved_ips.go
@@ -4,6 +4,15 @@ import (
 	"context"
 )
 
+// ReservedIPAssignedEntity represents the entity that a reserved IP is assigned to.
+// NOTE: Reserved IP feature may not currently be available to all users.
+type ReservedIPAssignedEntity struct {
+	ID    int    `json:"id"`
+	Label string `json:"label"`
+	Type  string `json:"type"`
+	URL   string `json:"url"`
+}
+
 // ReserveIPOptions represents the options for reserving an IP address
 // NOTE: Reserved IP feature may not currently be available to all users.
 type ReserveIPOptions struct {

--- a/network_reserved_ips.go
+++ b/network_reserved_ips.go
@@ -7,7 +7,35 @@ import (
 // ReserveIPOptions represents the options for reserving an IP address
 // NOTE: Reserved IP feature may not currently be available to all users.
 type ReserveIPOptions struct {
-	Region string `json:"region"`
+	Region string   `json:"region"`
+	Tags   []string `json:"tags,omitempty"`
+}
+
+// UpdateReservedIPOptions represents the options for updating a reserved IP address
+// NOTE: Reserved IP feature may not currently be available to all users.
+type UpdateReservedIPOptions struct {
+	Tags []string `json:"tags"`
+}
+
+// ReservedIPPrice represents the pricing information for a reserved IP type
+type ReservedIPPrice struct {
+	Hourly  float64 `json:"hourly"`
+	Monthly float64 `json:"monthly"`
+}
+
+// ReservedIPRegionPrice represents region-specific pricing for a reserved IP type
+type ReservedIPRegionPrice struct {
+	ID      string  `json:"id"`
+	Hourly  float64 `json:"hourly"`
+	Monthly float64 `json:"monthly"`
+}
+
+// ReservedIPType represents a reserved IP type with pricing information
+type ReservedIPType struct {
+	ID           string                  `json:"id"`
+	Label        string                  `json:"label"`
+	Price        ReservedIPPrice         `json:"price"`
+	RegionPrices []ReservedIPRegionPrice `json:"region_prices"`
 }
 
 // ListReservedIPAddresses retrieves a list of reserved IP addresses
@@ -30,9 +58,22 @@ func (c *Client) ReserveIPAddress(ctx context.Context, opts ReserveIPOptions) (*
 	return doPOSTRequest[InstanceIP](ctx, c, "networking/reserved/ips", opts)
 }
 
+// UpdateReservedIPAddress updates the tags of a reserved IP address
+// NOTE: Reserved IP feature may not currently be available to all users.
+func (c *Client) UpdateReservedIPAddress(ctx context.Context, address string, opts UpdateReservedIPOptions) (*InstanceIP, error) {
+	e := formatAPIPath("networking/reserved/ips/%s", address)
+	return doPUTRequest[InstanceIP](ctx, c, e, opts)
+}
+
 // DeleteReservedIPAddress deletes a reserved IP address
 // NOTE: Reserved IP feature may not currently be available to all users.
 func (c *Client) DeleteReservedIPAddress(ctx context.Context, ipAddress string) error {
 	e := formatAPIPath("networking/reserved/ips/%s", ipAddress)
 	return doDELETERequest(ctx, c, e)
+}
+
+// ListReservedIPTypes retrieves a list of reserved IP types with pricing information
+// NOTE: Reserved IP feature may not currently be available to all users.
+func (c *Client) ListReservedIPTypes(ctx context.Context, opts *ListOptions) ([]ReservedIPType, error) {
+	return getPaginatedResults[ReservedIPType](ctx, c, "networking/reserved/ips/types", opts)
 }

--- a/network_reserved_ips.go
+++ b/network_reserved_ips.go
@@ -17,27 +17,17 @@ type UpdateReservedIPOptions struct {
 	Tags []string `json:"tags"`
 }
 
-// ReservedIPPrice represents the pricing information for a reserved IP type
-type ReservedIPPrice struct {
-	Hourly  float64 `json:"hourly"`
-	Monthly float64 `json:"monthly"`
-}
+// ReservedIPPrice represents the pricing information for a reserved IP type.
+// It is an alias of the shared baseTypePrice to keep pricing consistent across resources.
+type ReservedIPPrice = baseTypePrice
 
-// ReservedIPRegionPrice represents region-specific pricing for a reserved IP type
-type ReservedIPRegionPrice struct {
-	ID      string  `json:"id"`
-	Hourly  float64 `json:"hourly"`
-	Monthly float64 `json:"monthly"`
-}
+// ReservedIPRegionPrice represents region-specific pricing for a reserved IP type.
+// It is an alias of the shared baseTypeRegionPrice to keep region pricing consistent across resources.
+type ReservedIPRegionPrice = baseTypeRegionPrice
 
-// ReservedIPType represents a reserved IP type with pricing information
-type ReservedIPType struct {
-	ID           string                  `json:"id"`
-	Label        string                  `json:"label"`
-	Price        ReservedIPPrice         `json:"price"`
-	RegionPrices []ReservedIPRegionPrice `json:"region_prices"`
-}
-
+// ReservedIPType represents a reserved IP type with pricing information.
+// It reuses the generic baseType to avoid duplicating type/pricing structures.
+type ReservedIPType = baseType[ReservedIPPrice, ReservedIPRegionPrice]
 // ListReservedIPAddresses retrieves a list of reserved IP addresses
 // NOTE: Reserved IP feature may not currently be available to all users.
 func (c *Client) ListReservedIPAddresses(ctx context.Context, opts *ListOptions) ([]InstanceIP, error) {

--- a/network_reserved_ips.go
+++ b/network_reserved_ips.go
@@ -23,7 +23,7 @@ type ReserveIPOptions struct {
 // UpdateReservedIPOptions represents the options for updating a reserved IP address
 // NOTE: Reserved IP feature may not currently be available to all users.
 type UpdateReservedIPOptions struct {
-	Tags []string `json:"tags"`
+	Tags []string `json:"tags,omitzero"`
 }
 
 // ReservedIPPrice represents the pricing information for a reserved IP type.

--- a/network_reserved_ips.go
+++ b/network_reserved_ips.go
@@ -28,6 +28,7 @@ type ReservedIPRegionPrice = baseTypeRegionPrice
 // ReservedIPType represents a reserved IP type with pricing information.
 // It reuses the generic baseType to avoid duplicating type/pricing structures.
 type ReservedIPType = baseType[ReservedIPPrice, ReservedIPRegionPrice]
+
 // ListReservedIPAddresses retrieves a list of reserved IP addresses
 // NOTE: Reserved IP feature may not currently be available to all users.
 func (c *Client) ListReservedIPAddresses(ctx context.Context, opts *ListOptions) ([]InstanceIP, error) {

--- a/tags.go
+++ b/tags.go
@@ -38,10 +38,11 @@ type TagCreateOptions struct {
 	Label   string `json:"label"`
 	Linodes []int  `json:"linodes,omitempty"`
 	// @TODO is this implemented?
-	LKEClusters   []int `json:"lke_clusters,omitempty"`
-	Domains       []int `json:"domains,omitempty"`
-	Volumes       []int `json:"volumes,omitempty"`
-	NodeBalancers []int `json:"nodebalancers,omitempty"`
+	LKEClusters           []int    `json:"lke_clusters,omitempty"`
+	Domains               []int    `json:"domains,omitempty"`
+	Volumes               []int    `json:"volumes,omitempty"`
+	NodeBalancers         []int    `json:"nodebalancers,omitempty"`
+	ReservedIPv4Addresses []string `json:"reserved_ipv4_addresses,omitempty"`
 }
 
 // GetCreateOptions converts a Tag to TagCreateOptions for use in CreateTag
@@ -88,6 +89,13 @@ func (i *TaggedObject) fixData() (*TaggedObject, error) {
 		i.Data = obj
 	case "volume":
 		obj := Volume{}
+		if err := json.Unmarshal(i.RawData, &obj); err != nil {
+			return nil, err
+		}
+
+		i.Data = obj
+	case "reserved_ipv4_address":
+		obj := InstanceIP{}
 		if err := json.Unmarshal(i.RawData, &obj); err != nil {
 			return nil, err
 		}

--- a/test/integration/fixtures/TestReservedIPAddress_ReserveWithTags.yaml
+++ b/test/integration/fixtures/TestReservedIPAddress_ReserveWithTags.yaml
@@ -1,0 +1,167 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"region":"us-east","tags":["lb"]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"address": "66.175.209.100", "gateway": "66.175.209.1", "subnet_mask": "255.255.255.0",
+      "prefix": 24, "type": "ipv4", "public": true, "rdns": "66-175-209-100.ip.linodeusercontent.com",
+      "linode_id": null, "interface_id": null, "region": "us-east", "vpc_nat_1_1":
+      null, "reserved": true, "tags": ["lb"], "assigned_entity": null}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/66.175.209.100
+    method: GET
+  response:
+    body: '{"address": "66.175.209.100", "gateway": "66.175.209.1", "subnet_mask": "255.255.255.0",
+      "prefix": 24, "type": "ipv4", "public": true, "rdns": "66-175-209-100.ip.linodeusercontent.com",
+      "linode_id": null, "interface_id": null, "region": "us-east", "vpc_nat_1_1":
+      null, "reserved": true, "tags": ["lb"], "assigned_entity": null}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/66.175.209.100
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/fixtures/TestReservedIPAddress_UpdateTags.yaml
+++ b/test/integration/fixtures/TestReservedIPAddress_UpdateTags.yaml
@@ -1,0 +1,224 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"region":"us-east"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"address": "66.175.209.101", "gateway": "66.175.209.1", "subnet_mask": "255.255.255.0",
+      "prefix": 24, "type": "ipv4", "public": true, "rdns": "66-175-209-101.ip.linodeusercontent.com",
+      "linode_id": null, "interface_id": null, "region": "us-east", "vpc_nat_1_1":
+      null, "reserved": true, "tags": [], "assigned_entity": null}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"tags":["lb"]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/66.175.209.101
+    method: PUT
+  response:
+    body: '{"address": "66.175.209.101", "gateway": "66.175.209.1", "subnet_mask": "255.255.255.0",
+      "prefix": 24, "type": "ipv4", "public": true, "rdns": "66-175-209-101.ip.linodeusercontent.com",
+      "linode_id": null, "interface_id": null, "region": "us-east", "vpc_nat_1_1":
+      null, "reserved": true, "tags": ["lb"], "assigned_entity": null}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"tags":[]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/66.175.209.101
+    method: PUT
+  response:
+    body: '{"address": "66.175.209.101", "gateway": "66.175.209.1", "subnet_mask": "255.255.255.0",
+      "prefix": 24, "type": "ipv4", "public": true, "rdns": "66-175-209-101.ip.linodeusercontent.com",
+      "linode_id": null, "interface_id": null, "region": "us-east", "vpc_nat_1_1":
+      null, "reserved": true, "tags": [], "assigned_entity": null}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/66.175.209.101
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/fixtures/TestReservedIPTypes_List.yaml
+++ b/test/integration/fixtures/TestReservedIPTypes_List.yaml
@@ -1,0 +1,60 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/types?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": "ipv4", "label": "IPv4 Address", "price": {"hourly": 0.005,
+      "monthly": 2.0}, "region_prices": [{"id": "us-east", "hourly": 0.005, "monthly":
+      2.0}, {"id": "br-gru", "hourly": 0.006, "monthly": 3.0}]}], "page": 1, "pages":
+      1, "results": 1}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "800"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/network_reserved_ips_test.go
+++ b/test/integration/network_reserved_ips_test.go
@@ -143,7 +143,7 @@ func TestReservedIPAddresses_InsufficientPermissions(t *testing.T) {
 	defer func() { validTestAPIKey = original }()
 
 	filter := ""
-	ips, listErr := client.ListReservedIPAddresses(context.Background(), NewListOptions(0, filter))
+	ips, listErr := client.ListReservedIPAddresses(context.Background(), linodego.NewListOptions(0, filter))
 	if listErr == nil {
 		t.Errorf("Expected error due to insufficient permissions, but got none %v", ips)
 	} else {
@@ -155,7 +155,7 @@ func TestReservedIPAddresses_InsufficientPermissions(t *testing.T) {
 	}
 
 	// Attempt to reserve an IP address
-	resIP, resErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+	resIP, resErr := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{
 		Region: "us-east",
 	})
 	if resErr == nil {
@@ -191,7 +191,7 @@ func TestReservedIPAddresses_EndToEndTest(t *testing.T) {
 
 	filter := ""
 
-	ipList, err := client.ListReservedIPAddresses(context.Background(), NewListOptions(0, filter))
+	ipList, err := client.ListReservedIPAddresses(context.Background(), linodego.NewListOptions(0, filter))
 	if err != nil {
 		t.Fatalf("Error listing IP addresses: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestReservedIPAddresses_EndToEndTest(t *testing.T) {
 	initialCount := len(ipList)
 
 	// Attempt to reserve an IP
-	resIP, resErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+	resIP, resErr := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{
 		Region: "us-east",
 	})
 
@@ -223,7 +223,7 @@ func TestReservedIPAddresses_EndToEndTest(t *testing.T) {
 	}
 
 	// Verify the list of IPs has increased
-	verifyList, verifyErr := client.ListReservedIPAddresses(context.Background(), NewListOptions(0, filter))
+	verifyList, verifyErr := client.ListReservedIPAddresses(context.Background(), linodego.NewListOptions(0, filter))
 	if verifyErr != nil {
 		t.Fatalf("Error listing IP addresses after reservation: %v", verifyErr)
 	}
@@ -244,7 +244,7 @@ func TestReservedIPAddresses_EndToEndTest(t *testing.T) {
 		t.Errorf("Expected error when fetching %s, got nil", resIP.Address)
 	}
 
-	verifyDelList, verifyDelErr := client.ListReservedIPAddresses(context.Background(), NewListOptions(0, filter))
+	verifyDelList, verifyDelErr := client.ListReservedIPAddresses(context.Background(), linodego.NewListOptions(0, filter))
 	if verifyDelErr != nil {
 		t.Fatalf("Error listing IP addresses after deletion: %v", verifyDelErr)
 	}
@@ -326,7 +326,7 @@ func TestReservedIPAddresses_GetIPAddressVariants(t *testing.T) {
 	defer teardown()
 
 	// Reserve an IP for testing
-	resIP, resErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+	resIP, resErr := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{
 		Region: "us-east",
 	})
 
@@ -391,19 +391,19 @@ func TestReservedIPAddresses_ReserveIPAddressVariants(t *testing.T) {
 	defer cleanupIPs()
 
 	// Test reserving IP with omitted region
-	_, omitErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{})
+	_, omitErr := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{})
 	if omitErr == nil {
 		t.Errorf("Expected error when reserving IP with omitted region, got nil")
 	}
 
 	// Test reserving IP with invalid region
-	_, invalidErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{Region: "us"})
+	_, invalidErr := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{Region: "us"})
 	if invalidErr == nil {
 		t.Errorf("Expected error when reserving IP with invalid region, got nil")
 	}
 
 	// Test reserving IP with empty region
-	_, emptyErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{Region: ""})
+	_, emptyErr := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{Region: ""})
 	if emptyErr == nil {
 		t.Errorf("Expected error when reserving IP with empty region, got nil")
 	}
@@ -467,7 +467,7 @@ func TestReservedIPAddresses_DeleteIPAddressVariants(t *testing.T) {
 	client, teardown := createTestClient(t, "fixtures/TestReservedIPAddresses_DeleteIPAddressVariants")
 	defer teardown()
 
-	validRes, validErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{Region: "us-east"})
+	validRes, validErr := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{Region: "us-east"})
 	if validErr != nil {
 		t.Fatalf("Failed to reserve IP. This test should start with 0 reservations or reservations < limit. Error from the API: %v", validErr)
 	}
@@ -479,7 +479,7 @@ func TestReservedIPAddresses_DeleteIPAddressVariants(t *testing.T) {
 	t.Logf("Successfully reserved IP: %+v", validRes)
 
 	filter := ""
-	ipList, listErr := client.ListReservedIPAddresses(context.Background(), NewListOptions(0, filter))
+	ipList, listErr := client.ListReservedIPAddresses(context.Background(), linodego.NewListOptions(0, filter))
 	if listErr != nil {
 		t.Fatalf("Error listing IP addresses: %v", listErr)
 	}
@@ -494,7 +494,7 @@ func TestReservedIPAddresses_DeleteIPAddressVariants(t *testing.T) {
 	}
 
 	// Verify deletion
-	verifyDelList, verifyDelErr := client.ListReservedIPAddresses(context.Background(), NewListOptions(0, filter))
+	verifyDelList, verifyDelErr := client.ListReservedIPAddresses(context.Background(), linodego.NewListOptions(0, filter))
 	if verifyDelErr != nil {
 		t.Fatalf("Error listing IP addresses after deletion: %v", verifyDelErr)
 	}

--- a/test/integration/network_reserved_ips_test.go
+++ b/test/integration/network_reserved_ips_test.go
@@ -9,6 +9,129 @@ import (
 	. "github.com/linode/linodego"
 )
 
+// TestReservedIPAddress_ReserveWithTags verifies that tags can be passed when reserving
+// an IP and are returned in the response.
+func TestReservedIPAddress_ReserveWithTags(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIPAddress_ReserveWithTags")
+	defer teardown()
+
+	resIP, err := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{
+		Region: "us-east",
+		Tags:   []string{"lb"},
+	})
+	if err != nil {
+		t.Fatalf("Failed to reserve IP with tags: %v", err)
+	}
+
+	if resIP.Address == "" {
+		t.Fatal("Expected a non-empty address in the response")
+	}
+	if !resIP.Reserved {
+		t.Errorf("Expected Reserved=true, got false")
+	}
+	found := false
+	for _, tag := range resIP.Tags {
+		if tag == "lb" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected tag 'lb' in response tags, got %v", resIP.Tags)
+	}
+
+	defer func() {
+		if err := client.DeleteReservedIPAddress(context.Background(), resIP.Address); err != nil {
+			t.Errorf("Failed to delete reserved IP %s: %v", resIP.Address, err)
+		}
+	}()
+
+	// Verify tags round-trip via Get
+	fetched, err := client.GetReservedIPAddress(context.Background(), resIP.Address)
+	if err != nil {
+		t.Fatalf("Failed to get reserved IP: %v", err)
+	}
+	foundInFetch := false
+	for _, tag := range fetched.Tags {
+		if tag == "lb" {
+			foundInFetch = true
+			break
+		}
+	}
+	if !foundInFetch {
+		t.Errorf("Expected tag 'lb' in fetched IP tags, got %v", fetched.Tags)
+	}
+}
+
+// TestReservedIPAddress_UpdateTags verifies that PUT /networking/reserved/ips/{address}
+// replaces tags in full.
+func TestReservedIPAddress_UpdateTags(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIPAddress_UpdateTags")
+	defer teardown()
+
+	// Reserve without tags first
+	resIP, err := client.ReserveIPAddress(context.Background(), linodego.ReserveIPOptions{
+		Region: "us-east",
+	})
+	if err != nil {
+		t.Fatalf("Failed to reserve IP: %v", err)
+	}
+	defer func() {
+		if err := client.DeleteReservedIPAddress(context.Background(), resIP.Address); err != nil {
+			t.Errorf("Failed to delete reserved IP %s: %v", resIP.Address, err)
+		}
+	}()
+
+	// Set tags
+	updated, err := client.UpdateReservedIPAddress(context.Background(), resIP.Address, linodego.UpdateReservedIPOptions{
+		Tags: []string{"lb"},
+	})
+	if err != nil {
+		t.Fatalf("Failed to update reserved IP tags: %v", err)
+	}
+	if len(updated.Tags) != 1 || updated.Tags[0] != "lb" {
+		t.Errorf("Expected tags=[lb] after update, got %v", updated.Tags)
+	}
+
+	// Replace tags entirely (full replacement semantics)
+	cleared, err := client.UpdateReservedIPAddress(context.Background(), resIP.Address, linodego.UpdateReservedIPOptions{
+		Tags: []string{},
+	})
+	if err != nil {
+		t.Fatalf("Failed to clear reserved IP tags: %v", err)
+	}
+	if len(cleared.Tags) != 0 {
+		t.Errorf("Expected empty tags after clearing, got %v", cleared.Tags)
+	}
+}
+
+// TestReservedIPTypes_List verifies that GET /networking/reserved/ips/types returns
+// pricing structs with all expected fields populated.
+func TestReservedIPTypes_List(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIPTypes_List")
+	defer teardown()
+
+	types, err := client.ListReservedIPTypes(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Failed to list reserved IP types: %v", err)
+	}
+	if len(types) == 0 {
+		t.Fatal("Expected at least one reserved IP type, got none")
+	}
+
+	for _, rt := range types {
+		if rt.ID == "" {
+			t.Errorf("Expected non-empty ID for reserved IP type")
+		}
+		if rt.Label == "" {
+			t.Errorf("Expected non-empty Label for reserved IP type")
+		}
+		if rt.Price.Hourly == 0 && rt.Price.Monthly == 0 {
+			t.Errorf("Expected non-zero pricing for type %s", rt.ID)
+		}
+	}
+}
+
 // TestReservedIPAddresses_InsufficientPermissions tests the behavior when a user account
 // doesn't have the permission to use the Reserved IP feature
 func TestReservedIPAddresses_InsufficientPermissions(t *testing.T) {

--- a/test/integration/network_reserved_ips_test.go
+++ b/test/integration/network_reserved_ips_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/linode/linodego"
-	. "github.com/linode/linodego"
 )
 
 // TestReservedIPAddress_ReserveWithTags verifies that tags can be passed when reserving

--- a/test/unit/fixtures/instance_ip_reserved.json
+++ b/test/unit/fixtures/instance_ip_reserved.json
@@ -6,6 +6,12 @@
     "type": "ipv4",
     "public": false,
     "linode_id": 123,
-    "region": "us-central"
+    "region": "us-central",
+    "reserved": true,
+    "assigned_entity": {
+        "id": 123,
+        "label": "my-linode",
+        "type": "linode",
+        "url": "/v4/linode/instances/123"
+    }
 }
-  

--- a/test/unit/fixtures/network_reserved_ip_types_list.json
+++ b/test/unit/fixtures/network_reserved_ip_types_list.json
@@ -1,0 +1,22 @@
+{
+    "data": [
+        {
+            "id": "ipv4_address",
+            "label": "IPv4 Address",
+            "price": {
+                "hourly": 0.005,
+                "monthly": 2.00
+            },
+            "region_prices": [
+                {
+                    "id": "us-east",
+                    "hourly": 0.006,
+                    "monthly": 3.00
+                }
+            ]
+        }
+    ],
+    "page": 1,
+    "pages": 1,
+    "results": 1
+}

--- a/test/unit/fixtures/network_reserved_ip_update.json
+++ b/test/unit/fixtures/network_reserved_ip_update.json
@@ -1,0 +1,7 @@
+{
+    "address": "192.168.1.10",
+    "region": "us-east",
+    "linode_id": 12345,
+    "reserved": true,
+    "tags": ["lb", "team:infra"]
+}

--- a/test/unit/fixtures/network_reserved_ip_update.json
+++ b/test/unit/fixtures/network_reserved_ip_update.json
@@ -3,5 +3,6 @@
     "region": "us-east",
     "linode_id": 12345,
     "reserved": true,
-    "tags": ["lb", "team:infra"]
+    "tags": ["lb", "team:infra"],
+    "assigned_entity": null
 }

--- a/test/unit/fixtures/network_reserved_ips.json
+++ b/test/unit/fixtures/network_reserved_ips.json
@@ -4,6 +4,8 @@
     "linode_id": 13579,
     "label": "test-ip-3",
     "created": "2025-02-03T12:00:00",
-    "status": "reserved"
+    "status": "reserved",
+    "reserved": true,
+    "tags": ["env:staging"]
 }
   

--- a/test/unit/fixtures/network_reserved_ips_get.json
+++ b/test/unit/fixtures/network_reserved_ips_get.json
@@ -6,6 +6,11 @@
     "created": "2025-02-03T12:00:00",
     "status": "reserved",
     "reserved": true,
-    "tags": ["lb"]
+    "tags": ["lb"],
+    "assigned_entity": {
+        "id": 1234,
+        "label": "my-linode",
+        "type": "linode",
+        "url": "/v4/linode/instances/12345"
+    }
 }
-  

--- a/test/unit/fixtures/network_reserved_ips_get.json
+++ b/test/unit/fixtures/network_reserved_ips_get.json
@@ -4,6 +4,8 @@
     "linode_id": 12345,
     "label": "test-ip-1",
     "created": "2025-02-03T12:00:00",
-    "status": "reserved"
+    "status": "reserved",
+    "reserved": true,
+    "tags": ["lb"]
 }
   

--- a/test/unit/fixtures/network_reserved_ips_get.json
+++ b/test/unit/fixtures/network_reserved_ips_get.json
@@ -2,9 +2,6 @@
     "address": "192.168.1.10",
     "region": "us-east",
     "linode_id": 12345,
-    "label": "test-ip-1",
-    "created": "2025-02-03T12:00:00",
-    "status": "reserved",
     "reserved": true,
     "tags": ["lb"],
     "assigned_entity": {

--- a/test/unit/fixtures/network_reserved_ips_list.json
+++ b/test/unit/fixtures/network_reserved_ips_list.json
@@ -6,7 +6,9 @@
         "linode_id": 12345,
         "label": "test-ip-1",
         "created": "2025-02-03T12:00:00",
-        "status": "reserved"
+        "status": "reserved",
+        "reserved": true,
+        "tags": ["lb"]
       },
       {
         "address": "192.168.1.20",
@@ -14,7 +16,9 @@
         "linode_id": 67890,
         "label": "test-ip-2",
         "created": "2025-02-03T12:00:00",
-        "status": "reserved"
+        "status": "reserved",
+        "reserved": true,
+        "tags": []
       }
     ],
     "pages": 1,

--- a/test/unit/fixtures/tagged_objects_reserved_ip_list.json
+++ b/test/unit/fixtures/tagged_objects_reserved_ip_list.json
@@ -1,0 +1,25 @@
+{
+    "data": [
+        {
+            "type": "reserved_ipv4_address",
+            "data": {
+                "address": "192.168.1.10",
+                "gateway": "192.0.2.1",
+                "interface_id": null,
+                "linode_id": 0,
+                "prefix": 24,
+                "public": true,
+                "rdns": "",
+                "region": "us-east",
+                "subnet_mask": "255.255.255.0",
+                "type": "ipv4",
+                "vpc_nat_1_1": null,
+                "reserved": true,
+                "tags": ["lb"]
+            }
+        }
+    ],
+    "page": 1,
+    "pages": 1,
+    "results": 1
+}

--- a/test/unit/instance_ip_test.go
+++ b/test/unit/instance_ip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
 )
@@ -126,4 +127,21 @@ func TestInstanceReservedIP_Assign(t *testing.T) {
 	assert.NotNil(t, ip)
 	assert.Equal(t, "203.0.113.1", ip.Address)
 	assert.False(t, ip.Public)
+}
+
+func TestInstanceReservedIP_Assign_RequestBody(t *testing.T) {
+	client := createMockClient(t)
+
+	opts := linodego.InstanceReserveIPOptions{
+		Type:    "ipv4",
+		Public:  false,
+		Address: "203.0.113.1",
+	}
+
+	httpmock.RegisterRegexpResponder("POST", mockRequestURL(t, "/linode/instances/123/ips"),
+		mockRequestBodyValidate(t, opts, nil))
+
+	if _, err := client.AssignInstanceReservedIP(context.Background(), 123, opts); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/test/unit/instance_ip_test.go
+++ b/test/unit/instance_ip_test.go
@@ -127,6 +127,14 @@ func TestInstanceReservedIP_Assign(t *testing.T) {
 	assert.NotNil(t, ip)
 	assert.Equal(t, "203.0.113.1", ip.Address)
 	assert.False(t, ip.Public)
+	assert.True(t, ip.Reserved)
+
+	// AssignedEntity assertions
+	assert.NotNil(t, ip.AssignedEntity)
+	assert.Equal(t, 123, ip.AssignedEntity.ID)
+	assert.Equal(t, "my-linode", ip.AssignedEntity.Label)
+	assert.Equal(t, "linode", ip.AssignedEntity.Type)
+	assert.Equal(t, "/v4/linode/instances/123", ip.AssignedEntity.URL)
 }
 
 func TestInstanceReservedIP_Assign_RequestBody(t *testing.T) {

--- a/test/unit/instance_test.go
+++ b/test/unit/instance_test.go
@@ -312,3 +312,20 @@ func TestInstance_Rebuild(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "linode/ubuntu22.04", instance.Image)
 }
+
+func TestCreateInstance_IPv4ReservedIPs(t *testing.T) {
+	client := createMockClient(t)
+
+	createOpts := linodego.InstanceCreateOptions{
+		Region: "us-east",
+		Type:   "g6-standard-1",
+		IPv4:   []string{"192.0.2.1"},
+	}
+
+	httpmock.RegisterRegexpResponder("POST", mockRequestURL(t, "/linode/instances"),
+		mockRequestBodyValidate(t, createOpts, nil))
+
+	if _, err := client.CreateInstance(context.Background(), createOpts); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/unit/network_ips_test.go
+++ b/test/unit/network_ips_test.go
@@ -2,8 +2,11 @@ package unit
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,6 +33,32 @@ func TestIPUpdateAddressV2(t *testing.T) {
 	assert.True(t, updatedIP.Reserved, "Expected Reserved to be true")
 }
 
+// TestIPUpdateAddressV2_BothFields: both "rdns" and "reserved" present in request body.
+func TestIPUpdateAddressV2_BothFields(t *testing.T) {
+	client := createMockClient(t)
+
+	rdns := "test.example.org"
+	opts := linodego.IPAddressUpdateOptionsV2{
+		RDNS:     linodego.Pointer(&rdns),
+		Reserved: linodego.Pointer(true),
+	}
+
+	httpmock.RegisterRegexpResponder("PUT", mockRequestURL(t, "/networking/ips/192.168.1.1"),
+		func(req *http.Request) (*http.Response, error) {
+			var body map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, rdns, body["rdns"])
+			assert.Equal(t, true, body["reserved"])
+			return httpmock.NewJsonResponse(http.StatusOK, nil)
+		})
+
+	if _, err := client.UpdateIPAddressV2(context.Background(), "192.168.1.1", opts); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestIPAllocateReserve(t *testing.T) {
 	var base ClientBaseCase
 	base.SetUp(t)
@@ -54,6 +83,24 @@ func TestIPAllocateReserve(t *testing.T) {
 	assert.Equal(t, "us-east", ip.Region, "Expected Region to match")
 	assert.True(t, ip.Public, "Expected Public to be true")
 	assert.Nil(t, ip.InterfaceID)
+}
+
+func TestIPAllocateReserve_RequestBody(t *testing.T) {
+	client := createMockClient(t)
+
+	opts := linodego.AllocateReserveIPOptions{
+		Type:     "ipv4",
+		Public:   true,
+		Reserved: true,
+		Region:   "us-east",
+	}
+
+	httpmock.RegisterRegexpResponder("POST", mockRequestURL(t, "/networking/ips"),
+		mockRequestBodyValidate(t, opts, nil))
+
+	if _, err := client.AllocateReserveIP(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestIPAssignInstances(t *testing.T) {
@@ -144,4 +191,23 @@ func TestIPAddresses_Get(t *testing.T) {
 	assert.Equal(t, "192.168.0.42", ip.VPCNAT1To1.Address)
 	assert.Equal(t, 101, ip.VPCNAT1To1.SubnetID)
 	assert.Equal(t, 111, ip.VPCNAT1To1.VPCID)
+}
+
+func TestIPAddresses_List_FilterByReserved(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("network_ip_addresses_list")
+	assert.NoError(t, err)
+
+	client := createMockClient(t)
+
+	httpmock.RegisterRegexpResponder("GET", mockRequestURL(t, "/networking/ips"),
+		func(req *http.Request) (*http.Response, error) {
+			filter := req.Header.Get("X-Filter")
+			assert.Equal(t, `{"reserved":true}`, filter, "Expected X-Filter header to filter by reserved=true")
+			return httpmock.NewJsonResponse(http.StatusOK, fixtureData)
+		})
+
+	_, err = client.ListIPAddresses(context.Background(), &linodego.ListOptions{
+		Filter: `{"reserved":true}`,
+	})
+	assert.NoError(t, err)
 }

--- a/test/unit/network_ips_test.go
+++ b/test/unit/network_ips_test.go
@@ -66,9 +66,10 @@ func TestIPAllocateReserve(t *testing.T) {
 
 	// Mock API response
 	base.MockPost("networking/ips", linodego.InstanceIP{
-		Address: "192.168.1.3",
-		Region:  "us-east",
-		Public:  true,
+		Address:        "192.168.1.3",
+		Region:         "us-east",
+		Public:         true,
+		AssignedEntity: nil,
 	})
 
 	ip, err := base.Client.AllocateReserveIP(context.Background(), linodego.AllocateReserveIPOptions{
@@ -83,6 +84,7 @@ func TestIPAllocateReserve(t *testing.T) {
 	assert.Equal(t, "us-east", ip.Region, "Expected Region to match")
 	assert.True(t, ip.Public, "Expected Public to be true")
 	assert.Nil(t, ip.InterfaceID)
+	assert.Nil(t, ip.AssignedEntity)
 }
 
 func TestIPAllocateReserve_RequestBody(t *testing.T) {

--- a/test/unit/network_reserved_ips_test.go
+++ b/test/unit/network_reserved_ips_test.go
@@ -88,11 +88,12 @@ func TestIPReserveIPAddress(t *testing.T) {
 
 	// Mock the POST request for reserving an IP
 	mockResponse := linodego.InstanceIP{
-		Address:  "192.168.1.30",
-		Region:   "us-west",
-		LinodeID: 13579,
-		Reserved: true,
-		Tags:     []string{"env:staging"},
+		Address:        "192.168.1.30",
+		Region:         "us-west",
+		LinodeID:       13579,
+		Reserved:       true,
+		Tags:           []string{"env:staging"},
+		AssignedEntity: nil,
 	}
 
 	base.MockPost("networking/reserved/ips", mockResponse)
@@ -105,6 +106,7 @@ func TestIPReserveIPAddress(t *testing.T) {
 	assert.Equal(t, "us-west", reservedIP.Region, "Expected region to match")
 	assert.Equal(t, 13579, reservedIP.LinodeID, "Expected Linode ID to match")
 	assert.Equal(t, []string{"env:staging"}, reservedIP.Tags, "Expected tags to match")
+	assert.Nil(t, reservedIP.AssignedEntity, "Expected AssignedEntity to be nil for newly reserved IP")
 }
 
 func TestReservedIPAddress_Delete(t *testing.T) {
@@ -144,6 +146,7 @@ func TestUpdateReservedIPAddress(t *testing.T) {
 	assert.Equal(t, ip, updated.Address)
 	assert.True(t, updated.Reserved)
 	assert.Equal(t, []string{"lb", "team:infra"}, updated.Tags)
+	assert.Nil(t, updated.AssignedEntity, "Expected AssignedEntity to be nil for unassigned reserved IP")
 }
 
 func TestListReservedIPTypes(t *testing.T) {

--- a/test/unit/network_reserved_ips_test.go
+++ b/test/unit/network_reserved_ips_test.go
@@ -23,12 +23,14 @@ func TestReservedIPAddresses_List(t *testing.T) {
 				Region:   "us-east",
 				LinodeID: 12345,
 				Reserved: true,
+				Tags:     []string{"lb"},
 			},
 			{
 				Address:  "192.168.1.20",
 				Region:   "us-west",
 				LinodeID: 67890,
 				Reserved: true,
+				Tags:     []string{},
 			},
 		},
 	}
@@ -43,6 +45,8 @@ func TestReservedIPAddresses_List(t *testing.T) {
 	assert.Equal(t, "192.168.1.10", reservedIPs[0].Address, "Expected first reserved IP address to match")
 	assert.Equal(t, "us-east", reservedIPs[0].Region, "Expected region to match")
 	assert.Equal(t, 12345, reservedIPs[0].LinodeID, "Expected Linode ID to match")
+	assert.True(t, reservedIPs[0].Reserved, "Expected first IP to be reserved")
+	assert.Equal(t, []string{"lb"}, reservedIPs[0].Tags, "Expected tags to match")
 }
 
 func TestReservedIPAddress_Get(t *testing.T) {
@@ -58,6 +62,7 @@ func TestReservedIPAddress_Get(t *testing.T) {
 		Region:   "us-east",
 		LinodeID: 12345,
 		Reserved: true,
+		Tags:     []string{"lb"},
 	}
 
 	base.MockGet("networking/reserved/ips/"+ip, mockResponse)
@@ -69,6 +74,8 @@ func TestReservedIPAddress_Get(t *testing.T) {
 	assert.Equal(t, ip, reservedIP.Address, "Expected reserved IP address to match")
 	assert.Equal(t, "us-east", reservedIP.Region, "Expected region to match")
 	assert.Equal(t, 12345, reservedIP.LinodeID, "Expected Linode ID to match")
+	assert.True(t, reservedIP.Reserved, "Expected IP to be reserved")
+	assert.Equal(t, []string{"lb"}, reservedIP.Tags, "Expected tags to match")
 }
 
 func TestIPReserveIPAddress(t *testing.T) {
@@ -86,6 +93,7 @@ func TestIPReserveIPAddress(t *testing.T) {
 		Region:   "us-west",
 		LinodeID: 13579,
 		Reserved: true,
+		Tags:     []string{"env:staging"},
 	}
 
 	base.MockPost("networking/reserved/ips", mockResponse)
@@ -97,6 +105,7 @@ func TestIPReserveIPAddress(t *testing.T) {
 	assert.Equal(t, "192.168.1.30", reservedIP.Address, "Expected reserved IP address to match")
 	assert.Equal(t, "us-west", reservedIP.Region, "Expected region to match")
 	assert.Equal(t, 13579, reservedIP.LinodeID, "Expected Linode ID to match")
+	assert.Equal(t, []string{"env:staging"}, reservedIP.Tags, "Expected tags to match")
 }
 
 func TestReservedIPAddress_Delete(t *testing.T) {
@@ -112,4 +121,51 @@ func TestReservedIPAddress_Delete(t *testing.T) {
 	err := base.Client.DeleteReservedIPAddress(context.Background(), ip)
 
 	assert.NoError(t, err, "Expected no error when deleting reserved IP address")
+}
+
+func TestUpdateReservedIPAddress(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("network_reserved_ip_update")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	ip := "192.168.1.10"
+	base.MockPut("networking/reserved/ips/"+ip, fixtureData)
+
+	updateOpts := linodego.UpdateReservedIPOptions{
+		Tags: []string{"lb", "team:infra"},
+	}
+
+	updated, err := base.Client.UpdateReservedIPAddress(context.Background(), ip, updateOpts)
+
+	assert.NoError(t, err, "Expected no error when updating reserved IP address")
+	assert.NotNil(t, updated)
+	assert.Equal(t, ip, updated.Address)
+	assert.True(t, updated.Reserved)
+	assert.Equal(t, []string{"lb", "team:infra"}, updated.Tags)
+}
+
+func TestListReservedIPTypes(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("network_reserved_ip_types_list")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockGet("networking/reserved/ips/types", fixtureData)
+
+	types, err := base.Client.ListReservedIPTypes(context.Background(), nil)
+
+	assert.NoError(t, err, "Expected no error when listing reserved IP types")
+	assert.Len(t, types, 1)
+	assert.Equal(t, "ipv4_address", types[0].ID)
+	assert.Equal(t, "IPv4 Address", types[0].Label)
+	assert.Equal(t, 0.005, types[0].Price.Hourly)
+	assert.Equal(t, 2.00, types[0].Price.Monthly)
+	assert.Len(t, types[0].RegionPrices, 1)
+	assert.Equal(t, "us-east", types[0].RegionPrices[0].ID)
+	assert.Equal(t, 0.006, types[0].RegionPrices[0].Hourly)
 }

--- a/test/unit/network_reserved_ips_test.go
+++ b/test/unit/network_reserved_ips_test.go
@@ -50,22 +50,15 @@ func TestReservedIPAddresses_List(t *testing.T) {
 }
 
 func TestReservedIPAddress_Get(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("network_reserved_ips_get")
+	assert.NoError(t, err)
+
 	var base ClientBaseCase
 	base.SetUp(t)
 	defer base.TearDown(t)
 
 	ip := "192.168.1.10"
-
-	// Mock response with necessary attributes
-	mockResponse := linodego.InstanceIP{
-		Address:  ip,
-		Region:   "us-east",
-		LinodeID: 12345,
-		Reserved: true,
-		Tags:     []string{"lb"},
-	}
-
-	base.MockGet("networking/reserved/ips/"+ip, mockResponse)
+	base.MockGet("networking/reserved/ips/"+ip, fixtureData)
 
 	reservedIP, err := base.Client.GetReservedIPAddress(context.Background(), ip)
 
@@ -76,6 +69,12 @@ func TestReservedIPAddress_Get(t *testing.T) {
 	assert.Equal(t, 12345, reservedIP.LinodeID, "Expected Linode ID to match")
 	assert.True(t, reservedIP.Reserved, "Expected IP to be reserved")
 	assert.Equal(t, []string{"lb"}, reservedIP.Tags, "Expected tags to match")
+
+	assert.NotNil(t, reservedIP.AssignedEntity)
+	assert.Equal(t, 1234, reservedIP.AssignedEntity.ID)
+	assert.Equal(t, "my-linode", reservedIP.AssignedEntity.Label)
+	assert.Equal(t, "linode", reservedIP.AssignedEntity.Type)
+	assert.Equal(t, "/v4/linode/instances/12345", reservedIP.AssignedEntity.URL)
 }
 
 func TestIPReserveIPAddress(t *testing.T) {

--- a/test/unit/nodebalancer_test.go
+++ b/test/unit/nodebalancer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
 )
@@ -151,4 +152,21 @@ func TestNodeBalancer_Delete(t *testing.T) {
 
 	err := base.Client.DeleteNodeBalancer(context.Background(), 123)
 	assert.NoError(t, err, "Expected no error when deleting NodeBalancer")
+}
+
+func TestNodeBalancer_Create_IPv4RequestBody(t *testing.T) {
+	client := createMockClient(t)
+
+	opts := linodego.NodeBalancerCreateOptions{
+		Label:  String("Test NodeBalancer IPv4"),
+		Region: "us-east",
+		IPv4:   String("192.0.2.2"),
+	}
+
+	httpmock.RegisterRegexpResponder("POST", mockRequestURL(t, "/nodebalancers"),
+		mockRequestBodyValidate(t, opts, nil))
+
+	if _, err := client.CreateNodeBalancer(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/test/unit/tag_test.go
+++ b/test/unit/tag_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jarcoal/httpmock"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/exp/slices"
@@ -116,4 +117,72 @@ func TestSortedObjects(t *testing.T) {
 
 	assert.NotEmpty(t, sortedObjects.Instances, "Expected non-empty instances list in sorted objects")
 	assert.Equal(t, "example-instance", sortedObjects.Instances[0].Label, "Expected instance label to be 'example-instance'")
+}
+
+func TestCreateTagWithReservedIPv4Addresses(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("tag_create")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockPost("tags", fixtureData)
+
+	opts := linodego.TagCreateOptions{
+		Label:                 "new-tag",
+		ReservedIPv4Addresses: []string{"192.168.1.10", "192.168.1.20"},
+	}
+
+	tag, err := base.Client.CreateTag(context.Background(), opts)
+	assert.NoError(t, err, "Expected no error when creating tag with reserved IPv4 addresses")
+	assert.Equal(t, "new-tag", tag.Label)
+}
+
+func TestListTaggedObjectsWithReservedIPv4Address(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("tagged_objects_reserved_ip_list")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	tagLabel := "lb"
+	base.MockGet(fmt.Sprintf("tags/%s", tagLabel), fixtureData)
+
+	taggedObjects, err := base.Client.ListTaggedObjects(context.Background(), tagLabel, &linodego.ListOptions{})
+	assert.NoError(t, err)
+	assert.Len(t, taggedObjects, 1)
+
+	assert.Equal(t, "reserved_ipv4_address", taggedObjects[0].Type)
+
+	ip, ok := taggedObjects[0].Data.(linodego.InstanceIP)
+	assert.True(t, ok, "Expected Data to be InstanceIP")
+	assert.Equal(t, "192.168.1.10", ip.Address)
+	assert.Equal(t, "192.0.2.1", ip.Gateway)
+	assert.Equal(t, 24, ip.Prefix)
+	assert.True(t, ip.Public)
+	assert.Equal(t, "", ip.RDNS)
+	assert.Equal(t, "us-east", ip.Region)
+	assert.Equal(t, "255.255.255.0", ip.SubnetMask)
+	assert.Equal(t, linodego.InstanceIPType("ipv4"), ip.Type)
+	assert.Nil(t, ip.VPCNAT1To1)
+	assert.True(t, ip.Reserved)
+	assert.Equal(t, []string{"lb"}, ip.Tags)
+}
+
+func TestCreateTag_ReservedIPv4AddressesRequestBody(t *testing.T) {
+	client := createMockClient(t)
+
+	opts := linodego.TagCreateOptions{
+		Label:                 "new-tag",
+		ReservedIPv4Addresses: []string{"192.0.2.141"},
+	}
+
+	httpmock.RegisterRegexpResponder("POST", mockRequestURL(t, "/tags"),
+		mockRequestBodyValidate(t, opts, nil))
+
+	if _, err := client.CreateTag(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
## 📝 Description

Complete the Go SDK (linodego) support for the Reserved IP feature. Several foundations are already in place; this story addresses the remaining gaps to bring the SDK fully in line with the API Specification.

## ✔️ How to Test

```
make test-unit
make TEST_ARGS="-run TestReservedIPAddress" test-int
```

As the API is not ready yet, there are only mocked integration tests.