### PR TITLE
TPT-3499: Support NodeBalancer lke_cluster field

### DIFF
--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -37,6 +37,9 @@ type NodeBalancer struct {
 	// An array of tags applied to this object. Tags are for organizational purposes only.
 	Tags []string `json:"tags"`
 
+	// This NodeBalancer's related LKE cluster, if any. The value is null if this NodeBalancer is not related to an LKE cluster.
+	LKECluster *NodeBalancerLKECluster `json:"lke_cluster"`
+
 	// An array of locks applied to this NodeBalancer for deletion protection.
 	// Locks prevent the NodeBalancer or its subresources from being deleted.
 	// NOTE: Locks can only be used with v4beta.
@@ -89,6 +92,17 @@ type NodeBalancerUpdateOptions struct {
 	ClientUDPSessThrottle *int `json:"client_udp_sess_throttle,omitempty"`
 
 	Tags *[]string `json:"tags,omitempty"`
+}
+
+type NodeBalancerLKECluster struct {
+	// The ID of the related LKE cluster.
+	ID int `json:"id"`
+	// The label of the related LKE cluster.
+	Label string `json:"label"`
+	// The type for LKE clusters.
+	Type string `json:"type"`
+	// The URL where you can access the related LKE cluster.
+	URL string `json:"url"`
 }
 
 // NodeBalancerPlanType constants start with NBType and include Linode API NodeBalancer's plan types

--- a/test/unit/fixtures/nodebalancer_get_with_lke_cluster.json
+++ b/test/unit/fixtures/nodebalancer_get_with_lke_cluster.json
@@ -11,7 +11,13 @@
       "in": 1000.0,
       "out": 1000.0
     },
-    "lke_cluster": null,
+    "type": "common",
+    "lke_cluster": {
+        "id": 1234,
+        "type": "lkecluster",
+        "label": "test-cluster",
+        "url": "/v4/lke/clusters/1234"
+    },
     "tags": ["production"],
     "locks": ["cannot_delete_with_subresources"],
     "created": "2025-01-15T08:00:00",

--- a/test/unit/fixtures/nodebalancers_list.json
+++ b/test/unit/fixtures/nodebalancers_list.json
@@ -5,14 +5,21 @@
             "label": "NodeBalancer A",
             "region": "us-east",
             "tags": ["tag1", "tag2"],
-            "locks": ["cannot_delete"]
+            "locks": ["cannot_delete"],
+            "lke_cluster": null
         },
         {
             "id": 456,
             "label": "NodeBalancer B",
             "region": "us-west",
             "tags": ["tag3"],
-            "locks": []
+            "locks": [],
+            "lke_cluster": {
+                "id": 1234,
+                "type": "lkecluster",
+                "label": "test-cluster",
+                "url": "/v4/lke/clusters/1234"
+            }
         }
     ],
     "page": 1,

