### PR TITLE
[DPS-42278] added support for log definitions api + unit tests

### DIFF
--- a/internal/parseabletime/parseable_time.go
+++ b/internal/parseabletime/parseable_time.go
@@ -11,12 +11,14 @@ const (
 type ParseableTime time.Time
 
 func (p *ParseableTime) UnmarshalJSON(b []byte) error {
-	t, err := time.Parse(`"`+dateLayout+`"`, string(b))
-	if err != nil {
-		return err
+	var err error
+	for _, layout := range []string{time.RFC3339, dateLayout} {
+		var t time.Time
+		if t, err = time.Parse(`"`+layout+`"`, string(b)); err == nil {
+			*p = ParseableTime(t)
+			return nil
+		}
 	}
-
-	*p = ParseableTime(t)
-
-	return nil
+	return err
 }
+

--- a/monitor_log_definitions.go
+++ b/monitor_log_definitions.go
@@ -1,0 +1,125 @@
+package linodego
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/linode/linodego/internal/parseabletime"
+)
+
+// LogsDestinationType represents the type of a logs destination.
+type LogsDestinationType string
+
+const (
+	LogsDestinationTypeAkamaiObjectStorage LogsDestinationType = "akamai_object_storage"
+)
+
+// LogsDestinationStatus represents the status of a logs destination.
+type LogsDestinationStatus string
+
+const (
+	LogsDestinationStatusActive   LogsDestinationStatus = "active"
+	LogsDestinationStatusInactive LogsDestinationStatus = "inactive"
+)
+
+// LogsDestinationDetails represents the details block returned in a LogsDestination response.
+type LogsDestinationDetails struct {
+	AccessKeyID string `json:"access_key_id"`
+	BucketName  string `json:"bucket_name"`
+	Host        string `json:"host"`
+	Path        string `json:"path"`
+}
+
+// LogsDestinationDetailsCreateOptions represents the details block used when creating a LogsDestination.
+type LogsDestinationDetailsCreateOptions struct {
+	AccessKeyID     string  `json:"access_key_id"`
+	AccessKeySecret string  `json:"access_key_secret"`
+	BucketName      string  `json:"bucket_name"`
+	Host            string  `json:"host"`
+	Path            *string `json:"path,omitempty"`
+}
+
+// LogsDestination represents a logs destination object.
+type LogsDestination struct {
+	Created   *time.Time             `json:"-"`
+	CreatedBy string                 `json:"created_by"`
+	Details   LogsDestinationDetails `json:"details"`
+	ID        int                    `json:"id"`
+	Label     string                 `json:"label"`
+	Status    LogsDestinationStatus  `json:"status"`
+	Type      LogsDestinationType    `json:"type"`
+	Updated   *time.Time             `json:"-"`
+	UpdatedBy string                 `json:"updated_by"`
+	Version   int                    `json:"version"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for LogsDestination.
+func (i *LogsDestination) UnmarshalJSON(b []byte) error {
+	type Mask LogsDestination
+
+	p := struct {
+		*Mask
+
+		Created *parseabletime.ParseableTime `json:"created"`
+		Updated *parseabletime.ParseableTime `json:"updated"`
+	}{
+		Mask: (*Mask)(i),
+	}
+
+	if err := json.Unmarshal(b, &p); err != nil {
+		return err
+	}
+
+	i.Created = (*time.Time)(p.Created)
+	i.Updated = (*time.Time)(p.Updated)
+
+	return nil
+}
+
+// LogsDestinationCreateOptions are the options used to create a new logs destination.
+type LogsDestinationCreateOptions struct {
+	Label   string                              `json:"label"`
+	Type    LogsDestinationType                 `json:"type"`
+	Details LogsDestinationDetailsCreateOptions `json:"details"`
+}
+
+// LogsDestinationUpdateOptions are the options used to update a logs destination.
+type LogsDestinationUpdateOptions struct {
+	Label   string                  `json:"label,omitempty"`
+	Details *LogsDestinationDetails `json:"details,omitempty"`
+}
+
+// ListLogsDestinations returns a paginated list of logs destinations.
+func (c *Client) ListLogsDestinations(ctx context.Context, opts *ListOptions) ([]LogsDestination, error) {
+	return getPaginatedResults[LogsDestination](ctx, c, "monitor/streams/destinations", opts)
+}
+
+// GetLogsDestination gets a single logs destination by ID.
+func (c *Client) GetLogsDestination(ctx context.Context, destinationID int) (*LogsDestination, error) {
+	e := formatAPIPath("monitor/streams/destinations/%d", destinationID)
+	return doGETRequest[LogsDestination](ctx, c, e)
+}
+
+// CreateLogsDestination creates a new logs destination.
+func (c *Client) CreateLogsDestination(ctx context.Context, opts LogsDestinationCreateOptions) (*LogsDestination, error) {
+	return doPOSTRequest[LogsDestination](ctx, c, "monitor/streams/destinations", opts)
+}
+
+// UpdateLogsDestination updates a logs destination.
+func (c *Client) UpdateLogsDestination(ctx context.Context, destinationID int, opts LogsDestinationUpdateOptions) (*LogsDestination, error) {
+	e := formatAPIPath("monitor/streams/destinations/%d", destinationID)
+	return doPUTRequest[LogsDestination](ctx, c, e, opts)
+}
+
+// DeleteLogsDestination deletes a logs destination.
+func (c *Client) DeleteLogsDestination(ctx context.Context, destinationID int) error {
+	e := formatAPIPath("monitor/streams/destinations/%d", destinationID)
+	return doDELETERequest(ctx, c, e)
+}
+
+// ListLogsDestinationHistory returns the version history for a logs destination.
+func (c *Client) ListLogsDestinationHistory(ctx context.Context, destinationID int, opts *ListOptions) ([]LogsDestination, error) {
+	e := formatAPIPath("monitor/streams/destinations/%d/history", destinationID)
+	return getPaginatedResults[LogsDestination](ctx, c, e, opts)
+}

--- a/test/unit/fixtures/monitor_log_destinations_get.json
+++ b/test/unit/fixtures/monitor_log_destinations_get.json
@@ -1,0 +1,17 @@
+{
+  "created": "2025-07-20T09:45:13Z",
+  "created_by": "John Q. Linode",
+  "details": {
+    "access_key_id": "123",
+    "bucket_name": "primary-bucket",
+    "host": "primary-bucket-1.us-iad-12.linodeobjects.com",
+    "path": "audit-logs"
+  },
+  "id": 12345,
+  "label": "OBJ_logs_destination",
+  "status": "active",
+  "type": "akamai_object_storage",
+  "updated": "2025-07-21T12:41:09Z",
+  "updated_by": "Jane Q. Linode",
+  "version": 1
+}

--- a/test/unit/fixtures/monitor_log_destinations_list.json
+++ b/test/unit/fixtures/monitor_log_destinations_list.json
@@ -1,0 +1,24 @@
+{
+  "data":[
+    {
+      "created": "2025-07-20T09:45:13Z",
+      "created_by": "John Q. Linode",
+      "details": {
+        "access_key_id": "123",
+        "bucket_name": "primary-bucket",
+        "host": "primary-bucket-1.us-iad-12.linodeobjects.com",
+        "path": "audit-logs"
+      },
+      "id": 12345,
+      "label": "OBJ_logs_destination",
+      "status": "active",
+      "type": "akamai_object_storage",
+      "updated": "2025-07-21T12:41:09Z",
+      "updated_by": "Jane Q. Linode",
+      "version": 1
+    }
+  ],
+  "page":1,
+  "pages":1,
+  "results":1
+}

--- a/test/unit/monitor_log_destinations_test.go
+++ b/test/unit/monitor_log_destinations_test.go
@@ -1,0 +1,180 @@
+package unit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+    testLogsDestinationID = 12345
+)
+
+func TestCreateLogsDestination(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("monitor_log_destinations_get")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockPost("monitor/streams/destinations", fixtureData)
+
+	path := "audit-logs"
+	opts := linodego.LogsDestinationCreateOptions{
+		Label: "my-logs-destination",
+		Type:  linodego.LogsDestinationTypeAkamaiObjectStorage,
+		Details: linodego.LogsDestinationDetailsCreateOptions{
+			AccessKeyID:     "123",
+			BucketName:      "primary-bucket",
+			Host:            "primary-bucket-1.us-east-12.linodeobjects.com",
+			Path:            &path,
+		},
+	}
+
+	dest, err := base.Client.CreateLogsDestination(context.Background(), opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, dest)
+	assert.Equal(t, testLogsDestinationID, dest.ID)
+	assert.Equal(t, "OBJ_logs_destination", dest.Label)
+	assert.Equal(t, linodego.LogsDestinationStatusActive, dest.Status)
+	assert.Equal(t, linodego.LogsDestinationTypeAkamaiObjectStorage, dest.Type)
+	assert.Equal(t, "123", string(dest.Details.AccessKeyID))
+	assert.Equal(t, "primary-bucket", dest.Details.BucketName)
+	assert.Equal(t, "primary-bucket-1.us-iad-12.linodeobjects.com", dest.Details.Host)
+	assert.Equal(t, "audit-logs", dest.Details.Path)
+	assert.NotNil(t, dest.Created)
+	assert.NotNil(t, dest.Updated)
+}
+
+func TestCreateLogsDestination_NoPath(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("monitor_log_destinations_get")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockPost("monitor/streams/destinations", fixtureData)
+
+	opts := linodego.LogsDestinationCreateOptions{
+		Label: "my-logs-destination",
+		Type:  linodego.LogsDestinationTypeAkamaiObjectStorage,
+		Details: linodego.LogsDestinationDetailsCreateOptions{
+			AccessKeyID:     "1ABCD23EFG4HIJKLMNO5",
+			AccessKeySecret: "1aB2CD3e4fgHi5JK6lmnop7qR8STU9VxYzabcdefHh",
+			BucketName:      "primary-bucket",
+			Host:            "primary-bucket-1.us-east-12.linodeobjects.com",
+			// Path intentionally omitted
+		},
+	}
+
+	dest, err := base.Client.CreateLogsDestination(context.Background(), opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, dest)
+	assert.Equal(t, testLogsDestinationID, dest.ID)
+}
+
+func TestGetLogsDestination(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("monitor_log_destinations_get")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockGet("monitor/streams/destinations/12345", fixtureData)
+
+	dest, err := base.Client.GetLogsDestination(context.Background(), testLogsDestinationID)
+	assert.NoError(t, err)
+	assert.NotNil(t, dest)
+	assert.Equal(t, testLogsDestinationID, dest.ID)
+	assert.Equal(t, "OBJ_logs_destination", dest.Label)
+	assert.Equal(t, linodego.LogsDestinationStatusActive, dest.Status)
+	assert.Equal(t, linodego.LogsDestinationTypeAkamaiObjectStorage, dest.Type)
+	assert.Equal(t, "John Q. Linode", dest.CreatedBy)
+	assert.Equal(t, "Jane Q. Linode", dest.UpdatedBy)
+	assert.Equal(t, 1, dest.Version)
+	assert.Equal(t, "123", string(dest.Details.AccessKeyID))
+	assert.Equal(t, "primary-bucket", dest.Details.BucketName)
+	assert.Equal(t, "primary-bucket-1.us-iad-12.linodeobjects.com", dest.Details.Host)
+	assert.Equal(t, "audit-logs", dest.Details.Path)
+	assert.NotNil(t, dest.Created)
+	assert.NotNil(t, dest.Updated)
+}
+
+func TestListLogsDestinations(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("monitor_log_destinations_list")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockGet("monitor/streams/destinations", fixtureData)
+
+	dests, err := base.Client.ListLogsDestinations(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.Len(t, dests, 1)
+	assert.Equal(t, testLogsDestinationID, dests[0].ID)
+	assert.Equal(t, "OBJ_logs_destination", dests[0].Label)
+	assert.Equal(t, linodego.LogsDestinationStatusActive, dests[0].Status)
+	assert.Equal(t, linodego.LogsDestinationTypeAkamaiObjectStorage, dests[0].Type)
+	assert.Equal(t, "123", string(dests[0].Details.AccessKeyID))
+}
+
+func TestUpdateLogsDestination(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("monitor_log_destinations_get")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockPut("monitor/streams/destinations/12345", fixtureData)
+
+	opts := linodego.LogsDestinationUpdateOptions{
+		Label: "my-logs-destination-renamed",
+	}
+
+	dest, err := base.Client.UpdateLogsDestination(context.Background(), testLogsDestinationID, opts)
+	assert.NoError(t, err)
+	assert.NotNil(t, dest)
+}
+
+func TestDeleteLogsDestination(t *testing.T) {
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockDelete("monitor/streams/destinations/12345", nil)
+
+	err := base.Client.DeleteLogsDestination(context.Background(), testLogsDestinationID)
+	assert.NoError(t, err)
+}
+
+func TestListLogsDestinationHistory(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("monitor_log_destinations_list")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockGet("monitor/streams/destinations/12345/history", fixtureData)
+
+	history, err := base.Client.ListLogsDestinationHistory(context.Background(), testLogsDestinationID, nil)
+	assert.NoError(t, err)
+	assert.Len(t, history, 1)
+	assert.Equal(t, testLogsDestinationID, history[0].ID)
+	assert.Equal(t, "OBJ_logs_destination", history[0].Label)
+	assert.Equal(t, linodego.LogsDestinationStatusActive, history[0].Status)
+	assert.Equal(t, linodego.LogsDestinationTypeAkamaiObjectStorage, history[0].Type)
+	assert.Equal(t, 1, history[0].Version)
+	assert.Equal(t, "123", string(history[0].Details.AccessKeyID))
+	assert.Equal(t, "primary-bucket", history[0].Details.BucketName)
+	assert.NotNil(t, history[0].Created)
+	assert.NotNil(t, history[0].Updated)
+}


### PR DESCRIPTION
To run unit tests just for new cases execute: `go test ./test/unit -run 'LogsDestination' -v`
To run all unit tests run: `make test-unit`

Integration tests in progress. 
