### PR TITLE
TPT-4329: Deprecate vpcs in favor of backend_vpcs

### DIFF
--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -61,6 +61,13 @@ type NodeBalancerVPCOptions struct {
 	IPv4RangeAutoAssign bool   `json:"ipv4_range_auto_assign,omitempty"`
 }
 
+type NodeBalancerBackendVPCOptions struct {
+	IPv4Range           string `json:"ipv4_range,omitempty"`
+	IPv6Range           string `json:"ipv6_range,omitempty"`
+	SubnetID            int    `json:"subnet_id"`
+	IPv4RangeAutoAssign bool   `json:"ipv4_range_auto_assign,omitempty"`
+}
+
 type NodeBalancerFrontendVPCOptions struct {
 	IPv4Range string `json:"ipv4_range,omitempty"`
 	IPv6Range string `json:"ipv6_range,omitempty"`
@@ -83,7 +90,7 @@ type NodeBalancerCreateOptions struct {
 	// Deprecated: `VPCs` is deprecated in favor of `BackendVPCs`.
 	// This field may be removed in a later release.
 	VPCs         []NodeBalancerVPCOptions         `json:"vpcs,omitempty"`
-	BackendVPCs  []NodeBalancerVPCOptions         `json:"backend_vpcs,omitempty"`
+	BackendVPCs  []NodeBalancerBackendVPCOptions  `json:"backend_vpcs,omitempty"`
 	FrontendVPCs []NodeBalancerFrontendVPCOptions `json:"frontend_vpcs,omitempty"`
 	IPv4         *string                          `json:"ipv4,omitempty"`
 }

--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -76,13 +76,16 @@ type NodeBalancerCreateOptions struct {
 	// NOTE: ClientUDPSessThrottle may not currently be available to all users.
 	ClientUDPSessThrottle *int `json:"client_udp_sess_throttle,omitempty"`
 
-	Configs      []*NodeBalancerConfigCreateOptions `json:"configs,omitempty"`
-	Tags         []string                           `json:"tags"`
-	FirewallID   int                                `json:"firewall_id,omitempty"`
-	Type         NodeBalancerPlanType               `json:"type,omitempty"`
-	VPCs         []NodeBalancerVPCOptions           `json:"vpcs,omitempty"`
-	FrontendVPCs []NodeBalancerFrontendVPCOptions   `json:"frontend_vpcs,omitempty"`
-	IPv4         *string                            `json:"ipv4,omitempty"`
+	Configs    []*NodeBalancerConfigCreateOptions `json:"configs,omitempty"`
+	Tags       []string                           `json:"tags"`
+	FirewallID int                                `json:"firewall_id,omitempty"`
+	Type       NodeBalancerPlanType               `json:"type,omitempty"`
+	// Deprecated: `VPCs` is deprecated in favor of `BackendVPCs`.
+	// This field may be removed in a later release.
+	VPCs         []NodeBalancerVPCOptions         `json:"vpcs,omitempty"`
+	BackendVPCs  []NodeBalancerVPCOptions         `json:"backend_vpcs,omitempty"`
+	FrontendVPCs []NodeBalancerFrontendVPCOptions `json:"frontend_vpcs,omitempty"`
+	IPv4         *string                          `json:"ipv4,omitempty"`
 }
 
 // NodeBalancerUpdateOptions are the options permitted for UpdateNodeBalancer

--- a/test/unit/nodebalancer_test.go
+++ b/test/unit/nodebalancer_test.go
@@ -201,3 +201,49 @@ func TestNodeBalancer_Create_with_VPCs(t *testing.T) {
 	assert.Equal(t, linodego.NodeBalancerVPCFrontendAddressTypeVPC, nb.FrontendAddressType)
 	assert.Equal(t, 456, *nb.FrontendVPCSubnetID)
 }
+
+func TestNodeBalancer_Create_with_BackendVPCs(t *testing.T) {
+	// The response fixture is the same as the VPCs test since BackendVPCs and
+	// VPCs are currently both accepted by the API.
+	fixtureData, err := fixtures.GetFixture("nodebalancer_create_with_vpcs")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	requestData := linodego.NodeBalancerCreateOptions{
+		Label:  String("Test NodeBalancer VPC"),
+		Region: "us-east",
+		Type:   linodego.NBTypePremium40GB,
+		BackendVPCs: []linodego.NodeBalancerVPCOptions{
+			{
+				SubnetID:            123,
+				IPv4Range:           "10.200.4.16/28",
+				IPv6Range:           "2600:3c01:e000:1::/64",
+				IPv4RangeAutoAssign: false,
+			},
+		},
+		FrontendVPCs: []linodego.NodeBalancerFrontendVPCOptions{
+			{
+				SubnetID:  456,
+				IPv4Range: "10.200.5.16/28",
+				IPv6Range: "2600:3c01:e000:101::/64",
+			},
+		},
+	}
+
+	base.MockPost("nodebalancers", fixtureData)
+
+	nb, err := base.Client.CreateNodeBalancer(context.Background(), requestData)
+
+	assert.NoError(t, err)
+
+	assert.Equal(t, 12345, nb.ID)
+	assert.Equal(t, "Test NodeBalancer VPC", *nb.Label)
+	assert.Equal(t, "us-east", nb.Region)
+	assert.Equal(t, linodego.NBTypePremium40GB, nb.Type)
+
+	assert.Equal(t, linodego.NodeBalancerVPCFrontendAddressTypeVPC, nb.FrontendAddressType)
+	assert.Equal(t, 456, *nb.FrontendVPCSubnetID)
+}

--- a/test/unit/nodebalancer_test.go
+++ b/test/unit/nodebalancer_test.go
@@ -216,7 +216,7 @@ func TestNodeBalancer_Create_with_BackendVPCs(t *testing.T) {
 		Label:  String("Test NodeBalancer VPC"),
 		Region: "us-east",
 		Type:   linodego.NBTypePremium40GB,
-		BackendVPCs: []linodego.NodeBalancerVPCOptions{
+		BackendVPCs: []linodego.NodeBalancerBackendVPCOptions{
 			{
 				SubnetID:            123,
 				IPv4Range:           "10.200.4.16/28",


### PR DESCRIPTION
## 📝 Description

PR deprecates `vpcs` attribute from Create Nodebalancer operation and recommends using `backend_vpcs`, which was added to the request options.

## ✔️ How to Test

```
make test-unit
```