--- a/test/unit/nodebalancer_test.go
+++ b/test/unit/nodebalancer_test.go
@@ -2,6 +2,7 @@ package unit
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/linode/linodego"
@@ -66,23 +67,53 @@ func String(s string) *string {
 }
 
 func TestNodeBalancer_Get(t *testing.T) {
-	fixtureData, err := fixtures.GetFixture("nodebalancer_get")
-	assert.NoError(t, err)
+	tests := []struct {
+		name               string
+		nodeBalancerID     int
+		fixture            string
+		expectedLKECluster *linodego.NodeBalancerLKECluster
+	}{
+		{
+			name:               "basic get",
+			nodeBalancerID:     123,
+			fixture:            "nodebalancer_get",
+			expectedLKECluster: nil,
+		},
+		{
+			name:           "get with lke_cluster",
+			nodeBalancerID: 123,
+			fixture:        "nodebalancer_get_with_lke_cluster",
+			expectedLKECluster: &linodego.NodeBalancerLKECluster{
+				ID:    1234,
+				Type:  "lkecluster",
+				Label: "test-cluster",
+				URL:   "/v4/lke/clusters/1234",
+			},
+		},
+	}
 
-	var base ClientBaseCase
-	base.SetUp(t)
-	defer base.TearDown(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixtureData, err := fixtures.GetFixture(tt.fixture)
+			assert.NoError(t, err)
 
-	// Mock the GET request with the fixture response
-	base.MockGet("nodebalancers/123", fixtureData)
+			var base ClientBaseCase
+			base.SetUp(t)
+			defer base.TearDown(t)
 
-	nodebalancer, err := base.Client.GetNodeBalancer(context.Background(), 123)
-	assert.NoError(t, err)
+			// Mock the GET request with the fixture response
+			base.MockGet(fmt.Sprintf("nodebalancers/%d", tt.nodeBalancerID), fixtureData)
 
-	assert.Equal(t, 123, nodebalancer.ID, "Expected NodeBalancer ID to match")
-	assert.Equal(t, "Existing NodeBalancer", *nodebalancer.Label, "Expected NodeBalancer label to match")
-	assert.Equal(t, "us-west", nodebalancer.Region, "Expected NodeBalancer region to match")
-	assert.Equal(t, []linodego.LockType{linodego.LockTypeCannotDeleteWithSubresources}, nodebalancer.Locks, "Expected NodeBalancer locks to match")
+			nodebalancer, err := base.Client.GetNodeBalancer(context.Background(), tt.nodeBalancerID)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tt.nodeBalancerID, nodebalancer.ID, "Expected NodeBalancer ID to match")
+			assert.Equal(t, "Existing NodeBalancer", *nodebalancer.Label, "Expected NodeBalancer label to match")
+			assert.Equal(t, "us-west", nodebalancer.Region, "Expected NodeBalancer region to match")
+			assert.Equal(t, []linodego.LockType{linodego.LockTypeCannotDeleteWithSubresources}, nodebalancer.Locks, "Expected NodeBalancer locks to match")
+			assert.Equal(t, tt.expectedLKECluster, nodebalancer.LKECluster, "Expected NodeBalancer LKECluster to match")
+		})
+	}
 }
 
 func TestNodeBalancer_List(t *testing.T) {
@@ -107,6 +138,7 @@ func TestNodeBalancer_List(t *testing.T) {
 	assert.Equal(t, "us-east", nodebalancers[0].Region, "Expected first NodeBalancer region to match")
 	assert.Equal(t, []string{"tag1", "tag2"}, nodebalancers[0].Tags, "Expected first NodeBalancer tags to match")
 	assert.Equal(t, []linodego.LockType{linodego.LockTypeCannotDelete}, nodebalancers[0].Locks, "Expected first NodeBalancer locks to match")
+	assert.Nil(t, nodebalancers[0].LKECluster, "Expected first NodeBalancer LKECluster to match")
 
 	// Verify details of the second NodeBalancer
 	assert.Equal(t, 456, nodebalancers[1].ID, "Expected second NodeBalancer ID to match")
@@ -114,6 +146,12 @@ func TestNodeBalancer_List(t *testing.T) {
 	assert.Equal(t, "us-west", nodebalancers[1].Region, "Expected second NodeBalancer region to match")
 	assert.Equal(t, []string{"tag3"}, nodebalancers[1].Tags, "Expected second NodeBalancer tags to match")
 	assert.Empty(t, nodebalancers[1].Locks, "Expected second NodeBalancer to have no locks")
+	assert.Equal(t, &linodego.NodeBalancerLKECluster{
+		ID:    1234,
+		Type:  "lkecluster",
+		Label: "test-cluster",
+		URL:   "/v4/lke/clusters/1234",
+	}, nodebalancers[1].LKECluster, "Expected second NodeBalancer LKECluster to match")
 }
 
 func TestNodeBalancer_Update(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

This PR adds support for the new read-only field `lke_cluster` in the NodeBalancer struct.

## ✔️ How to Test

To run relevant unit tests use:
```
make test-unit
```
