### PR TITLE
TPT-4414: Refactor JSON tags to use "omitzero" for optional fields across multiple files

### DIFF
--- a/account.go
+++ b/account.go
@@ -34,18 +34,18 @@ type Account struct {
 
 // AccountUpdateOptions fields are those accepted by UpdateAccount
 type AccountUpdateOptions struct {
-	Address1  string `json:"address_1,omitempty"`
-	Address2  string `json:"address_2,omitempty"`
-	City      string `json:"city,omitempty"`
-	Company   string `json:"company,omitempty"`
-	Country   string `json:"country,omitempty"`
-	Email     string `json:"email,omitempty"`
-	FirstName string `json:"first_name,omitempty"`
-	LastName  string `json:"last_name,omitempty"`
-	Phone     string `json:"phone,omitempty"`
-	State     string `json:"state,omitempty"`
-	TaxID     string `json:"tax_id,omitempty"`
-	Zip       string `json:"zip,omitempty"`
+	Address1  string `json:"address_1,omitzero"`
+	Address2  string `json:"address_2,omitzero"`
+	City      string `json:"city,omitzero"`
+	Company   string `json:"company,omitzero"`
+	Country   string `json:"country,omitzero"`
+	Email     string `json:"email,omitzero"`
+	FirstName string `json:"first_name,omitzero"`
+	LastName  string `json:"last_name,omitzero"`
+	Phone     string `json:"phone,omitzero"`
+	State     string `json:"state,omitzero"`
+	TaxID     string `json:"tax_id,omitzero"`
+	Zip       string `json:"zip,omitzero"`
 }
 
 // GetUpdateOptions converts an Account to AccountUpdateOptions for use in UpdateAccount

--- a/account_agreements.go
+++ b/account_agreements.go
@@ -11,9 +11,9 @@ type AccountAgreements struct {
 
 // AccountAgreementsUpdateOptions fields are those accepted by UpdateAccountAgreements
 type AccountAgreementsUpdateOptions struct {
-	EUModel                bool `json:"eu_model,omitempty"`
-	MasterServiceAgreement bool `json:"master_service_agreement,omitempty"`
-	PrivacyPolicy          bool `json:"privacy_policy,omitempty"`
+	EUModel                bool `json:"eu_model,omitzero"`
+	MasterServiceAgreement bool `json:"master_service_agreement,omitzero"`
+	PrivacyPolicy          bool `json:"privacy_policy,omitzero"`
 }
 
 // GetUpdateOptions converts an AccountAgreements to AccountAgreementsUpdateOptions for use in UpdateAccountAgreements

--- a/account_payments.go
+++ b/account_payments.go
@@ -23,7 +23,7 @@ type Payment struct {
 // PaymentCreateOptions fields are those accepted by CreatePayment
 type PaymentCreateOptions struct {
 	// CVV (Card Verification Value) of the credit card to be used for the Payment
-	CVV string `json:"cvv,omitempty"`
+	CVV string `json:"cvv,omitzero"`
 
 	// The amount, in US dollars, of the Payment
 	USD json.Number `json:"usd"`

--- a/account_settings.go
+++ b/account_settings.go
@@ -40,17 +40,17 @@ type AccountSettings struct {
 // AccountSettingsUpdateOptions are the updateable account wide flags or plans that effect new resources.
 type AccountSettingsUpdateOptions struct {
 	// The default backups enrollment status for all new Linodes for all users on the account.  When enabled, backups are mandatory per instance.
-	BackupsEnabled *bool `json:"backups_enabled,omitempty"`
+	BackupsEnabled *bool `json:"backups_enabled,omitzero"`
 
 	// The default network helper setting for all new Linodes and Linode Configs for all users on the account.
-	NetworkHelper *bool `json:"network_helper,omitempty"`
+	NetworkHelper *bool `json:"network_helper,omitzero"`
 
 	// NOTE: Interfaces for new linode setting may not currently be available to all users.
 	// A new configuration flag defines whether new Linodes can use Linode and/or legacy config interfaces.
 	InterfacesForNewLinodes *InterfacesForNewLinodes `json:"interfaces_for_new_linodes"`
 
 	// The slug of the maintenance policy to set the account to.
-	MaintenancePolicy *string `json:"maintenance_policy,omitempty"`
+	MaintenancePolicy *string `json:"maintenance_policy,omitzero"`
 }
 
 // GetAccountSettings gets the account wide flags or plans that effect new resources

--- a/account_user_grants.go
+++ b/account_user_grants.go
@@ -56,17 +56,17 @@ type UserGrants struct {
 }
 
 type UserGrantsUpdateOptions struct {
-	Database       []GrantedEntity   `json:"database,omitempty"`
-	Domain         []EntityUserGrant `json:"domain,omitempty"`
-	Firewall       []EntityUserGrant `json:"firewall,omitempty"`
-	Image          []EntityUserGrant `json:"image,omitempty"`
-	Linode         []EntityUserGrant `json:"linode,omitempty"`
-	Longview       []EntityUserGrant `json:"longview,omitempty"`
-	NodeBalancer   []EntityUserGrant `json:"nodebalancer,omitempty"`
-	PlacementGroup []EntityUserGrant `json:"placement_group,omitempty"`
-	StackScript    []EntityUserGrant `json:"stackscript,omitempty"`
-	Volume         []EntityUserGrant `json:"volume,omitempty"`
-	VPC            []EntityUserGrant `json:"vpc,omitempty"`
+	Database       []GrantedEntity   `json:"database,omitzero"`
+	Domain         []EntityUserGrant `json:"domain,omitzero"`
+	Firewall       []EntityUserGrant `json:"firewall,omitzero"`
+	Image          []EntityUserGrant `json:"image,omitzero"`
+	Linode         []EntityUserGrant `json:"linode,omitzero"`
+	Longview       []EntityUserGrant `json:"longview,omitzero"`
+	NodeBalancer   []EntityUserGrant `json:"nodebalancer,omitzero"`
+	PlacementGroup []EntityUserGrant `json:"placement_group,omitzero"`
+	StackScript    []EntityUserGrant `json:"stackscript,omitzero"`
+	Volume         []EntityUserGrant `json:"volume,omitzero"`
+	VPC            []EntityUserGrant `json:"vpc,omitzero"`
 
 	Global GlobalUserGrants `json:"global"`
 }

--- a/account_users.go
+++ b/account_users.go
@@ -45,9 +45,9 @@ type UserCreateOptions struct {
 
 // UserUpdateOptions fields are those accepted by UpdateUser
 type UserUpdateOptions struct {
-	Username   string `json:"username,omitempty"`
-	Restricted *bool  `json:"restricted,omitempty"`
-	Email      string `json:"email,omitempty"`
+	Username   string `json:"username,omitzero"`
+	Restricted *bool  `json:"restricted,omitzero"`
+	Email      string `json:"email,omitzero"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface

--- a/databases.go
+++ b/databases.go
@@ -90,7 +90,7 @@ type Database struct {
 	Updated           *time.Time `json:"-"`
 	OldestRestoreTime *time.Time `json:"-"`
 
-	PrivateNetwork *DatabasePrivateNetwork `json:"private_network,omitempty"`
+	PrivateNetwork *DatabasePrivateNetwork `json:"private_network,omitzero"`
 }
 
 // DatabaseHost for Primary/Secondary of Database
@@ -119,7 +119,7 @@ type DatabaseMaintenanceWindow struct {
 	Frequency DatabaseMaintenanceFrequency `json:"frequency"`
 	HourOfDay int                          `json:"hour_of_day"`
 
-	Pending []DatabaseMaintenanceWindowPending `json:"pending,omitempty"`
+	Pending []DatabaseMaintenanceWindowPending `json:"pending,omitzero"`
 }
 
 type DatabaseMaintenanceWindowPending struct {
@@ -161,7 +161,7 @@ type ClusterPrice struct {
 // DatabaseFork describes the source and restore time for the fork for forked DBs
 type DatabaseFork struct {
 	Source      int        `json:"source"`
-	RestoreTime *time.Time `json:"-,omitempty"`
+	RestoreTime *time.Time `json:"-,omitzero"`
 }
 
 func (d *Database) UnmarshalJSON(b []byte) error {

--- a/domain_records.go
+++ b/domain_records.go
@@ -30,27 +30,27 @@ type DomainRecordCreateOptions struct {
 	Type     DomainRecordType `json:"type"`
 	Name     string           `json:"name"`
 	Target   string           `json:"target"`
-	Priority *int             `json:"priority,omitempty"`
-	Weight   *int             `json:"weight,omitempty"`
-	Port     *int             `json:"port,omitempty"`
-	Service  *string          `json:"service,omitempty"`
-	Protocol *string          `json:"protocol,omitempty"`
-	TTLSec   int              `json:"ttl_sec,omitempty"` // 0 is not accepted by Linode, so can be omitted
-	Tag      *string          `json:"tag,omitempty"`
+	Priority *int             `json:"priority,omitzero"`
+	Weight   *int             `json:"weight,omitzero"`
+	Port     *int             `json:"port,omitzero"`
+	Service  *string          `json:"service,omitzero"`
+	Protocol *string          `json:"protocol,omitzero"`
+	TTLSec   int              `json:"ttl_sec,omitzero"` // 0 is not accepted by Linode, so can be omitted
+	Tag      *string          `json:"tag,omitzero"`
 }
 
 // DomainRecordUpdateOptions fields are those accepted by UpdateDomainRecord
 type DomainRecordUpdateOptions struct {
-	Type     DomainRecordType `json:"type,omitempty"`
-	Name     string           `json:"name,omitempty"`
-	Target   string           `json:"target,omitempty"`
-	Priority *int             `json:"priority,omitempty"` // 0 is valid, so omit only nil values
-	Weight   *int             `json:"weight,omitempty"`   // 0 is valid, so omit only nil values
-	Port     *int             `json:"port,omitempty"`     // 0 is valid to spec, so omit only nil values
-	Service  *string          `json:"service,omitempty"`
-	Protocol *string          `json:"protocol,omitempty"`
-	TTLSec   int              `json:"ttl_sec,omitempty"` // 0 is not accepted by Linode, so can be omitted
-	Tag      *string          `json:"tag,omitempty"`
+	Type     DomainRecordType `json:"type,omitzero"`
+	Name     string           `json:"name,omitzero"`
+	Target   string           `json:"target,omitzero"`
+	Priority *int             `json:"priority,omitzero"` // 0 is valid, so omit only nil values
+	Weight   *int             `json:"weight,omitzero"`   // 0 is valid, so omit only nil values
+	Port     *int             `json:"port,omitzero"`     // 0 is valid to spec, so omit only nil values
+	Service  *string          `json:"service,omitzero"`
+	Protocol *string          `json:"protocol,omitzero"`
+	TTLSec   int              `json:"ttl_sec,omitzero"` // 0 is not accepted by Linode, so can be omitted
+	Tag      *string          `json:"tag,omitzero"`
 }
 
 // DomainRecordType constants start with RecordType and include Linode API Domain Record Types

--- a/domains.go
+++ b/domains.go
@@ -63,17 +63,17 @@ type DomainCreateOptions struct {
 
 	// Used to control whether this Domain is currently being rendered.
 	// Enum:"disabled" "active" "edit_mode" "has_errors"
-	Status DomainStatus `json:"status,omitempty"`
+	Status DomainStatus `json:"status,omitzero"`
 
 	// A description for this Domain. This is for display purposes only.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitzero"`
 
 	// Start of Authority email address. This is required for master Domains.
-	SOAEmail string `json:"soa_email,omitempty"`
+	SOAEmail string `json:"soa_email,omitzero"`
 
 	// The interval, in seconds, at which a failed refresh should be retried.
 	// Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	RetrySec int `json:"retry_sec,omitempty"`
+	RetrySec int `json:"retry_sec,omitzero"`
 
 	// The IP addresses representing the master DNS for this Domain.
 	MasterIPs []string `json:"master_ips"`
@@ -85,37 +85,37 @@ type DomainCreateOptions struct {
 	Tags []string `json:"tags"`
 
 	// The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	ExpireSec int `json:"expire_sec,omitempty"`
+	ExpireSec int `json:"expire_sec,omitzero"`
 
 	// The amount of time in seconds before this Domain should be refreshed. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	RefreshSec int `json:"refresh_sec,omitempty"`
+	RefreshSec int `json:"refresh_sec,omitzero"`
 
 	// "Time to Live" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	TTLSec int `json:"ttl_sec,omitempty"`
+	TTLSec int `json:"ttl_sec,omitzero"`
 }
 
 // DomainUpdateOptions converts a Domain to DomainUpdateOptions for use in UpdateDomain
 type DomainUpdateOptions struct {
 	// The domain this Domain represents. These must be unique in our system; you cannot have two Domains representing the same domain.
-	Domain string `json:"domain,omitempty"`
+	Domain string `json:"domain,omitzero"`
 
 	// If this Domain represents the authoritative source of information for the domain it describes, or if it is a read-only copy of a master (also called a slave).
 	// Enum:"master" "slave"
-	Type DomainType `json:"type,omitempty"`
+	Type DomainType `json:"type,omitzero"`
 
 	// Used to control whether this Domain is currently being rendered.
 	// Enum:"disabled" "active" "edit_mode" "has_errors"
-	Status DomainStatus `json:"status,omitempty"`
+	Status DomainStatus `json:"status,omitzero"`
 
 	// A description for this Domain. This is for display purposes only.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitzero"`
 
 	// Start of Authority email address. This is required for master Domains.
-	SOAEmail string `json:"soa_email,omitempty"`
+	SOAEmail string `json:"soa_email,omitzero"`
 
 	// The interval, in seconds, at which a failed refresh should be retried.
 	// Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	RetrySec int `json:"retry_sec,omitempty"`
+	RetrySec int `json:"retry_sec,omitzero"`
 
 	// The IP addresses representing the master DNS for this Domain.
 	MasterIPs []string `json:"master_ips"`
@@ -127,13 +127,13 @@ type DomainUpdateOptions struct {
 	Tags []string `json:"tags"`
 
 	// The amount of time in seconds that may pass before this Domain is no longer authoritative. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	ExpireSec int `json:"expire_sec,omitempty"`
+	ExpireSec int `json:"expire_sec,omitzero"`
 
 	// The amount of time in seconds before this Domain should be refreshed. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	RefreshSec int `json:"refresh_sec,omitempty"`
+	RefreshSec int `json:"refresh_sec,omitzero"`
 
 	// "Time to Live" - the amount of time in seconds that this Domain's records may be cached by resolvers or other domain servers. Valid values are 300, 3600, 7200, 14400, 28800, 57600, 86400, 172800, 345600, 604800, 1209600, and 2419200 - any other value will be rounded to the nearest valid value.
-	TTLSec int `json:"ttl_sec,omitempty"`
+	TTLSec int `json:"ttl_sec,omitzero"`
 }
 
 // DomainType constants start with DomainType and include Linode API Domain Type values

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -18,8 +18,8 @@ const (
 
 // NetworkAddresses are arrays of ipv4 and v6 addresses
 type NetworkAddresses struct {
-	IPv4 *[]string `json:"ipv4,omitempty"`
-	IPv6 *[]string `json:"ipv6,omitempty"`
+	IPv4 *[]string `json:"ipv4,omitzero"`
+	IPv6 *[]string `json:"ipv6,omitzero"`
 }
 
 // A FirewallRule is a whitelist of ports, protocols, and addresses for which traffic should be allowed.
@@ -28,15 +28,15 @@ type NetworkAddresses struct {
 type FirewallRule struct {
 	Action      string           `json:"action"`
 	Label       string           `json:"label"`
-	Description string           `json:"description,omitempty"`
-	Ports       string           `json:"ports,omitempty"`
+	Description string           `json:"description,omitzero"`
+	Ports       string           `json:"ports,omitzero"`
 	Protocol    NetworkProtocol  `json:"protocol"`
 	Addresses   NetworkAddresses `json:"addresses"`
 
 	// FirewallRule references one `Rule Set` by ID. When provided, this entry
 	// represents a reference and should be mutually exclusive with ordinary
 	// rule fields according to the API contract.
-	RuleSet int `json:"ruleset,omitempty"`
+	RuleSet int `json:"ruleset,omitzero"`
 }
 
 // MarshalJSON ensures that when a rule references a Rule Set (RuleSet != 0),
@@ -54,8 +54,8 @@ func (r FirewallRule) MarshalJSON() ([]byte, error) {
 	type normal struct {
 		Action      string           `json:"action"`
 		Label       string           `json:"label"`
-		Description string           `json:"description,omitempty"`
-		Ports       string           `json:"ports,omitempty"`
+		Description string           `json:"description,omitzero"`
+		Ports       string           `json:"ports,omitzero"`
 		Protocol    NetworkProtocol  `json:"protocol"`
 		Addresses   NetworkAddresses `json:"addresses"`
 	}
@@ -79,9 +79,9 @@ type FirewallRuleSet struct {
 
 	// TODO: separate request and response types in linodego v2
 	// read-only, can't be used in creating or updating a Firewall
-	Version int `json:"version,omitempty"`
+	Version int `json:"version,omitzero"`
 	// read-only, can't be used in creating or updating a Firewall
-	Fingerprint string `json:"fingerprint,omitempty"`
+	Fingerprint string `json:"fingerprint,omitzero"`
 }
 
 // GetFirewallRules gets the FirewallRuleSet for the given Firewall.

--- a/firewall_rulesets.go
+++ b/firewall_rulesets.go
@@ -22,7 +22,7 @@ const (
 type RuleSet struct {
 	ID               int                 `json:"id"`
 	Label            string              `json:"label"`
-	Description      string              `json:"description,omitempty"`
+	Description      string              `json:"description,omitzero"`
 	Type             FirewallRuleSetType `json:"type"`
 	Rules            []FirewallRule      `json:"rules"`
 	IsServiceDefined bool                `json:"is_service_defined"`
@@ -69,7 +69,7 @@ func (r *RuleSet) UnmarshalJSON(b []byte) error {
 // RuleSetCreateOptions fields accepted by CreateRuleSet.
 type RuleSetCreateOptions struct {
 	Label       string              `json:"label"`
-	Description string              `json:"description,omitempty"`
+	Description string              `json:"description,omitzero"`
 	Type        FirewallRuleSetType `json:"type"`
 	Rules       []FirewallRule      `json:"rules"`
 }
@@ -78,9 +78,9 @@ type RuleSetCreateOptions struct {
 // Omit a top-level field to leave it unchanged. If Rules is provided, it
 // replaces the entire ordered rules array.
 type RuleSetUpdateOptions struct {
-	Label       *string         `json:"label,omitempty"`
-	Description *string         `json:"description,omitempty"`
-	Rules       *[]FirewallRule `json:"rules,omitempty"`
+	Label       *string         `json:"label,omitzero"`
+	Description *string         `json:"description,omitzero"`
+	Rules       *[]FirewallRule `json:"rules,omitzero"`
 }
 
 // ListFirewallRuleSets returns a paginated list of Rule Sets.

--- a/firewalls.go
+++ b/firewalls.go
@@ -32,24 +32,24 @@ type Firewall struct {
 
 // DevicesCreationOptions fields are used when adding devices during the Firewall creation process.
 type DevicesCreationOptions struct {
-	Linodes          []int `json:"linodes,omitempty"`
-	NodeBalancers    []int `json:"nodebalancers,omitempty"`
-	LinodeInterfaces []int `json:"linode_interfaces,omitempty"`
+	Linodes          []int `json:"linodes,omitzero"`
+	NodeBalancers    []int `json:"nodebalancers,omitzero"`
+	LinodeInterfaces []int `json:"linode_interfaces,omitzero"`
 }
 
 // FirewallCreateOptions fields are those accepted by CreateFirewall
 type FirewallCreateOptions struct {
-	Label   string                 `json:"label,omitempty"`
+	Label   string                 `json:"label,omitzero"`
 	Rules   FirewallRuleSet        `json:"rules"`
-	Tags    []string               `json:"tags,omitempty"`
+	Tags    []string               `json:"tags,omitzero"`
 	Devices DevicesCreationOptions `json:"devices,omitzero"`
 }
 
 // FirewallUpdateOptions is an options struct used when Updating a Firewall
 type FirewallUpdateOptions struct {
-	Label  string         `json:"label,omitempty"`
-	Status FirewallStatus `json:"status,omitempty"`
-	Tags   *[]string      `json:"tags,omitempty"`
+	Label  string         `json:"label,omitzero"`
+	Status FirewallStatus `json:"status,omitzero"`
+	Tags   *[]string      `json:"tags,omitzero"`
 }
 
 // FirewallSettings represents the default firewalls for Linodes,
@@ -67,14 +67,14 @@ type DefaultFirewallIDs struct {
 
 // FirewallSettingsUpdateOptions is an options struct used when Updating FirewallSettings
 type FirewallSettingsUpdateOptions struct {
-	DefaultFirewallIDs *DefaultFirewallIDsOptions `json:"default_firewall_ids,omitempty"`
+	DefaultFirewallIDs *DefaultFirewallIDsOptions `json:"default_firewall_ids,omitzero"`
 }
 
 type DefaultFirewallIDsOptions struct {
-	Linode          **int `json:"linode,omitempty"`
-	NodeBalancer    **int `json:"nodebalancer,omitempty"`
-	PublicInterface **int `json:"public_interface,omitempty"`
-	VPCInterface    **int `json:"vpc_interface,omitempty"`
+	Linode          **int `json:"linode,omitzero"`
+	NodeBalancer    **int `json:"nodebalancer,omitzero"`
+	PublicInterface **int `json:"public_interface,omitzero"`
+	VPCInterface    **int `json:"vpc_interface,omitzero"`
 }
 
 // GetUpdateOptions converts a Firewall to FirewallUpdateOptions for use in Client.UpdateFirewall.

--- a/image_sharegroups_consumer.go
+++ b/image_sharegroups_consumer.go
@@ -125,7 +125,7 @@ func (t *ImageShareGroupCreateTokenResponse) UnmarshalJSON(b []byte) error {
 
 // ImageShareGroupCreateTokenOptions fields are those accepted by ImageShareGroupCreateToken
 type ImageShareGroupCreateTokenOptions struct {
-	Label                  *string `json:"label,omitempty"`
+	Label                  *string `json:"label,omitzero"`
 	ValidForShareGroupUUID string  `json:"valid_for_sharegroup_uuid"`
 }
 

--- a/image_sharegroups_producer.go
+++ b/image_sharegroups_producer.go
@@ -50,14 +50,14 @@ func (isg *ProducerImageShareGroup) UnmarshalJSON(b []byte) error {
 // ImageShareGroupCreateOptions fields are those accepted by CreateImageShareGroup.
 type ImageShareGroupCreateOptions struct {
 	Label       string                 `json:"label"`
-	Description *string                `json:"description,omitempty"`
-	Images      []ImageShareGroupImage `json:"images,omitempty"`
+	Description *string                `json:"description,omitzero"`
+	Images      []ImageShareGroupImage `json:"images,omitzero"`
 }
 
 // ImageShareGroupUpdateOptions fields are those accepted by UpdateImageShareGroup.
 type ImageShareGroupUpdateOptions struct {
-	Label       *string `json:"label,omitempty"`
-	Description *string `json:"description,omitempty"`
+	Label       *string `json:"label,omitzero"`
+	Description *string `json:"description,omitzero"`
 }
 
 // ImageShareGroupAddImagesOptions fields are those accepted by ImageShareGroupAddImages.
@@ -67,15 +67,15 @@ type ImageShareGroupAddImagesOptions struct {
 
 // ImageShareGroupUpdateImageOptions fields are those accepted by ImageShareGroupUpdateImage.
 type ImageShareGroupUpdateImageOptions struct {
-	Label       *string `json:"label,omitempty"`
-	Description *string `json:"description,omitempty"`
+	Label       *string `json:"label,omitzero"`
+	Description *string `json:"description,omitzero"`
 }
 
 // ImageShareGroupImage represents an Image to be included in a ProducerImageShareGroup.
 type ImageShareGroupImage struct {
 	ID          string  `json:"id"`
-	Label       *string `json:"label,omitempty"`
-	Description *string `json:"description,omitempty"`
+	Label       *string `json:"label,omitzero"`
+	Description *string `json:"description,omitzero"`
 }
 
 // ImageShareGroupMember represents a Member of an ImageShareGroup owned by the producer.

--- a/images.go
+++ b/images.go
@@ -117,16 +117,16 @@ type ImageShareEntry struct {
 type ImageCreateOptions struct {
 	DiskID      int       `json:"disk_id"`
 	Label       string    `json:"label"`
-	Description string    `json:"description,omitempty"`
-	CloudInit   bool      `json:"cloud_init,omitempty"`
-	Tags        *[]string `json:"tags,omitempty"`
+	Description string    `json:"description,omitzero"`
+	CloudInit   bool      `json:"cloud_init,omitzero"`
+	Tags        *[]string `json:"tags,omitzero"`
 }
 
 // ImageUpdateOptions fields are those accepted by UpdateImage
 type ImageUpdateOptions struct {
-	Label       string    `json:"label,omitempty"`
-	Description *string   `json:"description,omitempty"`
-	Tags        *[]string `json:"tags,omitempty"`
+	Label       string    `json:"label,omitzero"`
+	Description *string   `json:"description,omitzero"`
+	Tags        *[]string `json:"tags,omitzero"`
 }
 
 // ImageReplicateOptions represents the options accepted by the
@@ -145,18 +145,18 @@ type ImageCreateUploadResponse struct {
 type ImageCreateUploadOptions struct {
 	Region      string    `json:"region"`
 	Label       string    `json:"label"`
-	Description string    `json:"description,omitempty"`
-	CloudInit   bool      `json:"cloud_init,omitempty"`
-	Tags        *[]string `json:"tags,omitempty"`
+	Description string    `json:"description,omitzero"`
+	CloudInit   bool      `json:"cloud_init,omitzero"`
+	Tags        *[]string `json:"tags,omitzero"`
 }
 
 // ImageUploadOptions fields are those accepted by UploadImage
 type ImageUploadOptions struct {
 	Region      string    `json:"region"`
 	Label       string    `json:"label"`
-	Description string    `json:"description,omitempty"`
+	Description string    `json:"description,omitzero"`
 	CloudInit   bool      `json:"cloud_init"`
-	Tags        *[]string `json:"tags,omitempty"`
+	Tags        *[]string `json:"tags,omitzero"`
 	Image       io.Reader
 }
 

--- a/instance_config_interfaces.go
+++ b/instance_config_interfaces.go
@@ -45,31 +45,31 @@ type InstanceConfigInterfaceIPv6Range struct {
 }
 
 type VPCIPv4 struct {
-	VPC     string  `json:"vpc,omitempty"`
-	NAT1To1 *string `json:"nat_1_1,omitempty"`
+	VPC     string  `json:"vpc,omitzero"`
+	NAT1To1 *string `json:"nat_1_1,omitzero"`
 }
 
 type InstanceConfigInterfaceCreateOptions struct {
-	IPAMAddress string                 `json:"ipam_address,omitempty"`
-	Label       string                 `json:"label,omitempty"`
-	Purpose     ConfigInterfacePurpose `json:"purpose,omitempty"`
-	Primary     bool                   `json:"primary,omitempty"`
-	SubnetID    *int                   `json:"subnet_id,omitempty"`
-	IPv4        *VPCIPv4               `json:"ipv4,omitempty"`
+	IPAMAddress string                 `json:"ipam_address,omitzero"`
+	Label       string                 `json:"label,omitzero"`
+	Purpose     ConfigInterfacePurpose `json:"purpose,omitzero"`
+	Primary     bool                   `json:"primary,omitzero"`
+	SubnetID    *int                   `json:"subnet_id,omitzero"`
+	IPv4        *VPCIPv4               `json:"ipv4,omitzero"`
 
 	// NOTE: IPv6 interfaces may not currently be available to all users.
-	IPv6 *InstanceConfigInterfaceCreateOptionsIPv6 `json:"ipv6,omitempty"`
+	IPv6 *InstanceConfigInterfaceCreateOptionsIPv6 `json:"ipv6,omitzero"`
 
-	IPRanges []string `json:"ip_ranges,omitempty"`
+	IPRanges []string `json:"ip_ranges,omitzero"`
 }
 
 // InstanceConfigInterfaceCreateOptionsIPv6 represents the IPv6 configuration of a Linode interface
 // specified during creation.
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type InstanceConfigInterfaceCreateOptionsIPv6 struct {
-	SLAAC    []InstanceConfigInterfaceCreateOptionsIPv6SLAAC `json:"slaac,omitempty"`
-	Ranges   []InstanceConfigInterfaceCreateOptionsIPv6Range `json:"ranges,omitempty"`
-	IsPublic *bool                                           `json:"is_public,omitempty"`
+	SLAAC    []InstanceConfigInterfaceCreateOptionsIPv6SLAAC `json:"slaac,omitzero"`
+	Ranges   []InstanceConfigInterfaceCreateOptionsIPv6Range `json:"ranges,omitzero"`
+	IsPublic *bool                                           `json:"is_public,omitzero"`
 }
 
 // InstanceConfigInterfaceCreateOptionsIPv6SLAAC represents a single IPv6 SLAAC of a Linode interface
@@ -83,40 +83,40 @@ type InstanceConfigInterfaceCreateOptionsIPv6SLAAC struct {
 // specified during creation.
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type InstanceConfigInterfaceCreateOptionsIPv6Range struct {
-	Range *string `json:"range,omitempty"`
+	Range *string `json:"range,omitzero"`
 }
 
 type InstanceConfigInterfaceUpdateOptions struct {
-	Primary bool     `json:"primary,omitempty"`
-	IPv4    *VPCIPv4 `json:"ipv4,omitempty"`
+	Primary bool     `json:"primary,omitzero"`
+	IPv4    *VPCIPv4 `json:"ipv4,omitzero"`
 
 	// NOTE: IPv6 interfaces may not currently be available to all users.
-	IPv6 *InstanceConfigInterfaceUpdateOptionsIPv6 `json:"ipv6,omitempty"`
+	IPv6 *InstanceConfigInterfaceUpdateOptionsIPv6 `json:"ipv6,omitzero"`
 
-	IPRanges *[]string `json:"ip_ranges,omitempty"`
+	IPRanges *[]string `json:"ip_ranges,omitzero"`
 }
 
 // InstanceConfigInterfaceUpdateOptionsIPv6 represents the IPv6 configuration of a Linode interface
 // specified during updates.
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type InstanceConfigInterfaceUpdateOptionsIPv6 struct {
-	SLAAC    *[]InstanceConfigInterfaceUpdateOptionsIPv6SLAAC `json:"slaac,omitempty"`
-	Ranges   *[]InstanceConfigInterfaceUpdateOptionsIPv6Range `json:"ranges,omitempty"`
-	IsPublic *bool                                            `json:"is_public,omitempty"`
+	SLAAC    *[]InstanceConfigInterfaceUpdateOptionsIPv6SLAAC `json:"slaac,omitzero"`
+	Ranges   *[]InstanceConfigInterfaceUpdateOptionsIPv6Range `json:"ranges,omitzero"`
+	IsPublic *bool                                            `json:"is_public,omitzero"`
 }
 
 // InstanceConfigInterfaceUpdateOptionsIPv6SLAAC represents a single IPv6 SLAAC of a Linode interface
 // specified during updates.
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type InstanceConfigInterfaceUpdateOptionsIPv6SLAAC struct {
-	Range *string `json:"range,omitempty"`
+	Range *string `json:"range,omitzero"`
 }
 
 // InstanceConfigInterfaceUpdateOptionsIPv6Range represents a single IPv6 ranges of a Linode interface
 // specified during updates.
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type InstanceConfigInterfaceUpdateOptionsIPv6Range struct {
-	Range *string `json:"range,omitempty"`
+	Range *string `json:"range,omitzero"`
 }
 
 type InstanceConfigInterfacesReorderOptions struct {

--- a/instance_configs.go
+++ b/instance_configs.go
@@ -28,81 +28,81 @@ type InstanceConfig struct {
 
 // InstanceConfigDevice contains either the DiskID or VolumeID assigned to a Config Device
 type InstanceConfigDevice struct {
-	DiskID   int `json:"disk_id,omitempty"`
-	VolumeID int `json:"volume_id,omitempty"`
+	DiskID   int `json:"disk_id,omitzero"`
+	VolumeID int `json:"volume_id,omitzero"`
 }
 
 // InstanceConfigDeviceMap contains SDA-SDH InstanceConfigDevice settings
 type InstanceConfigDeviceMap struct {
 	// sda-sdz
-	SDA *InstanceConfigDevice `json:"sda,omitempty"`
-	SDB *InstanceConfigDevice `json:"sdb,omitempty"`
-	SDC *InstanceConfigDevice `json:"sdc,omitempty"`
-	SDD *InstanceConfigDevice `json:"sdd,omitempty"`
-	SDE *InstanceConfigDevice `json:"sde,omitempty"`
-	SDF *InstanceConfigDevice `json:"sdf,omitempty"`
-	SDG *InstanceConfigDevice `json:"sdg,omitempty"`
-	SDH *InstanceConfigDevice `json:"sdh,omitempty"`
-	SDI *InstanceConfigDevice `json:"sdi,omitempty"`
-	SDJ *InstanceConfigDevice `json:"sdj,omitempty"`
-	SDK *InstanceConfigDevice `json:"sdk,omitempty"`
-	SDL *InstanceConfigDevice `json:"sdl,omitempty"`
-	SDM *InstanceConfigDevice `json:"sdm,omitempty"`
-	SDN *InstanceConfigDevice `json:"sdn,omitempty"`
-	SDO *InstanceConfigDevice `json:"sdo,omitempty"`
-	SDP *InstanceConfigDevice `json:"sdp,omitempty"`
-	SDQ *InstanceConfigDevice `json:"sdq,omitempty"`
-	SDR *InstanceConfigDevice `json:"sdr,omitempty"`
-	SDS *InstanceConfigDevice `json:"sds,omitempty"`
-	SDT *InstanceConfigDevice `json:"sdt,omitempty"`
-	SDU *InstanceConfigDevice `json:"sdu,omitempty"`
-	SDV *InstanceConfigDevice `json:"sdv,omitempty"`
-	SDW *InstanceConfigDevice `json:"sdw,omitempty"`
-	SDX *InstanceConfigDevice `json:"sdx,omitempty"`
-	SDY *InstanceConfigDevice `json:"sdy,omitempty"`
-	SDZ *InstanceConfigDevice `json:"sdz,omitempty"`
+	SDA *InstanceConfigDevice `json:"sda,omitzero"`
+	SDB *InstanceConfigDevice `json:"sdb,omitzero"`
+	SDC *InstanceConfigDevice `json:"sdc,omitzero"`
+	SDD *InstanceConfigDevice `json:"sdd,omitzero"`
+	SDE *InstanceConfigDevice `json:"sde,omitzero"`
+	SDF *InstanceConfigDevice `json:"sdf,omitzero"`
+	SDG *InstanceConfigDevice `json:"sdg,omitzero"`
+	SDH *InstanceConfigDevice `json:"sdh,omitzero"`
+	SDI *InstanceConfigDevice `json:"sdi,omitzero"`
+	SDJ *InstanceConfigDevice `json:"sdj,omitzero"`
+	SDK *InstanceConfigDevice `json:"sdk,omitzero"`
+	SDL *InstanceConfigDevice `json:"sdl,omitzero"`
+	SDM *InstanceConfigDevice `json:"sdm,omitzero"`
+	SDN *InstanceConfigDevice `json:"sdn,omitzero"`
+	SDO *InstanceConfigDevice `json:"sdo,omitzero"`
+	SDP *InstanceConfigDevice `json:"sdp,omitzero"`
+	SDQ *InstanceConfigDevice `json:"sdq,omitzero"`
+	SDR *InstanceConfigDevice `json:"sdr,omitzero"`
+	SDS *InstanceConfigDevice `json:"sds,omitzero"`
+	SDT *InstanceConfigDevice `json:"sdt,omitzero"`
+	SDU *InstanceConfigDevice `json:"sdu,omitzero"`
+	SDV *InstanceConfigDevice `json:"sdv,omitzero"`
+	SDW *InstanceConfigDevice `json:"sdw,omitzero"`
+	SDX *InstanceConfigDevice `json:"sdx,omitzero"`
+	SDY *InstanceConfigDevice `json:"sdy,omitzero"`
+	SDZ *InstanceConfigDevice `json:"sdz,omitzero"`
 
 	// sdaa-sdaz
-	SDAA *InstanceConfigDevice `json:"sdaa,omitempty"`
-	SDAB *InstanceConfigDevice `json:"sdab,omitempty"`
-	SDAC *InstanceConfigDevice `json:"sdac,omitempty"`
-	SDAD *InstanceConfigDevice `json:"sdad,omitempty"`
-	SDAE *InstanceConfigDevice `json:"sdae,omitempty"`
-	SDAF *InstanceConfigDevice `json:"sdaf,omitempty"`
-	SDAG *InstanceConfigDevice `json:"sdag,omitempty"`
-	SDAH *InstanceConfigDevice `json:"sdah,omitempty"`
-	SDAI *InstanceConfigDevice `json:"sdai,omitempty"`
-	SDAJ *InstanceConfigDevice `json:"sdaj,omitempty"`
-	SDAK *InstanceConfigDevice `json:"sdak,omitempty"`
-	SDAL *InstanceConfigDevice `json:"sdal,omitempty"`
-	SDAM *InstanceConfigDevice `json:"sdam,omitempty"`
-	SDAN *InstanceConfigDevice `json:"sdan,omitempty"`
-	SDAO *InstanceConfigDevice `json:"sdao,omitempty"`
-	SDAP *InstanceConfigDevice `json:"sdap,omitempty"`
-	SDAQ *InstanceConfigDevice `json:"sdaq,omitempty"`
-	SDAR *InstanceConfigDevice `json:"sdar,omitempty"`
-	SDAS *InstanceConfigDevice `json:"sdas,omitempty"`
-	SDAT *InstanceConfigDevice `json:"sdat,omitempty"`
-	SDAU *InstanceConfigDevice `json:"sdau,omitempty"`
-	SDAV *InstanceConfigDevice `json:"sdav,omitempty"`
-	SDAW *InstanceConfigDevice `json:"sdaw,omitempty"`
-	SDAX *InstanceConfigDevice `json:"sdax,omitempty"`
-	SDAY *InstanceConfigDevice `json:"sday,omitempty"`
-	SDAZ *InstanceConfigDevice `json:"sdaz,omitempty"`
+	SDAA *InstanceConfigDevice `json:"sdaa,omitzero"`
+	SDAB *InstanceConfigDevice `json:"sdab,omitzero"`
+	SDAC *InstanceConfigDevice `json:"sdac,omitzero"`
+	SDAD *InstanceConfigDevice `json:"sdad,omitzero"`
+	SDAE *InstanceConfigDevice `json:"sdae,omitzero"`
+	SDAF *InstanceConfigDevice `json:"sdaf,omitzero"`
+	SDAG *InstanceConfigDevice `json:"sdag,omitzero"`
+	SDAH *InstanceConfigDevice `json:"sdah,omitzero"`
+	SDAI *InstanceConfigDevice `json:"sdai,omitzero"`
+	SDAJ *InstanceConfigDevice `json:"sdaj,omitzero"`
+	SDAK *InstanceConfigDevice `json:"sdak,omitzero"`
+	SDAL *InstanceConfigDevice `json:"sdal,omitzero"`
+	SDAM *InstanceConfigDevice `json:"sdam,omitzero"`
+	SDAN *InstanceConfigDevice `json:"sdan,omitzero"`
+	SDAO *InstanceConfigDevice `json:"sdao,omitzero"`
+	SDAP *InstanceConfigDevice `json:"sdap,omitzero"`
+	SDAQ *InstanceConfigDevice `json:"sdaq,omitzero"`
+	SDAR *InstanceConfigDevice `json:"sdar,omitzero"`
+	SDAS *InstanceConfigDevice `json:"sdas,omitzero"`
+	SDAT *InstanceConfigDevice `json:"sdat,omitzero"`
+	SDAU *InstanceConfigDevice `json:"sdau,omitzero"`
+	SDAV *InstanceConfigDevice `json:"sdav,omitzero"`
+	SDAW *InstanceConfigDevice `json:"sdaw,omitzero"`
+	SDAX *InstanceConfigDevice `json:"sdax,omitzero"`
+	SDAY *InstanceConfigDevice `json:"sday,omitzero"`
+	SDAZ *InstanceConfigDevice `json:"sdaz,omitzero"`
 
 	// sdba-sdbl
-	SDBA *InstanceConfigDevice `json:"sdba,omitempty"`
-	SDBB *InstanceConfigDevice `json:"sdbb,omitempty"`
-	SDBC *InstanceConfigDevice `json:"sdbc,omitempty"`
-	SDBD *InstanceConfigDevice `json:"sdbd,omitempty"`
-	SDBE *InstanceConfigDevice `json:"sdbe,omitempty"`
-	SDBF *InstanceConfigDevice `json:"sdbf,omitempty"`
-	SDBG *InstanceConfigDevice `json:"sdbg,omitempty"`
-	SDBH *InstanceConfigDevice `json:"sdbh,omitempty"`
-	SDBI *InstanceConfigDevice `json:"sdbi,omitempty"`
-	SDBJ *InstanceConfigDevice `json:"sdbj,omitempty"`
-	SDBK *InstanceConfigDevice `json:"sdbk,omitempty"`
-	SDBL *InstanceConfigDevice `json:"sdbl,omitempty"`
+	SDBA *InstanceConfigDevice `json:"sdba,omitzero"`
+	SDBB *InstanceConfigDevice `json:"sdbb,omitzero"`
+	SDBC *InstanceConfigDevice `json:"sdbc,omitzero"`
+	SDBD *InstanceConfigDevice `json:"sdbd,omitzero"`
+	SDBE *InstanceConfigDevice `json:"sdbe,omitzero"`
+	SDBF *InstanceConfigDevice `json:"sdbf,omitzero"`
+	SDBG *InstanceConfigDevice `json:"sdbg,omitzero"`
+	SDBH *InstanceConfigDevice `json:"sdbh,omitzero"`
+	SDBI *InstanceConfigDevice `json:"sdbi,omitzero"`
+	SDBJ *InstanceConfigDevice `json:"sdbj,omitzero"`
+	SDBK *InstanceConfigDevice `json:"sdbk,omitzero"`
+	SDBL *InstanceConfigDevice `json:"sdbl,omitzero"`
 }
 
 // InstanceConfigHelpers are Instance Config options that control Linux distribution specific tweaks
@@ -125,34 +125,34 @@ const (
 
 // InstanceConfigCreateOptions are InstanceConfig settings that can be used at creation
 type InstanceConfigCreateOptions struct {
-	Label       string                                 `json:"label,omitempty"`
-	Comments    string                                 `json:"comments,omitempty"`
+	Label       string                                 `json:"label,omitzero"`
+	Comments    string                                 `json:"comments,omitzero"`
 	Devices     InstanceConfigDeviceMap                `json:"devices"`
-	Helpers     *InstanceConfigHelpers                 `json:"helpers,omitempty"`
+	Helpers     *InstanceConfigHelpers                 `json:"helpers,omitzero"`
 	Interfaces  []InstanceConfigInterfaceCreateOptions `json:"interfaces"`
-	MemoryLimit int                                    `json:"memory_limit,omitempty"`
-	Kernel      string                                 `json:"kernel,omitempty"`
-	InitRD      int                                    `json:"init_rd,omitempty"`
-	RootDevice  *string                                `json:"root_device,omitempty"`
-	RunLevel    string                                 `json:"run_level,omitempty"`
-	VirtMode    string                                 `json:"virt_mode,omitempty"`
+	MemoryLimit int                                    `json:"memory_limit,omitzero"`
+	Kernel      string                                 `json:"kernel,omitzero"`
+	InitRD      int                                    `json:"init_rd,omitzero"`
+	RootDevice  *string                                `json:"root_device,omitzero"`
+	RunLevel    string                                 `json:"run_level,omitzero"`
+	VirtMode    string                                 `json:"virt_mode,omitzero"`
 }
 
 // InstanceConfigUpdateOptions are InstanceConfig settings that can be used in updates
 type InstanceConfigUpdateOptions struct {
-	Label      string                                 `json:"label,omitempty"`
+	Label      string                                 `json:"label,omitzero"`
 	Comments   string                                 `json:"comments"`
-	Devices    *InstanceConfigDeviceMap               `json:"devices,omitempty"`
-	Helpers    *InstanceConfigHelpers                 `json:"helpers,omitempty"`
+	Devices    *InstanceConfigDeviceMap               `json:"devices,omitzero"`
+	Helpers    *InstanceConfigHelpers                 `json:"helpers,omitzero"`
 	Interfaces []InstanceConfigInterfaceCreateOptions `json:"interfaces"`
 	// MemoryLimit 0 means unlimitted, this is not omitted
 	MemoryLimit int    `json:"memory_limit"`
-	Kernel      string `json:"kernel,omitempty"`
+	Kernel      string `json:"kernel,omitzero"`
 	// InitRD is nullable, permit the sending of null
 	InitRD     *int   `json:"init_rd"`
-	RootDevice string `json:"root_device,omitempty"`
-	RunLevel   string `json:"run_level,omitempty"`
-	VirtMode   string `json:"virt_mode,omitempty"`
+	RootDevice string `json:"root_device,omitzero"`
+	RunLevel   string `json:"run_level,omitzero"`
+	VirtMode   string `json:"virt_mode,omitzero"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -48,14 +48,14 @@ type InstanceDiskCreateOptions struct {
 	Size  int    `json:"size"`
 
 	// Image is optional, but requires RootPass if provided
-	Image    string `json:"image,omitempty"`
-	RootPass string `json:"root_pass,omitempty"`
+	Image    string `json:"image,omitzero"`
+	RootPass string `json:"root_pass,omitzero"`
 
-	Filesystem      string            `json:"filesystem,omitempty"`
-	AuthorizedKeys  []string          `json:"authorized_keys,omitempty"`
-	AuthorizedUsers []string          `json:"authorized_users,omitempty"`
-	StackscriptID   int               `json:"stackscript_id,omitempty"`
-	StackscriptData map[string]string `json:"stackscript_data,omitempty"`
+	Filesystem      string            `json:"filesystem,omitzero"`
+	AuthorizedKeys  []string          `json:"authorized_keys,omitzero"`
+	AuthorizedUsers []string          `json:"authorized_users,omitzero"`
+	StackscriptID   int               `json:"stackscript_id,omitzero"`
+	StackscriptData map[string]string `json:"stackscript_data,omitzero"`
 }
 
 // InstanceDiskUpdateOptions are InstanceDisk settings that can be used in updates

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -36,7 +36,7 @@ type InstanceIP struct {
 }
 
 type InstanceIPAddressUpdateOptions struct {
-	RDNS **string `json:"rdns,omitempty"`
+	RDNS **string `json:"rdns,omitzero"`
 }
 
 // VPCIP represents a private IP address in a VPC subnet with additional networking details

--- a/instances.go
+++ b/instances.go
@@ -100,12 +100,12 @@ type InstanceAlert struct {
 
 // InstanceBackup represents backup settings for an instance
 type InstanceBackup struct {
-	Available      bool       `json:"available,omitempty"` // read-only
-	Enabled        bool       `json:"enabled,omitempty"`   // read-only
-	LastSuccessful *time.Time `json:"-"`                   // read-only
+	Available      bool       `json:"available,omitzero"` // read-only
+	Enabled        bool       `json:"enabled,omitzero"`   // read-only
+	LastSuccessful *time.Time `json:"-"`                  // read-only
 	Schedule       struct {
-		Day    string `json:"day,omitempty"`
-		Window string `json:"window,omitempty"`
+		Day    string `json:"day,omitzero"`
+		Window string `json:"window,omitzero"`
 	} `json:"schedule"`
 }
 
@@ -154,7 +154,7 @@ type InstancePlacementGroup struct {
 // that relate to the Linode Metadata service.
 type InstanceMetadataOptions struct {
 	// UserData expects a Base64-encoded string
-	UserData string `json:"user_data,omitempty"`
+	UserData string `json:"user_data,omitzero"`
 }
 
 // InstancePasswordResetOptions specifies the new password for the Linode
@@ -166,23 +166,23 @@ type InstancePasswordResetOptions struct {
 type InstanceCreateOptions struct {
 	Region              string                               `json:"region"`
 	Type                string                               `json:"type"`
-	Label               string                               `json:"label,omitempty"`
-	RootPass            string                               `json:"root_pass,omitempty"`
-	AuthorizedKeys      []string                             `json:"authorized_keys,omitempty"`
-	AuthorizedUsers     []string                             `json:"authorized_users,omitempty"`
-	StackScriptID       int                                  `json:"stackscript_id,omitempty"`
-	StackScriptData     map[string]string                    `json:"stackscript_data,omitempty"`
-	BackupID            int                                  `json:"backup_id,omitempty"`
-	Image               string                               `json:"image,omitempty"`
-	BackupsEnabled      bool                                 `json:"backups_enabled,omitempty"`
-	PrivateIP           bool                                 `json:"private_ip,omitempty"`
-	NetworkHelper       *bool                                `json:"network_helper,omitempty"`
-	Tags                []string                             `json:"tags,omitempty"`
-	Metadata            *InstanceMetadataOptions             `json:"metadata,omitempty"`
-	FirewallID          int                                  `json:"firewall_id,omitempty"`
-	InterfaceGeneration InterfaceGeneration                  `json:"interface_generation,omitempty"`
-	DiskEncryption      InstanceDiskEncryption               `json:"disk_encryption,omitempty"`
-	PlacementGroup      *InstanceCreatePlacementGroupOptions `json:"placement_group,omitempty"`
+	Label               string                               `json:"label,omitzero"`
+	RootPass            string                               `json:"root_pass,omitzero"`
+	AuthorizedKeys      []string                             `json:"authorized_keys,omitzero"`
+	AuthorizedUsers     []string                             `json:"authorized_users,omitzero"`
+	StackScriptID       int                                  `json:"stackscript_id,omitzero"`
+	StackScriptData     map[string]string                    `json:"stackscript_data,omitzero"`
+	BackupID            int                                  `json:"backup_id,omitzero"`
+	Image               string                               `json:"image,omitzero"`
+	BackupsEnabled      bool                                 `json:"backups_enabled,omitzero"`
+	PrivateIP           bool                                 `json:"private_ip,omitzero"`
+	NetworkHelper       *bool                                `json:"network_helper,omitzero"`
+	Tags                []string                             `json:"tags,omitzero"`
+	Metadata            *InstanceMetadataOptions             `json:"metadata,omitzero"`
+	FirewallID          int                                  `json:"firewall_id,omitzero"`
+	InterfaceGeneration InterfaceGeneration                  `json:"interface_generation,omitzero"`
+	DiskEncryption      InstanceDiskEncryption               `json:"disk_encryption,omitzero"`
+	PlacementGroup      *InstanceCreatePlacementGroupOptions `json:"placement_group,omitzero"`
 
 	// Linode Interfaces to create the new instance with.
 	// Conflicts with Interfaces.
@@ -193,30 +193,30 @@ type InstanceCreateOptions struct {
 	Interfaces []InstanceConfigInterfaceCreateOptions `json:"-"`
 
 	// Creation fields that need to be set explicitly false, "", or 0 use pointers
-	SwapSize *int  `json:"swap_size,omitempty"`
-	Booted   *bool `json:"booted,omitempty"`
+	SwapSize *int  `json:"swap_size,omitzero"`
+	Booted   *bool `json:"booted,omitzero"`
 
-	IPv4 []string `json:"ipv4,omitempty"`
+	IPv4 []string `json:"ipv4,omitzero"`
 
-	MaintenancePolicy *string `json:"maintenance_policy,omitempty"`
+	MaintenancePolicy *string `json:"maintenance_policy,omitzero"`
 }
 
 // InstanceCreatePlacementGroupOptions represents the placement group
 // to create this Linode under.
 type InstanceCreatePlacementGroupOptions struct {
 	ID            int   `json:"id"`
-	CompliantOnly *bool `json:"compliant_only,omitempty"`
+	CompliantOnly *bool `json:"compliant_only,omitzero"`
 }
 
 // InstanceUpdateOptions is an options struct used when Updating an Instance
 type InstanceUpdateOptions struct {
-	Label           string          `json:"label,omitempty"`
-	Backups         *InstanceBackup `json:"backups,omitempty"`
-	Alerts          *InstanceAlert  `json:"alerts,omitempty"`
-	WatchdogEnabled *bool           `json:"watchdog_enabled,omitempty"`
-	Tags            *[]string       `json:"tags,omitempty"`
+	Label           string          `json:"label,omitzero"`
+	Backups         *InstanceBackup `json:"backups,omitzero"`
+	Alerts          *InstanceAlert  `json:"alerts,omitzero"`
+	WatchdogEnabled *bool           `json:"watchdog_enabled,omitzero"`
+	Tags            *[]string       `json:"tags,omitzero"`
 
-	MaintenancePolicy *string `json:"maintenance_policy,omitempty"`
+	MaintenancePolicy *string `json:"maintenance_policy,omitzero"`
 }
 
 // MarshalJSON contains logic necessary to populate the `interfaces` field of
@@ -228,7 +228,7 @@ func (i InstanceCreateOptions) MarshalJSON() ([]byte, error) {
 	resultData := struct {
 		*Mask
 
-		Interfaces any `json:"interfaces,omitempty"`
+		Interfaces any `json:"interfaces,omitzero"`
 	}{
 		Mask:       (*Mask)(&i),
 		Interfaces: nil,
@@ -257,7 +257,7 @@ func (i *InstanceCreateOptions) UnmarshalJSON(b []byte) error {
 	p := struct {
 		*Mask
 
-		GenericInterfaces any `json:"interfaces,omitempty"`
+		GenericInterfaces any `json:"interfaces,omitzero"`
 	}{
 		Mask: (*Mask)(i),
 	}
@@ -354,36 +354,36 @@ func (i *Instance) GetUpdateOptions() InstanceUpdateOptions {
 
 // InstanceCloneOptions is an options struct sent when Cloning an Instance
 type InstanceCloneOptions struct {
-	Region string `json:"region,omitempty"`
-	Type   string `json:"type,omitempty"`
+	Region string `json:"region,omitzero"`
+	Type   string `json:"type,omitzero"`
 
 	// LinodeID is an optional existing instance to use as the target of the clone
-	LinodeID       int                                  `json:"linode_id,omitempty"`
-	Label          string                               `json:"label,omitempty"`
+	LinodeID       int                                  `json:"linode_id,omitzero"`
+	Label          string                               `json:"label,omitzero"`
 	BackupsEnabled bool                                 `json:"backups_enabled"`
-	Disks          []int                                `json:"disks,omitempty"`
-	Configs        []int                                `json:"configs,omitempty"`
-	PrivateIP      bool                                 `json:"private_ip,omitempty"`
-	Metadata       *InstanceMetadataOptions             `json:"metadata,omitempty"`
-	PlacementGroup *InstanceCreatePlacementGroupOptions `json:"placement_group,omitempty"`
+	Disks          []int                                `json:"disks,omitzero"`
+	Configs        []int                                `json:"configs,omitzero"`
+	PrivateIP      bool                                 `json:"private_ip,omitzero"`
+	Metadata       *InstanceMetadataOptions             `json:"metadata,omitzero"`
+	PlacementGroup *InstanceCreatePlacementGroupOptions `json:"placement_group,omitzero"`
 }
 
 // InstanceResizeOptions is an options struct used when resizing an instance
 type InstanceResizeOptions struct {
 	Type          string                `json:"type"`
-	MigrationType InstanceMigrationType `json:"migration_type,omitempty"`
+	MigrationType InstanceMigrationType `json:"migration_type,omitzero"`
 
 	// When enabled, an instance resize will also resize a data disk if the instance has no more than one data disk and one swap disk
-	AllowAutoDiskResize *bool `json:"allow_auto_disk_resize,omitempty"`
+	AllowAutoDiskResize *bool `json:"allow_auto_disk_resize,omitzero"`
 }
 
 // InstanceMigrateOptions is an options struct used when migrating an instance
 type InstanceMigrateOptions struct {
-	Type    InstanceMigrationType `json:"type,omitempty"`
-	Region  string                `json:"region,omitempty"`
-	Upgrade *bool                 `json:"upgrade,omitempty"`
+	Type    InstanceMigrationType `json:"type,omitzero"`
+	Region  string                `json:"region,omitzero"`
+	Upgrade *bool                 `json:"upgrade,omitzero"`
 
-	PlacementGroup *InstanceCreatePlacementGroupOptions `json:"placement_group,omitempty"`
+	PlacementGroup *InstanceCreatePlacementGroupOptions `json:"placement_group,omitzero"`
 }
 
 // ListInstances lists linode instances
@@ -473,16 +473,16 @@ func (c *Client) RebootInstance(ctx context.Context, linodeID int, configID int)
 
 // InstanceRebuildOptions is a struct representing the options to send to the rebuild linode endpoint
 type InstanceRebuildOptions struct {
-	Image           string                   `json:"image,omitempty"`
-	RootPass        string                   `json:"root_pass,omitempty"`
-	AuthorizedKeys  []string                 `json:"authorized_keys,omitempty"`
-	AuthorizedUsers []string                 `json:"authorized_users,omitempty"`
-	StackScriptID   int                      `json:"stackscript_id,omitempty"`
-	StackScriptData map[string]string        `json:"stackscript_data,omitempty"`
-	Booted          *bool                    `json:"booted,omitempty"`
-	Metadata        *InstanceMetadataOptions `json:"metadata,omitempty"`
-	Type            string                   `json:"type,omitempty"`
-	DiskEncryption  InstanceDiskEncryption   `json:"disk_encryption,omitempty"`
+	Image           string                   `json:"image,omitzero"`
+	RootPass        string                   `json:"root_pass,omitzero"`
+	AuthorizedKeys  []string                 `json:"authorized_keys,omitzero"`
+	AuthorizedUsers []string                 `json:"authorized_users,omitzero"`
+	StackScriptID   int                      `json:"stackscript_id,omitzero"`
+	StackScriptData map[string]string        `json:"stackscript_data,omitzero"`
+	Booted          *bool                    `json:"booted,omitzero"`
+	Metadata        *InstanceMetadataOptions `json:"metadata,omitzero"`
+	Type            string                   `json:"type,omitzero"`
+	DiskEncryption  InstanceDiskEncryption   `json:"disk_encryption,omitzero"`
 }
 
 // RebuildInstance Deletes all Disks and Configs on this Linode,

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,8 +21,8 @@ type LinodeInterface struct {
 }
 
 type InterfaceDefaultRoute struct {
-	IPv4 *bool `json:"ipv4,omitempty"`
-	IPv6 *bool `json:"ipv6,omitempty"`
+	IPv4 *bool `json:"ipv4,omitzero"`
+	IPv6 *bool `json:"ipv6,omitzero"`
 }
 
 type PublicInterface struct {
@@ -108,39 +108,39 @@ type VPCInterfaceIPv6Range struct {
 
 type VLANInterface struct {
 	VLANLabel   string  `json:"vlan_label"`
-	IPAMAddress *string `json:"ipam_address,omitempty"`
+	IPAMAddress *string `json:"ipam_address,omitzero"`
 }
 
 type LinodeInterfaceCreateOptions struct {
-	FirewallID   *int                          `json:"firewall_id,omitempty"`
-	DefaultRoute *InterfaceDefaultRoute        `json:"default_route,omitempty"`
-	Public       *PublicInterfaceCreateOptions `json:"public,omitempty"`
-	VPC          *VPCInterfaceCreateOptions    `json:"vpc,omitempty"`
-	VLAN         *VLANInterface                `json:"vlan,omitempty"`
+	FirewallID   *int                          `json:"firewall_id,omitzero"`
+	DefaultRoute *InterfaceDefaultRoute        `json:"default_route,omitzero"`
+	Public       *PublicInterfaceCreateOptions `json:"public,omitzero"`
+	VPC          *VPCInterfaceCreateOptions    `json:"vpc,omitzero"`
+	VLAN         *VLANInterface                `json:"vlan,omitzero"`
 }
 
 type LinodeInterfaceUpdateOptions struct {
-	DefaultRoute *InterfaceDefaultRoute        `json:"default_route,omitempty"`
-	Public       *PublicInterfaceCreateOptions `json:"public,omitempty"`
-	VPC          *VPCInterfaceUpdateOptions    `json:"vpc,omitempty"`
+	DefaultRoute *InterfaceDefaultRoute        `json:"default_route,omitzero"`
+	Public       *PublicInterfaceCreateOptions `json:"public,omitzero"`
+	VPC          *VPCInterfaceUpdateOptions    `json:"vpc,omitzero"`
 }
 
 type PublicInterfaceCreateOptions struct {
-	IPv4 *PublicInterfaceIPv4CreateOptions `json:"ipv4,omitempty"`
-	IPv6 *PublicInterfaceIPv6CreateOptions `json:"ipv6,omitempty"`
+	IPv4 *PublicInterfaceIPv4CreateOptions `json:"ipv4,omitzero"`
+	IPv6 *PublicInterfaceIPv6CreateOptions `json:"ipv6,omitzero"`
 }
 
 type PublicInterfaceIPv4CreateOptions struct {
-	Addresses *[]PublicInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
+	Addresses *[]PublicInterfaceIPv4AddressCreateOptions `json:"addresses,omitzero"`
 }
 
 type PublicInterfaceIPv4AddressCreateOptions struct {
-	Address *string `json:"address,omitempty"`
-	Primary *bool   `json:"primary,omitempty"`
+	Address *string `json:"address,omitzero"`
+	Primary *bool   `json:"primary,omitzero"`
 }
 
 type PublicInterfaceIPv6CreateOptions struct {
-	Ranges *[]PublicInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
+	Ranges *[]PublicInterfaceIPv6RangeCreateOptions `json:"ranges,omitzero"`
 }
 
 type PublicInterfaceIPv6RangeCreateOptions struct {
@@ -149,19 +149,19 @@ type PublicInterfaceIPv6RangeCreateOptions struct {
 
 type VPCInterfaceCreateOptions struct {
 	SubnetID int                            `json:"subnet_id"`
-	IPv4     *VPCInterfaceIPv4CreateOptions `json:"ipv4,omitempty"`
-	IPv6     *VPCInterfaceIPv6CreateOptions `json:"ipv6,omitempty"`
+	IPv4     *VPCInterfaceIPv4CreateOptions `json:"ipv4,omitzero"`
+	IPv6     *VPCInterfaceIPv6CreateOptions `json:"ipv6,omitzero"`
 }
 
 type VPCInterfaceIPv4CreateOptions struct {
-	Addresses *[]VPCInterfaceIPv4AddressCreateOptions `json:"addresses,omitempty"`
-	Ranges    *[]VPCInterfaceIPv4RangeCreateOptions   `json:"ranges,omitempty"`
+	Addresses *[]VPCInterfaceIPv4AddressCreateOptions `json:"addresses,omitzero"`
+	Ranges    *[]VPCInterfaceIPv4RangeCreateOptions   `json:"ranges,omitzero"`
 }
 
 type VPCInterfaceIPv4AddressCreateOptions struct {
-	Address        *string `json:"address,omitempty"`
-	Primary        *bool   `json:"primary,omitempty"`
-	NAT1To1Address *string `json:"nat_1_1_address,omitempty"`
+	Address        *string `json:"address,omitzero"`
+	Primary        *bool   `json:"primary,omitzero"`
+	NAT1To1Address *string `json:"nat_1_1_address,omitzero"`
 }
 
 type VPCInterfaceIPv4RangeCreateOptions struct {
@@ -171,8 +171,8 @@ type VPCInterfaceIPv4RangeCreateOptions struct {
 // VPCInterfaceIPv6CreateOptions specifies IPv6 configuration parameters for VPC creation.
 // NOTE: IPv6 interfaces may not currently be available to all users.
 type VPCInterfaceIPv6CreateOptions struct {
-	SLAAC    *[]VPCInterfaceIPv6SLAACCreateOptions `json:"slaac,omitempty"`
-	Ranges   *[]VPCInterfaceIPv6RangeCreateOptions `json:"ranges,omitempty"`
+	SLAAC    *[]VPCInterfaceIPv6SLAACCreateOptions `json:"slaac,omitzero"`
+	Ranges   *[]VPCInterfaceIPv6RangeCreateOptions `json:"ranges,omitzero"`
 	IsPublic *bool                                 `json:"is_public"`
 }
 
@@ -189,8 +189,8 @@ type VPCInterfaceIPv6RangeCreateOptions struct {
 }
 
 type VPCInterfaceUpdateOptions struct {
-	IPv4 *VPCInterfaceIPv4CreateOptions `json:"ipv4,omitempty"`
-	IPv6 *VPCInterfaceIPv6CreateOptions `json:"ipv6,omitempty"`
+	IPv4 *VPCInterfaceIPv4CreateOptions `json:"ipv4,omitzero"`
+	IPv6 *VPCInterfaceIPv6CreateOptions `json:"ipv6,omitzero"`
 }
 
 type LinodeInterfacesUpgrade struct {
@@ -200,8 +200,8 @@ type LinodeInterfacesUpgrade struct {
 }
 
 type LinodeInterfacesUpgradeOptions struct {
-	ConfigID *int  `json:"config_id,omitempty"`
-	DryRun   *bool `json:"dry_run,omitempty"`
+	ConfigID *int  `json:"config_id,omitzero"`
+	DryRun   *bool `json:"dry_run,omitzero"`
 }
 
 type InterfaceSettings struct {
@@ -210,13 +210,13 @@ type InterfaceSettings struct {
 }
 
 type InterfaceSettingsUpdateOptions struct {
-	NetworkHelper *bool                                      `json:"network_helper,omitempty"`
-	DefaultRoute  *InterfaceDefaultRouteSettingUpdateOptions `json:"default_route,omitempty"`
+	NetworkHelper *bool                                      `json:"network_helper,omitzero"`
+	DefaultRoute  *InterfaceDefaultRouteSettingUpdateOptions `json:"default_route,omitzero"`
 }
 
 type InterfaceDefaultRouteSettingUpdateOptions struct {
-	IPv4InterfaceID *int `json:"ipv4_interface_id,omitempty"`
-	IPv6InterfaceID *int `json:"ipv6_interface_id,omitempty"`
+	IPv4InterfaceID *int `json:"ipv4_interface_id,omitzero"`
+	IPv6InterfaceID *int `json:"ipv6_interface_id,omitzero"`
 }
 
 type InterfaceDefaultRouteSetting struct {

--- a/lke_clusters.go
+++ b/lke_clusters.go
@@ -55,27 +55,27 @@ type LKEClusterCreateOptions struct {
 	Label        string                         `json:"label"`
 	Region       string                         `json:"region"`
 	K8sVersion   string                         `json:"k8s_version"`
-	Tags         []string                       `json:"tags,omitempty"`
-	ControlPlane *LKEClusterControlPlaneOptions `json:"control_plane,omitempty"`
+	Tags         []string                       `json:"tags,omitzero"`
+	ControlPlane *LKEClusterControlPlaneOptions `json:"control_plane,omitzero"`
 
 	// NOTE: Tier may not currently be available to all users and can only be used with v4beta.
-	Tier string `json:"tier,omitempty"`
+	Tier string `json:"tier,omitzero"`
 
 	// NOTE: APLEnabled is currently in beta and may only function with API version v4beta.
-	APLEnabled bool `json:"apl_enabled,omitempty"`
+	APLEnabled bool `json:"apl_enabled,omitzero"`
 
 	// NOTE: SubnetID, VpcID, and StackType may not currently be available to all users and can only be used with v4beta.
-	SubnetID  *int                 `json:"subnet_id,omitempty"`
-	VpcID     *int                 `json:"vpc_id,omitempty"`
-	StackType *LKEClusterStackType `json:"stack_type,omitempty"`
+	SubnetID  *int                 `json:"subnet_id,omitzero"`
+	VpcID     *int                 `json:"vpc_id,omitzero"`
+	StackType *LKEClusterStackType `json:"stack_type,omitzero"`
 }
 
 // LKEClusterUpdateOptions fields are those accepted by UpdateLKECluster
 type LKEClusterUpdateOptions struct {
-	K8sVersion   string                         `json:"k8s_version,omitempty"`
-	Label        string                         `json:"label,omitempty"`
-	Tags         *[]string                      `json:"tags,omitempty"`
-	ControlPlane *LKEClusterControlPlaneOptions `json:"control_plane,omitempty"`
+	K8sVersion   string                         `json:"k8s_version,omitzero"`
+	Label        string                         `json:"label,omitzero"`
+	Tags         *[]string                      `json:"tags,omitzero"`
+	ControlPlane *LKEClusterControlPlaneOptions `json:"control_plane,omitzero"`
 }
 
 // LKEClusterAPIEndpoint fields are those returned by ListLKEClusterAPIEndpoints

--- a/lke_clusters_control_plane.go
+++ b/lke_clusters_control_plane.go
@@ -7,7 +7,7 @@ type LKEClusterControlPlane struct {
 	HighAvailability bool `json:"high_availability"`
 
 	// AuditLogsEnabled may not currently be available to all users and can only be used with v4beta.
-	AuditLogsEnabled bool `json:"audit_logs_enabled,omitempty"`
+	AuditLogsEnabled bool `json:"audit_logs_enabled,omitzero"`
 }
 
 // LKEClusterControlPlaneACLAddresses describes the
@@ -28,26 +28,26 @@ type LKEClusterControlPlaneACL struct {
 // LKEClusterControlPlaneACLAddressesOptions are the options used to
 // specify the allowed IP ranges for an LKE cluster's control plane.
 type LKEClusterControlPlaneACLAddressesOptions struct {
-	IPv4 *[]string `json:"ipv4,omitempty"`
-	IPv6 *[]string `json:"ipv6,omitempty"`
+	IPv4 *[]string `json:"ipv4,omitzero"`
+	IPv6 *[]string `json:"ipv6,omitzero"`
 }
 
 // LKEClusterControlPlaneACLOptions represents the options used when
 // configuring an LKE cluster's control plane ACL policy.
 type LKEClusterControlPlaneACLOptions struct {
-	Enabled    *bool                                      `json:"enabled,omitempty"`
-	Addresses  *LKEClusterControlPlaneACLAddressesOptions `json:"addresses,omitempty"`
-	RevisionID string                                     `json:"revision-id,omitempty"`
+	Enabled    *bool                                      `json:"enabled,omitzero"`
+	Addresses  *LKEClusterControlPlaneACLAddressesOptions `json:"addresses,omitzero"`
+	RevisionID string                                     `json:"revision-id,omitzero"`
 }
 
 // LKEClusterControlPlaneOptions represents the options used when
 // configuring an LKE cluster's control plane.
 type LKEClusterControlPlaneOptions struct {
-	HighAvailability *bool                             `json:"high_availability,omitempty"`
-	ACL              *LKEClusterControlPlaneACLOptions `json:"acl,omitempty"`
+	HighAvailability *bool                             `json:"high_availability,omitzero"`
+	ACL              *LKEClusterControlPlaneACLOptions `json:"acl,omitzero"`
 
 	// AuditLogsEnabled may not currently be available to all users and can only be used with v4beta.
-	AuditLogsEnabled *bool `json:"audit_logs_enabled,omitempty"`
+	AuditLogsEnabled *bool `json:"audit_logs_enabled,omitzero"`
 }
 
 // LKEClusterControlPlaneACLUpdateOptions represents the options

--- a/lke_node_pools.go
+++ b/lke_node_pools.go
@@ -55,7 +55,7 @@ const (
 // LKENodePoolTaint represents a corev1.Taint to add to an LKENodePool
 type LKENodePoolTaint struct {
 	Key    string                 `json:"key"`
-	Value  string                 `json:"value,omitempty"`
+	Value  string                 `json:"value,omitzero"`
 	Effect LKENodePoolTaintEffect `json:"effect"`
 }
 
@@ -75,14 +75,14 @@ type LKENodePool struct {
 	Label   *string             `json:"label"`
 
 	Autoscaler LKENodePoolAutoscaler `json:"autoscaler"`
-	FirewallID *int                  `json:"firewall_id,omitempty"`
+	FirewallID *int                  `json:"firewall_id,omitzero"`
 
-	DiskEncryption InstanceDiskEncryption `json:"disk_encryption,omitempty"`
+	DiskEncryption InstanceDiskEncryption `json:"disk_encryption,omitzero"`
 
 	// K8sVersion and UpdateStrategy are only for LKE Enterprise to support node pool upgrades.
 	// It may not currently be available to all users and is under v4beta.
-	K8sVersion     *string                    `json:"k8s_version,omitempty"`
-	UpdateStrategy *LKENodePoolUpdateStrategy `json:"update_strategy,omitempty"`
+	K8sVersion     *string                    `json:"k8s_version,omitzero"`
+	UpdateStrategy *LKENodePoolUpdateStrategy `json:"update_strategy,omitzero"`
 }
 
 // LKENodePoolCreateOptions fields are those accepted by CreateLKENodePool
@@ -93,34 +93,34 @@ type LKENodePoolCreateOptions struct {
 	Tags   []string           `json:"tags"`
 	Labels LKENodePoolLabels  `json:"labels"`
 	Taints []LKENodePoolTaint `json:"taints"`
-	Label  *string            `json:"label,omitempty"`
+	Label  *string            `json:"label,omitzero"`
 
-	Autoscaler *LKENodePoolAutoscaler `json:"autoscaler,omitempty"`
-	FirewallID *int                   `json:"firewall_id,omitempty"`
+	Autoscaler *LKENodePoolAutoscaler `json:"autoscaler,omitzero"`
+	FirewallID *int                   `json:"firewall_id,omitzero"`
 
 	// K8sVersion and UpdateStrategy only works for LKE Enterprise to support node pool upgrades.
 	// It may not currently be available to all users and is under v4beta.
-	K8sVersion     *string                    `json:"k8s_version,omitempty"`
-	UpdateStrategy *LKENodePoolUpdateStrategy `json:"update_strategy,omitempty"`
+	K8sVersion     *string                    `json:"k8s_version,omitzero"`
+	UpdateStrategy *LKENodePoolUpdateStrategy `json:"update_strategy,omitzero"`
 
-	DiskEncryption *InstanceDiskEncryption `json:"disk_encryption,omitempty"`
+	DiskEncryption *InstanceDiskEncryption `json:"disk_encryption,omitzero"`
 }
 
 // LKENodePoolUpdateOptions fields are those accepted by UpdateLKENodePoolUpdate
 type LKENodePoolUpdateOptions struct {
-	Count  int                 `json:"count,omitempty"`
-	Tags   *[]string           `json:"tags,omitempty"`
-	Labels *LKENodePoolLabels  `json:"labels,omitempty"`
-	Taints *[]LKENodePoolTaint `json:"taints,omitempty"`
-	Label  *string             `json:"label,omitempty"`
+	Count  int                 `json:"count,omitzero"`
+	Tags   *[]string           `json:"tags,omitzero"`
+	Labels *LKENodePoolLabels  `json:"labels,omitzero"`
+	Taints *[]LKENodePoolTaint `json:"taints,omitzero"`
+	Label  *string             `json:"label,omitzero"`
 
-	Autoscaler *LKENodePoolAutoscaler `json:"autoscaler,omitempty"`
-	FirewallID *int                   `json:"firewall_id,omitempty"`
+	Autoscaler *LKENodePoolAutoscaler `json:"autoscaler,omitzero"`
+	FirewallID *int                   `json:"firewall_id,omitzero"`
 
 	// K8sVersion and UpdateStrategy only works for LKE Enterprise to support node pool upgrades.
 	// It may not currently be available to all users and is under v4beta.
-	K8sVersion     *string                    `json:"k8s_version,omitempty"`
-	UpdateStrategy *LKENodePoolUpdateStrategy `json:"update_strategy,omitempty"`
+	K8sVersion     *string                    `json:"k8s_version,omitzero"`
+	UpdateStrategy *LKENodePoolUpdateStrategy `json:"update_strategy,omitzero"`
 }
 
 // GetCreateOptions converts a LKENodePool to LKENodePoolCreateOptions for

--- a/monitor_alert_definitions.go
+++ b/monitor_alert_definitions.go
@@ -71,15 +71,15 @@ type AlertDefinition struct {
 
 // TriggerConditions represents the trigger conditions for an alert.
 type TriggerConditions struct {
-	CriteriaCondition       string `json:"criteria_condition,omitempty"`
-	EvaluationPeriodSeconds int    `json:"evaluation_period_seconds,omitempty"`
-	PollingIntervalSeconds  int    `json:"polling_interval_seconds,omitempty"`
-	TriggerOccurrences      int    `json:"trigger_occurrences,omitempty"`
+	CriteriaCondition       string `json:"criteria_condition,omitzero"`
+	EvaluationPeriodSeconds int    `json:"evaluation_period_seconds,omitzero"`
+	PollingIntervalSeconds  int    `json:"polling_interval_seconds,omitzero"`
+	TriggerOccurrences      int    `json:"trigger_occurrences,omitzero"`
 }
 
 // RuleCriteria represents the rule criteria for an alert.
 type RuleCriteria struct {
-	Rules []Rule `json:"rules,omitempty"`
+	Rules []Rule `json:"rules,omitzero"`
 }
 
 // Rule represents a single rule for an alert.
@@ -103,23 +103,23 @@ type DimensionFilter struct {
 
 // RuleCriteriaOptions represents the rule criteria options for an alert.
 type RuleCriteriaOptions struct {
-	Rules []RuleOptions `json:"rules,omitempty"`
+	Rules []RuleOptions `json:"rules,omitzero"`
 }
 
 // RuleOptions represents a single rule option for an alert.
 type RuleOptions struct {
-	AggregateFunction string                   `json:"aggregate_function,omitempty"`
-	DimensionFilters  []DimensionFilterOptions `json:"dimension_filters,omitempty"`
-	Metric            string                   `json:"metric,omitempty"`
-	Operator          string                   `json:"operator,omitempty"`
-	Threshold         float64                  `json:"threshold,omitempty"`
+	AggregateFunction string                   `json:"aggregate_function,omitzero"`
+	DimensionFilters  []DimensionFilterOptions `json:"dimension_filters,omitzero"`
+	Metric            string                   `json:"metric,omitzero"`
+	Operator          string                   `json:"operator,omitzero"`
+	Threshold         float64                  `json:"threshold,omitzero"`
 }
 
 // DimensionFilterOptions represents a single dimension filter option used inside a Rule.
 type DimensionFilterOptions struct {
-	DimensionLabel string `json:"dimension_label,omitempty"`
-	Operator       string `json:"operator,omitempty"`
-	Value          string `json:"value,omitempty"`
+	DimensionLabel string `json:"dimension_label,omitzero"`
+	Operator       string `json:"operator,omitzero"`
+	Value          string `json:"value,omitzero"`
 }
 
 // AlertChannelEnvelope represents a single alert channel entry returned inside alert definition
@@ -161,11 +161,11 @@ type AlertDefinitionCreateOptions struct {
 	Label             string               `json:"label"`
 	Severity          int                  `json:"severity"`
 	ChannelIDs        []int                `json:"channel_ids"`
-	RuleCriteria      *RuleCriteriaOptions `json:"rule_criteria,omitempty"`
-	TriggerConditions *TriggerConditions   `json:"trigger_conditions,omitempty"`
-	EntityIDs         []string             `json:"entity_ids,omitempty"`
-	Description       *string              `json:"description,omitempty"`
-	Scope             AlertDefinitionScope `json:"scope,omitempty"`
+	RuleCriteria      *RuleCriteriaOptions `json:"rule_criteria,omitzero"`
+	TriggerConditions *TriggerConditions   `json:"trigger_conditions,omitzero"`
+	EntityIDs         []string             `json:"entity_ids,omitzero"`
+	Description       *string              `json:"description,omitzero"`
+	Scope             AlertDefinitionScope `json:"scope,omitzero"`
 	Regions           []string             `json:"regions,omitzero"`
 }
 
@@ -174,11 +174,11 @@ type AlertDefinitionUpdateOptions struct {
 	Label             string                 `json:"label"`
 	Severity          int                    `json:"severity"`
 	ChannelIDs        []int                  `json:"channel_ids"`
-	RuleCriteria      *RuleCriteriaOptions   `json:"rule_criteria,omitempty"`
-	TriggerConditions *TriggerConditions     `json:"trigger_conditions,omitempty"`
-	EntityIDs         []string               `json:"entity_ids,omitempty"`
-	Description       *string                `json:"description,omitempty"`
-	Status            *AlertDefinitionStatus `json:"status,omitempty"`
+	RuleCriteria      *RuleCriteriaOptions   `json:"rule_criteria,omitzero"`
+	TriggerConditions *TriggerConditions     `json:"trigger_conditions,omitzero"`
+	EntityIDs         []string               `json:"entity_ids,omitzero"`
+	Description       *string                `json:"description,omitzero"`
+	Status            *AlertDefinitionStatus `json:"status,omitzero"`
 	Regions           []string               `json:"regions,omitzero"`
 }
 

--- a/monitor_api_services.go
+++ b/monitor_api_services.go
@@ -61,11 +61,11 @@ type EntityMetricsFetchOptions struct {
 	// EntityIDs are expected to be type "any" as different service_types have different variable type for their entity_ids. For example, Linode has "int" entity_ids whereas object storage has "string" as entity_ids.
 	EntityIDs []any `json:"entity_ids"`
 
-	Filters              []MetricFilter              `json:"filters,omitempty"`
+	Filters              []MetricFilter              `json:"filters,omitzero"`
 	Metrics              []EntityMetric              `json:"metrics"`
-	TimeGranularity      []MetricTimeGranularity     `json:"time_granularity,omitempty"`
-	RelativeTimeDuration *MetricRelativeTimeDuration `json:"relative_time_duration,omitempty"`
-	AbsoluteTimeDuration *MetricAbsoluteTimeDuration `json:"absolute_time_duration,omitempty"`
+	TimeGranularity      []MetricTimeGranularity     `json:"time_granularity,omitzero"`
+	RelativeTimeDuration *MetricRelativeTimeDuration `json:"relative_time_duration,omitzero"`
+	AbsoluteTimeDuration *MetricAbsoluteTimeDuration `json:"absolute_time_duration,omitzero"`
 }
 
 // MetricFilter describes individual objects that define dimension filters for the query.

--- a/mysql.go
+++ b/mysql.go
@@ -46,42 +46,42 @@ type MySQLDatabase struct {
 	Port              int                       `json:"port"`
 
 	EngineConfig   MySQLDatabaseEngineConfig `json:"engine_config"`
-	PrivateNetwork *DatabasePrivateNetwork   `json:"private_network,omitempty"`
+	PrivateNetwork *DatabasePrivateNetwork   `json:"private_network,omitzero"`
 }
 
 type MySQLDatabaseEngineConfig struct {
-	MySQL                 *MySQLDatabaseEngineConfigMySQL `json:"mysql,omitempty"`
-	BinlogRetentionPeriod *int                            `json:"binlog_retention_period,omitempty"`
+	MySQL                 *MySQLDatabaseEngineConfigMySQL `json:"mysql,omitzero"`
+	BinlogRetentionPeriod *int                            `json:"binlog_retention_period,omitzero"`
 }
 
 type MySQLDatabaseEngineConfigMySQL struct {
-	ConnectTimeout               *int     `json:"connect_timeout,omitempty"`
-	DefaultTimeZone              *string  `json:"default_time_zone,omitempty"`
-	GroupConcatMaxLen            *float64 `json:"group_concat_max_len,omitempty"`
-	InformationSchemaStatsExpiry *int     `json:"information_schema_stats_expiry,omitempty"`
-	InnoDBChangeBufferMaxSize    *int     `json:"innodb_change_buffer_max_size,omitempty"`
-	InnoDBFlushNeighbors         *int     `json:"innodb_flush_neighbors,omitempty"`
-	InnoDBFTMinTokenSize         *int     `json:"innodb_ft_min_token_size,omitempty"`
-	InnoDBFTServerStopwordTable  **string `json:"innodb_ft_server_stopword_table,omitempty"`
-	InnoDBLockWaitTimeout        *int     `json:"innodb_lock_wait_timeout,omitempty"`
-	InnoDBLogBufferSize          *int     `json:"innodb_log_buffer_size,omitempty"`
-	InnoDBOnlineAlterLogMaxSize  *int     `json:"innodb_online_alter_log_max_size,omitempty"`
-	InnoDBReadIOThreads          *int     `json:"innodb_read_io_threads,omitempty"`
-	InnoDBRollbackOnTimeout      *bool    `json:"innodb_rollback_on_timeout,omitempty"`
-	InnoDBThreadConcurrency      *int     `json:"innodb_thread_concurrency,omitempty"`
-	InnoDBWriteIOThreads         *int     `json:"innodb_write_io_threads,omitempty"`
-	InteractiveTimeout           *int     `json:"interactive_timeout,omitempty"`
-	InternalTmpMemStorageEngine  *string  `json:"internal_tmp_mem_storage_engine,omitempty"`
-	MaxAllowedPacket             *int     `json:"max_allowed_packet,omitempty"`
-	MaxHeapTableSize             *int     `json:"max_heap_table_size,omitempty"`
-	NetBufferLength              *int     `json:"net_buffer_length,omitempty"`
-	NetReadTimeout               *int     `json:"net_read_timeout,omitempty"`
-	NetWriteTimeout              *int     `json:"net_write_timeout,omitempty"`
-	SortBufferSize               *int     `json:"sort_buffer_size,omitempty"`
-	SQLMode                      *string  `json:"sql_mode,omitempty"`
-	SQLRequirePrimaryKey         *bool    `json:"sql_require_primary_key,omitempty"`
-	TmpTableSize                 *int     `json:"tmp_table_size,omitempty"`
-	WaitTimeout                  *int     `json:"wait_timeout,omitempty"`
+	ConnectTimeout               *int     `json:"connect_timeout,omitzero"`
+	DefaultTimeZone              *string  `json:"default_time_zone,omitzero"`
+	GroupConcatMaxLen            *float64 `json:"group_concat_max_len,omitzero"`
+	InformationSchemaStatsExpiry *int     `json:"information_schema_stats_expiry,omitzero"`
+	InnoDBChangeBufferMaxSize    *int     `json:"innodb_change_buffer_max_size,omitzero"`
+	InnoDBFlushNeighbors         *int     `json:"innodb_flush_neighbors,omitzero"`
+	InnoDBFTMinTokenSize         *int     `json:"innodb_ft_min_token_size,omitzero"`
+	InnoDBFTServerStopwordTable  **string `json:"innodb_ft_server_stopword_table,omitzero"`
+	InnoDBLockWaitTimeout        *int     `json:"innodb_lock_wait_timeout,omitzero"`
+	InnoDBLogBufferSize          *int     `json:"innodb_log_buffer_size,omitzero"`
+	InnoDBOnlineAlterLogMaxSize  *int     `json:"innodb_online_alter_log_max_size,omitzero"`
+	InnoDBReadIOThreads          *int     `json:"innodb_read_io_threads,omitzero"`
+	InnoDBRollbackOnTimeout      *bool    `json:"innodb_rollback_on_timeout,omitzero"`
+	InnoDBThreadConcurrency      *int     `json:"innodb_thread_concurrency,omitzero"`
+	InnoDBWriteIOThreads         *int     `json:"innodb_write_io_threads,omitzero"`
+	InteractiveTimeout           *int     `json:"interactive_timeout,omitzero"`
+	InternalTmpMemStorageEngine  *string  `json:"internal_tmp_mem_storage_engine,omitzero"`
+	MaxAllowedPacket             *int     `json:"max_allowed_packet,omitzero"`
+	MaxHeapTableSize             *int     `json:"max_heap_table_size,omitzero"`
+	NetBufferLength              *int     `json:"net_buffer_length,omitzero"`
+	NetReadTimeout               *int     `json:"net_read_timeout,omitzero"`
+	NetWriteTimeout              *int     `json:"net_write_timeout,omitzero"`
+	SortBufferSize               *int     `json:"sort_buffer_size,omitzero"`
+	SQLMode                      *string  `json:"sql_mode,omitzero"`
+	SQLRequirePrimaryKey         *bool    `json:"sql_require_primary_key,omitzero"`
+	TmpTableSize                 *int     `json:"tmp_table_size,omitzero"`
+	WaitTimeout                  *int     `json:"wait_timeout,omitzero"`
 }
 
 type MySQLDatabaseConfigInfo struct {
@@ -397,24 +397,24 @@ type MySQLCreateOptions struct {
 	Region      string   `json:"region"`
 	Type        string   `json:"type"`
 	Engine      string   `json:"engine"`
-	AllowList   []string `json:"allow_list,omitempty"`
-	ClusterSize int      `json:"cluster_size,omitempty"`
+	AllowList   []string `json:"allow_list,omitzero"`
+	ClusterSize int      `json:"cluster_size,omitzero"`
 
-	Fork           *DatabaseFork              `json:"fork,omitempty"`
-	EngineConfig   *MySQLDatabaseEngineConfig `json:"engine_config,omitempty"`
-	PrivateNetwork *DatabasePrivateNetwork    `json:"private_network,omitempty"`
+	Fork           *DatabaseFork              `json:"fork,omitzero"`
+	EngineConfig   *MySQLDatabaseEngineConfig `json:"engine_config,omitzero"`
+	PrivateNetwork *DatabasePrivateNetwork    `json:"private_network,omitzero"`
 }
 
 // MySQLUpdateOptions fields are used when altering the existing MySQL Database
 type MySQLUpdateOptions struct {
-	Label          string                     `json:"label,omitempty"`
-	AllowList      *[]string                  `json:"allow_list,omitempty"`
-	Updates        *DatabaseMaintenanceWindow `json:"updates,omitempty"`
-	Type           string                     `json:"type,omitempty"`
-	ClusterSize    int                        `json:"cluster_size,omitempty"`
-	Version        string                     `json:"version,omitempty"`
-	EngineConfig   *MySQLDatabaseEngineConfig `json:"engine_config,omitempty"`
-	PrivateNetwork **DatabasePrivateNetwork   `json:"private_network,omitempty"`
+	Label          string                     `json:"label,omitzero"`
+	AllowList      *[]string                  `json:"allow_list,omitzero"`
+	Updates        *DatabaseMaintenanceWindow `json:"updates,omitzero"`
+	Type           string                     `json:"type,omitzero"`
+	ClusterSize    int                        `json:"cluster_size,omitzero"`
+	Version        string                     `json:"version,omitzero"`
+	EngineConfig   *MySQLDatabaseEngineConfig `json:"engine_config,omitzero"`
+	PrivateNetwork **DatabasePrivateNetwork   `json:"private_network,omitzero"`
 }
 
 // MySQLDatabaseCredential is the Root Credentials to access the Linode Managed Database

--- a/network_ips.go
+++ b/network_ips.go
@@ -12,8 +12,8 @@ import (
 //	}
 type IPAddressUpdateOptions struct {
 	// The reverse DNS assigned to this address. For public IPv4 addresses, this will be set to a default value provided by Linode if set to nil.
-	Reserved *bool    `json:"reserved,omitempty"`
-	RDNS     **string `json:"rdns,omitempty"`
+	Reserved *bool    `json:"reserved,omitzero"`
+	RDNS     **string `json:"rdns,omitzero"`
 }
 
 // LinodeIPAssignment stores an assignment between an IP address and a Linode instance.
@@ -25,9 +25,9 @@ type LinodeIPAssignment struct {
 type AllocateReserveIPOptions struct {
 	Type     string `json:"type"`
 	Public   bool   `json:"public"`
-	Reserved bool   `json:"reserved,omitempty"`
-	Region   string `json:"region,omitempty"`
-	LinodeID int    `json:"linode_id,omitempty"`
+	Reserved bool   `json:"reserved,omitzero"`
+	Region   string `json:"region,omitzero"`
+	LinodeID int    `json:"linode_id,omitzero"`
 }
 
 // LinodesAssignIPsOptions fields are those accepted by InstancesAssignIPs.

--- a/network_ranges.go
+++ b/network_ranges.go
@@ -6,9 +6,9 @@ import (
 
 // IPv6RangeCreateOptions fields are those accepted by CreateIPv6Range
 type IPv6RangeCreateOptions struct {
-	LinodeID     int    `json:"linode_id,omitempty"`
+	LinodeID     int    `json:"linode_id,omitzero"`
 	PrefixLength int    `json:"prefix_length"`
-	RouteTarget  string `json:"route_target,omitempty"`
+	RouteTarget  string `json:"route_target,omitzero"`
 }
 
 // ListIPv6Ranges lists IPv6Ranges

--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -57,38 +57,38 @@ type NodeBalancerTransfer struct {
 }
 
 type NodeBalancerVPCOptions struct {
-	IPv4Range           string `json:"ipv4_range,omitempty"`
-	IPv6Range           string `json:"ipv6_range,omitempty"`
+	IPv4Range           string `json:"ipv4_range,omitzero"`
+	IPv6Range           string `json:"ipv6_range,omitzero"`
 	SubnetID            int    `json:"subnet_id"`
-	IPv4RangeAutoAssign bool   `json:"ipv4_range_auto_assign,omitempty"`
+	IPv4RangeAutoAssign bool   `json:"ipv4_range_auto_assign,omitzero"`
 }
 
 // NodeBalancerCreateOptions are the options permitted for CreateNodeBalancer
 type NodeBalancerCreateOptions struct {
-	Label              *string `json:"label,omitempty"`
-	Region             string  `json:"region,omitempty"`
-	ClientConnThrottle *int    `json:"client_conn_throttle,omitempty"`
+	Label              *string `json:"label,omitzero"`
+	Region             string  `json:"region,omitzero"`
+	ClientConnThrottle *int    `json:"client_conn_throttle,omitzero"`
 
 	// NOTE: ClientUDPSessThrottle may not currently be available to all users.
-	ClientUDPSessThrottle *int `json:"client_udp_sess_throttle,omitempty"`
+	ClientUDPSessThrottle *int `json:"client_udp_sess_throttle,omitzero"`
 
-	Configs    []*NodeBalancerConfigCreateOptions `json:"configs,omitempty"`
+	Configs    []*NodeBalancerConfigCreateOptions `json:"configs,omitzero"`
 	Tags       []string                           `json:"tags"`
-	FirewallID int                                `json:"firewall_id,omitempty"`
-	Type       NodeBalancerPlanType               `json:"type,omitempty"`
-	VPCs       []NodeBalancerVPCOptions           `json:"vpcs,omitempty"`
-	IPv4       *string                            `json:"ipv4,omitempty"`
+	FirewallID int                                `json:"firewall_id,omitzero"`
+	Type       NodeBalancerPlanType               `json:"type,omitzero"`
+	VPCs       []NodeBalancerVPCOptions           `json:"vpcs,omitzero"`
+	IPv4       *string                            `json:"ipv4,omitzero"`
 }
 
 // NodeBalancerUpdateOptions are the options permitted for UpdateNodeBalancer
 type NodeBalancerUpdateOptions struct {
-	Label              *string `json:"label,omitempty"`
-	ClientConnThrottle *int    `json:"client_conn_throttle,omitempty"`
+	Label              *string `json:"label,omitzero"`
+	ClientConnThrottle *int    `json:"client_conn_throttle,omitzero"`
 
 	// NOTE: ClientUDPSessThrottle may not currently be available to all users.
-	ClientUDPSessThrottle *int `json:"client_udp_sess_throttle,omitempty"`
+	ClientUDPSessThrottle *int `json:"client_udp_sess_throttle,omitzero"`
 
-	Tags *[]string `json:"tags,omitempty"`
+	Tags *[]string `json:"tags,omitzero"`
 }
 
 // NodeBalancerPlanType constants start with NBType and include Linode API NodeBalancer's plan types

--- a/nodebalancer_config_nodes.go
+++ b/nodebalancer_config_nodes.go
@@ -38,18 +38,18 @@ var (
 type NodeBalancerNodeCreateOptions struct {
 	Address  string   `json:"address"`
 	Label    string   `json:"label"`
-	Weight   int      `json:"weight,omitempty"`
-	Mode     NodeMode `json:"mode,omitempty"`
-	SubnetID int      `json:"subnet_id,omitempty"`
+	Weight   int      `json:"weight,omitzero"`
+	Mode     NodeMode `json:"mode,omitzero"`
+	SubnetID int      `json:"subnet_id,omitzero"`
 }
 
 // NodeBalancerNodeUpdateOptions fields are those accepted by UpdateNodeBalancerNode
 type NodeBalancerNodeUpdateOptions struct {
-	Address  string   `json:"address,omitempty"`
-	Label    string   `json:"label,omitempty"`
-	Weight   int      `json:"weight,omitempty"`
-	Mode     NodeMode `json:"mode,omitempty"`
-	SubnetID int      `json:"subnet_id,omitempty"`
+	Address  string   `json:"address,omitzero"`
+	Label    string   `json:"label,omitzero"`
+	Weight   int      `json:"weight,omitzero"`
+	Mode     NodeMode `json:"mode,omitzero"`
+	SubnetID int      `json:"subnet_id,omitzero"`
 }
 
 // GetCreateOptions converts a NodeBalancerNode to NodeBalancerNodeCreateOptions for use in CreateNodeBalancerNode

--- a/nodebalancer_config_vpc.go
+++ b/nodebalancer_config_vpc.go
@@ -10,7 +10,7 @@ import (
 type NodeBalancerVPCConfig struct {
 	ID             int    `json:"id"`
 	IPv4Range      string `json:"ipv4_range"`
-	IPv6Range      string `json:"ipv6_range,omitempty"`
+	IPv6Range      string `json:"ipv6_range,omitzero"`
 	NodeBalancerID int    `json:"nodebalancer_id"`
 	SubnetID       int    `json:"subnet_id"`
 	VPCID          int    `json:"vpc_id"`

--- a/nodebalancer_configs.go
+++ b/nodebalancer_configs.go
@@ -108,48 +108,48 @@ type NodeBalancerNodeStatus struct {
 // NodeBalancerConfigCreateOptions are permitted by CreateNodeBalancerConfig
 type NodeBalancerConfigCreateOptions struct {
 	Port          int                 `json:"port"`
-	Protocol      ConfigProtocol      `json:"protocol,omitempty"`
-	ProxyProtocol ConfigProxyProtocol `json:"proxy_protocol,omitempty"`
-	Algorithm     ConfigAlgorithm     `json:"algorithm,omitempty"`
-	Stickiness    ConfigStickiness    `json:"stickiness,omitempty"`
-	Check         ConfigCheck         `json:"check,omitempty"`
-	CheckInterval int                 `json:"check_interval,omitempty"`
-	CheckAttempts int                 `json:"check_attempts,omitempty"`
-	CheckPath     string              `json:"check_path,omitempty"`
-	CheckBody     string              `json:"check_body,omitempty"`
-	CheckPassive  *bool               `json:"check_passive,omitempty"`
-	CheckTimeout  int                 `json:"check_timeout,omitempty"`
+	Protocol      ConfigProtocol      `json:"protocol,omitzero"`
+	ProxyProtocol ConfigProxyProtocol `json:"proxy_protocol,omitzero"`
+	Algorithm     ConfigAlgorithm     `json:"algorithm,omitzero"`
+	Stickiness    ConfigStickiness    `json:"stickiness,omitzero"`
+	Check         ConfigCheck         `json:"check,omitzero"`
+	CheckInterval int                 `json:"check_interval,omitzero"`
+	CheckAttempts int                 `json:"check_attempts,omitzero"`
+	CheckPath     string              `json:"check_path,omitzero"`
+	CheckBody     string              `json:"check_body,omitzero"`
+	CheckPassive  *bool               `json:"check_passive,omitzero"`
+	CheckTimeout  int                 `json:"check_timeout,omitzero"`
 
 	// NOTE: UDPCheckPort may not currently be available to all users.
-	UDPCheckPort *int `json:"udp_check_port,omitempty"`
+	UDPCheckPort *int `json:"udp_check_port,omitzero"`
 
-	CipherSuite ConfigCipher                    `json:"cipher_suite,omitempty"`
-	SSLCert     string                          `json:"ssl_cert,omitempty"`
-	SSLKey      string                          `json:"ssl_key,omitempty"`
-	Nodes       []NodeBalancerNodeCreateOptions `json:"nodes,omitempty"`
+	CipherSuite ConfigCipher                    `json:"cipher_suite,omitzero"`
+	SSLCert     string                          `json:"ssl_cert,omitzero"`
+	SSLKey      string                          `json:"ssl_key,omitzero"`
+	Nodes       []NodeBalancerNodeCreateOptions `json:"nodes,omitzero"`
 }
 
 // NodeBalancerConfigRebuildOptions used by RebuildNodeBalancerConfig
 type NodeBalancerConfigRebuildOptions struct {
 	Port          int                 `json:"port"`
-	Protocol      ConfigProtocol      `json:"protocol,omitempty"`
-	ProxyProtocol ConfigProxyProtocol `json:"proxy_protocol,omitempty"`
-	Algorithm     ConfigAlgorithm     `json:"algorithm,omitempty"`
-	Stickiness    ConfigStickiness    `json:"stickiness,omitempty"`
-	Check         ConfigCheck         `json:"check,omitempty"`
-	CheckInterval int                 `json:"check_interval,omitempty"`
-	CheckAttempts int                 `json:"check_attempts,omitempty"`
-	CheckPath     string              `json:"check_path,omitempty"`
-	CheckBody     string              `json:"check_body,omitempty"`
-	CheckPassive  *bool               `json:"check_passive,omitempty"`
-	CheckTimeout  int                 `json:"check_timeout,omitempty"`
+	Protocol      ConfigProtocol      `json:"protocol,omitzero"`
+	ProxyProtocol ConfigProxyProtocol `json:"proxy_protocol,omitzero"`
+	Algorithm     ConfigAlgorithm     `json:"algorithm,omitzero"`
+	Stickiness    ConfigStickiness    `json:"stickiness,omitzero"`
+	Check         ConfigCheck         `json:"check,omitzero"`
+	CheckInterval int                 `json:"check_interval,omitzero"`
+	CheckAttempts int                 `json:"check_attempts,omitzero"`
+	CheckPath     string              `json:"check_path,omitzero"`
+	CheckBody     string              `json:"check_body,omitzero"`
+	CheckPassive  *bool               `json:"check_passive,omitzero"`
+	CheckTimeout  int                 `json:"check_timeout,omitzero"`
 
 	// NOTE: UDPCheckPort may not currently be available to all users.
-	UDPCheckPort *int `json:"udp_check_port,omitempty"`
+	UDPCheckPort *int `json:"udp_check_port,omitzero"`
 
-	CipherSuite ConfigCipher                           `json:"cipher_suite,omitempty"`
-	SSLCert     string                                 `json:"ssl_cert,omitempty"`
-	SSLKey      string                                 `json:"ssl_key,omitempty"`
+	CipherSuite ConfigCipher                           `json:"cipher_suite,omitzero"`
+	SSLCert     string                                 `json:"ssl_cert,omitzero"`
+	SSLKey      string                                 `json:"ssl_key,omitzero"`
 	Nodes       []NodeBalancerConfigRebuildNodeOptions `json:"nodes"`
 }
 
@@ -158,7 +158,7 @@ type NodeBalancerConfigRebuildOptions struct {
 type NodeBalancerConfigRebuildNodeOptions struct {
 	NodeBalancerNodeCreateOptions
 
-	ID int `json:"id,omitempty"`
+	ID int `json:"id,omitzero"`
 }
 
 // NodeBalancerConfigUpdateOptions are permitted by UpdateNodeBalancerConfig

--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -70,20 +70,20 @@ func (i *ObjectStorageBucket) UnmarshalJSON(b []byte) error {
 
 // ObjectStorageBucketCreateOptions fields are those accepted by CreateObjectStorageBucket
 type ObjectStorageBucketCreateOptions struct {
-	Region string `json:"region,omitempty"`
+	Region string `json:"region,omitzero"`
 
 	Label        string                    `json:"label"`
-	S3Endpoint   string                    `json:"s3_endpoint,omitempty"`
-	EndpointType ObjectStorageEndpointType `json:"endpoint_type,omitempty"`
+	S3Endpoint   string                    `json:"s3_endpoint,omitzero"`
+	EndpointType ObjectStorageEndpointType `json:"endpoint_type,omitzero"`
 
-	ACL         ObjectStorageACL `json:"acl,omitempty"`
-	CorsEnabled *bool            `json:"cors_enabled,omitempty"`
+	ACL         ObjectStorageACL `json:"acl,omitzero"`
+	CorsEnabled *bool            `json:"cors_enabled,omitzero"`
 }
 
 // ObjectStorageBucketUpdateAccessOptions fields are those accepted by UpdateObjectStorageBucketAccess
 type ObjectStorageBucketUpdateAccessOptions struct {
-	ACL         ObjectStorageACL `json:"acl,omitempty"`
-	CorsEnabled *bool            `json:"cors_enabled,omitempty"`
+	ACL         ObjectStorageACL `json:"acl,omitzero"`
+	CorsEnabled *bool            `json:"cors_enabled,omitzero"`
 }
 
 // ObjectStorageBucketListContentsParams fields are the query parameters for ListObjectStorageBucketContents

--- a/object_storage_keys.go
+++ b/object_storage_keys.go
@@ -23,7 +23,7 @@ type ObjectStorageKey struct {
 
 // ObjectStorageKeyBucketAccess represents a linode limited object storage key's bucket access
 type ObjectStorageKeyBucketAccess struct {
-	Region string `json:"region,omitempty"`
+	Region string `json:"region,omitzero"`
 
 	BucketName  string `json:"bucket_name"`
 	Permissions string `json:"permissions"`
@@ -32,14 +32,14 @@ type ObjectStorageKeyBucketAccess struct {
 // ObjectStorageKeyCreateOptions fields are those accepted by CreateObjectStorageKey
 type ObjectStorageKeyCreateOptions struct {
 	Label        string                          `json:"label"`
-	BucketAccess *[]ObjectStorageKeyBucketAccess `json:"bucket_access,omitempty"`
-	Regions      []string                        `json:"regions,omitempty"`
+	BucketAccess *[]ObjectStorageKeyBucketAccess `json:"bucket_access,omitzero"`
+	Regions      []string                        `json:"regions,omitzero"`
 }
 
 // ObjectStorageKeyUpdateOptions fields are those accepted by UpdateObjectStorageKey
 type ObjectStorageKeyUpdateOptions struct {
-	Label   string   `json:"label,omitempty"`
-	Regions []string `json:"regions,omitempty"`
+	Label   string   `json:"label,omitzero"`
+	Regions []string `json:"regions,omitzero"`
 }
 
 // ListObjectStorageKeys lists ObjectStorageKeys

--- a/object_storage_object.go
+++ b/object_storage_object.go
@@ -7,9 +7,9 @@ import (
 type ObjectStorageObjectURLCreateOptions struct {
 	Name               string `json:"name"`
 	Method             string `json:"method"`
-	ContentType        string `json:"content_type,omitempty"`
-	ContentDisposition string `json:"content_disposition,omitempty"`
-	ExpiresIn          *int   `json:"expires_in,omitempty"`
+	ContentType        string `json:"content_type,omitzero"`
+	ContentDisposition string `json:"content_disposition,omitzero"`
+	ExpiresIn          *int   `json:"expires_in,omitzero"`
 }
 
 type ObjectStorageObjectURL struct {

--- a/pagination.go
+++ b/pagination.go
@@ -16,9 +16,9 @@ import (
 
 // PageOptions are the pagination parameters for List endpoints
 type PageOptions struct {
-	Page    int `json:"page"    url:"page,omitempty"`
-	Pages   int `json:"pages"   url:"pages,omitempty"`
-	Results int `json:"results" url:"results,omitempty"`
+	Page    int `json:"page"    url:"page,omitzero"`
+	Pages   int `json:"pages"   url:"pages,omitzero"`
+	Results int `json:"results" url:"results,omitzero"`
 }
 
 // ListOptions are the pagination and filtering (TODO) parameters for endpoints

--- a/pagination.go
+++ b/pagination.go
@@ -16,9 +16,9 @@ import (
 
 // PageOptions are the pagination parameters for List endpoints
 type PageOptions struct {
-	Page    int `json:"page"    url:"page,omitzero"`
-	Pages   int `json:"pages"   url:"pages,omitzero"`
-	Results int `json:"results" url:"results,omitzero"`
+	Page    int `json:"page"`
+	Pages   int `json:"pages"`
+	Results int `json:"results"`
 }
 
 // ListOptions are the pagination and filtering (TODO) parameters for endpoints

--- a/placement_groups.go
+++ b/placement_groups.go
@@ -61,14 +61,14 @@ type PlacementGroupCreateOptions struct {
 // PlacementGroupUpdateOptions represents the options to use
 // when updating a placement group.
 type PlacementGroupUpdateOptions struct {
-	Label string `json:"label,omitempty"`
+	Label string `json:"label,omitzero"`
 }
 
 // PlacementGroupAssignOptions represents options used when
 // assigning Linodes to a placement group.
 type PlacementGroupAssignOptions struct {
 	Linodes       []int `json:"linodes"`
-	CompliantOnly *bool `json:"compliant_only,omitempty"`
+	CompliantOnly *bool `json:"compliant_only,omitzero"`
 }
 
 // PlacementGroupUnAssignOptions represents options used when

--- a/postgres.go
+++ b/postgres.go
@@ -62,65 +62,65 @@ type PostgresDatabase struct {
 	UsedDiskSizeGB    int                          `json:"used_disk_size_gb"`
 	TotalDiskSizeGB   int                          `json:"total_disk_size_gb"`
 	EngineConfig      PostgresDatabaseEngineConfig `json:"engine_config"`
-	PrivateNetwork    *DatabasePrivateNetwork      `json:"private_network,omitempty"`
+	PrivateNetwork    *DatabasePrivateNetwork      `json:"private_network,omitzero"`
 }
 
 type PostgresDatabaseEngineConfig struct {
-	PG                      *PostgresDatabaseEngineConfigPG        `json:"pg,omitempty"`
-	PGStatMonitorEnable     *bool                                  `json:"pg_stat_monitor_enable,omitempty"`
-	PGLookout               *PostgresDatabaseEngineConfigPGLookout `json:"pglookout,omitempty"`
-	SharedBuffersPercentage *float64                               `json:"shared_buffers_percentage,omitempty"`
-	WorkMem                 *int                                   `json:"work_mem,omitempty"`
+	PG                      *PostgresDatabaseEngineConfigPG        `json:"pg,omitzero"`
+	PGStatMonitorEnable     *bool                                  `json:"pg_stat_monitor_enable,omitzero"`
+	PGLookout               *PostgresDatabaseEngineConfigPGLookout `json:"pglookout,omitzero"`
+	SharedBuffersPercentage *float64                               `json:"shared_buffers_percentage,omitzero"`
+	WorkMem                 *int                                   `json:"work_mem,omitzero"`
 }
 
 type PostgresDatabaseEngineConfigPG struct {
-	AutovacuumAnalyzeScaleFactor     *float64 `json:"autovacuum_analyze_scale_factor,omitempty"`
-	AutovacuumAnalyzeThreshold       *int32   `json:"autovacuum_analyze_threshold,omitempty"`
-	AutovacuumMaxWorkers             *int     `json:"autovacuum_max_workers,omitempty"`
-	AutovacuumNaptime                *int     `json:"autovacuum_naptime,omitempty"`
-	AutovacuumVacuumCostDelay        *int     `json:"autovacuum_vacuum_cost_delay,omitempty"`
-	AutovacuumVacuumCostLimit        *int     `json:"autovacuum_vacuum_cost_limit,omitempty"`
-	AutovacuumVacuumScaleFactor      *float64 `json:"autovacuum_vacuum_scale_factor,omitempty"`
-	AutovacuumVacuumThreshold        *int32   `json:"autovacuum_vacuum_threshold,omitempty"`
-	BGWriterDelay                    *int     `json:"bgwriter_delay,omitempty"`
-	BGWriterFlushAfter               *int     `json:"bgwriter_flush_after,omitempty"`
-	BGWriterLRUMaxPages              *int     `json:"bgwriter_lru_maxpages,omitempty"`
-	BGWriterLRUMultiplier            *float64 `json:"bgwriter_lru_multiplier,omitempty"`
-	DeadlockTimeout                  *int     `json:"deadlock_timeout,omitempty"`
-	DefaultToastCompression          *string  `json:"default_toast_compression,omitempty"`
-	IdleInTransactionSessionTimeout  *int     `json:"idle_in_transaction_session_timeout,omitempty"`
-	JIT                              *bool    `json:"jit,omitempty"`
-	MaxFilesPerProcess               *int     `json:"max_files_per_process,omitempty"`
-	MaxLocksPerTransaction           *int     `json:"max_locks_per_transaction,omitempty"`
-	MaxLogicalReplicationWorkers     *int     `json:"max_logical_replication_workers,omitempty"`
-	MaxParallelWorkers               *int     `json:"max_parallel_workers,omitempty"`
-	MaxParallelWorkersPerGather      *int     `json:"max_parallel_workers_per_gather,omitempty"`
-	MaxPredLocksPerTransaction       *int     `json:"max_pred_locks_per_transaction,omitempty"`
-	MaxReplicationSlots              *int     `json:"max_replication_slots,omitempty"`
-	MaxSlotWALKeepSize               *int32   `json:"max_slot_wal_keep_size,omitempty"`
-	MaxStackDepth                    *int     `json:"max_stack_depth,omitempty"`
-	MaxStandbyArchiveDelay           *int     `json:"max_standby_archive_delay,omitempty"`
-	MaxStandbyStreamingDelay         *int     `json:"max_standby_streaming_delay,omitempty"`
-	MaxWALSenders                    *int     `json:"max_wal_senders,omitempty"`
-	MaxWorkerProcesses               *int     `json:"max_worker_processes,omitempty"`
-	PasswordEncryption               *string  `json:"password_encryption,omitempty"`
-	PGPartmanBGWInterval             *int     `json:"pg_partman_bgw.interval,omitempty"`
-	PGPartmanBGWRole                 *string  `json:"pg_partman_bgw.role,omitempty"`
-	PGStatMonitorPGSMEnableQueryPlan *bool    `json:"pg_stat_monitor.pgsm_enable_query_plan,omitempty"`
-	PGStatMonitorPGSMMaxBuckets      *int     `json:"pg_stat_monitor.pgsm_max_buckets,omitempty"`
-	PGStatStatementsTrack            *string  `json:"pg_stat_statements.track,omitempty"`
-	TempFileLimit                    *int32   `json:"temp_file_limit,omitempty"`
-	Timezone                         *string  `json:"timezone,omitempty"`
-	TrackActivityQuerySize           *int     `json:"track_activity_query_size,omitempty"`
-	TrackCommitTimestamp             *string  `json:"track_commit_timestamp,omitempty"`
-	TrackFunctions                   *string  `json:"track_functions,omitempty"`
-	TrackIOTiming                    *string  `json:"track_io_timing,omitempty"`
-	WALSenderTimeout                 *int     `json:"wal_sender_timeout,omitempty"`
-	WALWriterDelay                   *int     `json:"wal_writer_delay,omitempty"`
+	AutovacuumAnalyzeScaleFactor     *float64 `json:"autovacuum_analyze_scale_factor,omitzero"`
+	AutovacuumAnalyzeThreshold       *int32   `json:"autovacuum_analyze_threshold,omitzero"`
+	AutovacuumMaxWorkers             *int     `json:"autovacuum_max_workers,omitzero"`
+	AutovacuumNaptime                *int     `json:"autovacuum_naptime,omitzero"`
+	AutovacuumVacuumCostDelay        *int     `json:"autovacuum_vacuum_cost_delay,omitzero"`
+	AutovacuumVacuumCostLimit        *int     `json:"autovacuum_vacuum_cost_limit,omitzero"`
+	AutovacuumVacuumScaleFactor      *float64 `json:"autovacuum_vacuum_scale_factor,omitzero"`
+	AutovacuumVacuumThreshold        *int32   `json:"autovacuum_vacuum_threshold,omitzero"`
+	BGWriterDelay                    *int     `json:"bgwriter_delay,omitzero"`
+	BGWriterFlushAfter               *int     `json:"bgwriter_flush_after,omitzero"`
+	BGWriterLRUMaxPages              *int     `json:"bgwriter_lru_maxpages,omitzero"`
+	BGWriterLRUMultiplier            *float64 `json:"bgwriter_lru_multiplier,omitzero"`
+	DeadlockTimeout                  *int     `json:"deadlock_timeout,omitzero"`
+	DefaultToastCompression          *string  `json:"default_toast_compression,omitzero"`
+	IdleInTransactionSessionTimeout  *int     `json:"idle_in_transaction_session_timeout,omitzero"`
+	JIT                              *bool    `json:"jit,omitzero"`
+	MaxFilesPerProcess               *int     `json:"max_files_per_process,omitzero"`
+	MaxLocksPerTransaction           *int     `json:"max_locks_per_transaction,omitzero"`
+	MaxLogicalReplicationWorkers     *int     `json:"max_logical_replication_workers,omitzero"`
+	MaxParallelWorkers               *int     `json:"max_parallel_workers,omitzero"`
+	MaxParallelWorkersPerGather      *int     `json:"max_parallel_workers_per_gather,omitzero"`
+	MaxPredLocksPerTransaction       *int     `json:"max_pred_locks_per_transaction,omitzero"`
+	MaxReplicationSlots              *int     `json:"max_replication_slots,omitzero"`
+	MaxSlotWALKeepSize               *int32   `json:"max_slot_wal_keep_size,omitzero"`
+	MaxStackDepth                    *int     `json:"max_stack_depth,omitzero"`
+	MaxStandbyArchiveDelay           *int     `json:"max_standby_archive_delay,omitzero"`
+	MaxStandbyStreamingDelay         *int     `json:"max_standby_streaming_delay,omitzero"`
+	MaxWALSenders                    *int     `json:"max_wal_senders,omitzero"`
+	MaxWorkerProcesses               *int     `json:"max_worker_processes,omitzero"`
+	PasswordEncryption               *string  `json:"password_encryption,omitzero"`
+	PGPartmanBGWInterval             *int     `json:"pg_partman_bgw.interval,omitzero"`
+	PGPartmanBGWRole                 *string  `json:"pg_partman_bgw.role,omitzero"`
+	PGStatMonitorPGSMEnableQueryPlan *bool    `json:"pg_stat_monitor.pgsm_enable_query_plan,omitzero"`
+	PGStatMonitorPGSMMaxBuckets      *int     `json:"pg_stat_monitor.pgsm_max_buckets,omitzero"`
+	PGStatStatementsTrack            *string  `json:"pg_stat_statements.track,omitzero"`
+	TempFileLimit                    *int32   `json:"temp_file_limit,omitzero"`
+	Timezone                         *string  `json:"timezone,omitzero"`
+	TrackActivityQuerySize           *int     `json:"track_activity_query_size,omitzero"`
+	TrackCommitTimestamp             *string  `json:"track_commit_timestamp,omitzero"`
+	TrackFunctions                   *string  `json:"track_functions,omitzero"`
+	TrackIOTiming                    *string  `json:"track_io_timing,omitzero"`
+	WALSenderTimeout                 *int     `json:"wal_sender_timeout,omitzero"`
+	WALWriterDelay                   *int     `json:"wal_writer_delay,omitzero"`
 }
 
 type PostgresDatabaseEngineConfigPGLookout struct {
-	MaxFailoverReplicationTimeLag *int64 `json:"max_failover_replication_time_lag,omitempty"`
+	MaxFailoverReplicationTimeLag *int64 `json:"max_failover_replication_time_lag,omitzero"`
 }
 
 type PostgresDatabaseConfigInfo struct {
@@ -594,25 +594,25 @@ type PostgresCreateOptions struct {
 	Region      string   `json:"region"`
 	Type        string   `json:"type"`
 	Engine      string   `json:"engine"`
-	AllowList   []string `json:"allow_list,omitempty"`
-	ClusterSize int      `json:"cluster_size,omitempty"`
+	AllowList   []string `json:"allow_list,omitzero"`
+	ClusterSize int      `json:"cluster_size,omitzero"`
 
-	Fork *DatabaseFork `json:"fork,omitempty"`
+	Fork *DatabaseFork `json:"fork,omitzero"`
 
-	EngineConfig   *PostgresDatabaseEngineConfig `json:"engine_config,omitempty"`
-	PrivateNetwork *DatabasePrivateNetwork       `json:"private_network,omitempty"`
+	EngineConfig   *PostgresDatabaseEngineConfig `json:"engine_config,omitzero"`
+	PrivateNetwork *DatabasePrivateNetwork       `json:"private_network,omitzero"`
 }
 
 // PostgresUpdateOptions fields are used when altering the existing Postgres Database
 type PostgresUpdateOptions struct {
-	Label          string                        `json:"label,omitempty"`
-	AllowList      *[]string                     `json:"allow_list,omitempty"`
-	Updates        *DatabaseMaintenanceWindow    `json:"updates,omitempty"`
-	Type           string                        `json:"type,omitempty"`
-	ClusterSize    int                           `json:"cluster_size,omitempty"`
-	Version        string                        `json:"version,omitempty"`
-	EngineConfig   *PostgresDatabaseEngineConfig `json:"engine_config,omitempty"`
-	PrivateNetwork *DatabasePrivateNetwork       `json:"private_network,omitempty"`
+	Label          string                        `json:"label,omitzero"`
+	AllowList      *[]string                     `json:"allow_list,omitzero"`
+	Updates        *DatabaseMaintenanceWindow    `json:"updates,omitzero"`
+	Type           string                        `json:"type,omitzero"`
+	ClusterSize    int                           `json:"cluster_size,omitzero"`
+	Version        string                        `json:"version,omitzero"`
+	EngineConfig   *PostgresDatabaseEngineConfig `json:"engine_config,omitzero"`
+	PrivateNetwork *DatabasePrivateNetwork       `json:"private_network,omitzero"`
 }
 
 // PostgresDatabaseSSL is the SSL Certificate to access the Linode Managed Postgres Database

--- a/profile.go
+++ b/profile.go
@@ -38,19 +38,19 @@ type Profile struct {
 	Referrals           ProfileReferrals `json:"referrals"`
 	AuthorizedKeys      []string         `json:"authorized_keys"`
 	AuthenticationType  string           `json:"authentication_type"`
-	VerifiedPhoneNumber string           `json:"verified_phone_number,omitempty"`
+	VerifiedPhoneNumber string           `json:"verified_phone_number,omitzero"`
 }
 
 // ProfileUpdateOptions fields are those accepted by UpdateProfile
 type ProfileUpdateOptions struct {
-	Email              string         `json:"email,omitempty"`
-	Timezone           string         `json:"timezone,omitempty"`
-	EmailNotifications *bool          `json:"email_notifications,omitempty"`
-	IPWhitelistEnabled *bool          `json:"ip_whitelist_enabled,omitempty"`
-	LishAuthMethod     LishAuthMethod `json:"lish_auth_method,omitempty"`
-	AuthorizedKeys     *[]string      `json:"authorized_keys,omitempty"`
-	TwoFactorAuth      *bool          `json:"two_factor_auth,omitempty"`
-	Restricted         *bool          `json:"restricted,omitempty"`
+	Email              string         `json:"email,omitzero"`
+	Timezone           string         `json:"timezone,omitzero"`
+	EmailNotifications *bool          `json:"email_notifications,omitzero"`
+	IPWhitelistEnabled *bool          `json:"ip_whitelist_enabled,omitzero"`
+	LishAuthMethod     LishAuthMethod `json:"lish_auth_method,omitzero"`
+	AuthorizedKeys     *[]string      `json:"authorized_keys,omitzero"`
+	TwoFactorAuth      *bool          `json:"two_factor_auth,omitzero"`
+	Restricted         *bool          `json:"restricted,omitzero"`
 }
 
 // GetUpdateOptions converts a Profile to ProfileUpdateOptions for use in UpdateProfile

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -13,9 +13,9 @@ import (
 // paginatedResponse represents a single response from a paginated
 // endpoint.
 type paginatedResponse[T any] struct {
-	Page    int `json:"page"    url:"page,omitempty"`
-	Pages   int `json:"pages"   url:"pages,omitempty"`
-	Results int `json:"results" url:"results,omitempty"`
+	Page    int `json:"page"    url:"page,omitzero"`
+	Pages   int `json:"pages"   url:"pages,omitzero"`
+	Results int `json:"results" url:"results,omitzero"`
 	Data    []T `json:"data"`
 }
 

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -13,9 +13,9 @@ import (
 // paginatedResponse represents a single response from a paginated
 // endpoint.
 type paginatedResponse[T any] struct {
-	Page    int `json:"page"    url:"page,omitzero"`
-	Pages   int `json:"pages"   url:"pages,omitzero"`
-	Results int `json:"results" url:"results,omitzero"`
+	Page    int `json:"page"`
+	Pages   int `json:"pages"`
+	Results int `json:"results"`
 	Data    []T `json:"data"`
 }
 

--- a/stackscripts.go
+++ b/stackscripts.go
@@ -41,13 +41,13 @@ type StackscriptUDF struct {
 	Example string `json:"example"`
 
 	// A list of acceptable single values for the field.
-	OneOf string `json:"oneOf,omitempty"`
+	OneOf string `json:"oneOf,omitzero"`
 
 	// A list of acceptable values for the field in any quantity, combination or order.
-	ManyOf string `json:"manyOf,omitempty"`
+	ManyOf string `json:"manyOf,omitzero"`
 
 	// The default value. If not specified, this value will be used.
-	Default string `json:"default,omitempty"`
+	Default string `json:"default,omitzero"`
 }
 
 // StackscriptCreateOptions fields are those accepted by CreateStackscript

--- a/tags.go
+++ b/tags.go
@@ -36,12 +36,12 @@ type TaggedObjectList []TaggedObject
 // TagCreateOptions fields are those accepted by CreateTag
 type TagCreateOptions struct {
 	Label   string `json:"label"`
-	Linodes []int  `json:"linodes,omitempty"`
+	Linodes []int  `json:"linodes,omitzero"`
 	// @TODO is this implemented?
-	LKEClusters   []int `json:"lke_clusters,omitempty"`
-	Domains       []int `json:"domains,omitempty"`
-	Volumes       []int `json:"volumes,omitempty"`
-	NodeBalancers []int `json:"nodebalancers,omitempty"`
+	LKEClusters   []int `json:"lke_clusters,omitzero"`
+	Domains       []int `json:"domains,omitzero"`
+	Volumes       []int `json:"volumes,omitzero"`
+	NodeBalancers []int `json:"nodebalancers,omitzero"`
 }
 
 // GetCreateOptions converts a Tag to TagCreateOptions for use in CreateTag

--- a/volumes.go
+++ b/volumes.go
@@ -45,29 +45,29 @@ type Volume struct {
 
 // VolumeCreateOptions fields are those accepted by CreateVolume
 type VolumeCreateOptions struct {
-	Label    string `json:"label,omitempty"`
-	Region   string `json:"region,omitempty"`
-	LinodeID int    `json:"linode_id,omitempty"`
-	ConfigID int    `json:"config_id,omitempty"`
+	Label    string `json:"label,omitzero"`
+	Region   string `json:"region,omitzero"`
+	LinodeID int    `json:"linode_id,omitzero"`
+	ConfigID int    `json:"config_id,omitzero"`
 	// The Volume's size, in GiB. Minimum size is 10GiB, maximum size is 10240GiB. A "0" value will result in the default size.
-	Size int `json:"size,omitempty"`
+	Size int `json:"size,omitzero"`
 	// An array of tags applied to this object. Tags are for organizational purposes only.
 	Tags               []string `json:"tags"`
-	PersistAcrossBoots *bool    `json:"persist_across_boots,omitempty"`
-	Encryption         string   `json:"encryption,omitempty"`
+	PersistAcrossBoots *bool    `json:"persist_across_boots,omitzero"`
+	Encryption         string   `json:"encryption,omitzero"`
 }
 
 // VolumeUpdateOptions fields are those accepted by UpdateVolume
 type VolumeUpdateOptions struct {
-	Label string    `json:"label,omitempty"`
-	Tags  *[]string `json:"tags,omitempty"`
+	Label string    `json:"label,omitzero"`
+	Tags  *[]string `json:"tags,omitzero"`
 }
 
 // VolumeAttachOptions fields are those accepted by AttachVolume
 type VolumeAttachOptions struct {
 	LinodeID           int   `json:"linode_id"`
-	ConfigID           int   `json:"config_id,omitempty"`
-	PersistAcrossBoots *bool `json:"persist_across_boots,omitempty"`
+	ConfigID           int   `json:"config_id,omitzero"`
+	PersistAcrossBoots *bool `json:"persist_across_boots,omitzero"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface

--- a/vpc.go
+++ b/vpc.go
@@ -30,26 +30,26 @@ type VPCIPv6Range struct {
 
 type VPCCreateOptions struct {
 	Label       string `json:"label"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitzero"`
 	Region      string `json:"region"`
 
 	// NOTE: IPv6 VPCs may not currently be available to all users.
-	IPv6 []VPCCreateOptionsIPv6 `json:"ipv6,omitempty"`
+	IPv6 []VPCCreateOptionsIPv6 `json:"ipv6,omitzero"`
 
-	Subnets []VPCSubnetCreateOptions `json:"subnets,omitempty"`
+	Subnets []VPCSubnetCreateOptions `json:"subnets,omitzero"`
 }
 
 // VPCCreateOptionsIPv6 represents a single IPv6 range assigned to a VPC
 // which is specified during a VPC's creation.
 // NOTE: IPv6 VPCs may not currently be available to all users.
 type VPCCreateOptionsIPv6 struct {
-	Range           *string `json:"range,omitempty"`
-	AllocationClass *string `json:"allocation_class,omitempty"`
+	Range           *string `json:"range,omitzero"`
+	AllocationClass *string `json:"allocation_class,omitzero"`
 }
 
 type VPCUpdateOptions struct {
-	Label       string `json:"label,omitempty"`
-	Description string `json:"description,omitempty"`
+	Label       string `json:"label,omitzero"`
+	Description string `json:"description,omitzero"`
 }
 
 func (v VPC) GetCreateOptions() VPCCreateOptions {

--- a/vpc_subnet.go
+++ b/vpc_subnet.go
@@ -62,14 +62,14 @@ type VPCSubnetCreateOptions struct {
 	IPv4  string `json:"ipv4"`
 
 	// NOTE: IPv6 VPCs may not currently be available to all users.
-	IPv6 []VPCSubnetCreateOptionsIPv6 `json:"ipv6,omitempty"`
+	IPv6 []VPCSubnetCreateOptionsIPv6 `json:"ipv6,omitzero"`
 }
 
 // VPCSubnetCreateOptionsIPv6 represents a single IPv6 range assigned to a VPC
 // which is specified during a VPC subnet's creation.
 // NOTE: IPv6 VPCs may not currently be available to all users.
 type VPCSubnetCreateOptionsIPv6 struct {
-	Range *string `json:"range,omitempty"`
+	Range *string `json:"range,omitzero"`
 }
 
 type VPCSubnetUpdateOptions struct {


### PR DESCRIPTION
## Description
Migrates SDK JSON struct tags from `omitempty` to Go 1.24's `omitzero`.

### Motivation & Behavior Change
* **Precise Slice Omission:** **(breaking change)** Historically, `omitempty` dropped both uninitialized (`nil`) slices and explicitly initialized empty slices (e.g., `[]string{}`). `omitzero` fixes this by evaluating the true zero value. Uninitialized `nil` slices are omitted, while initialized empty slices are intentionally sent as `[]` in the JSON payload, allowing us to explicitly clear lists in the Linode API.
* **True Zero-Value & Custom `IsZero` Support:** `omitzero` guarantees accurate zero-value evaluation across all fields rather than just checking for "emptiness". Furthermore, it respects types that implement the `IsZero() bool` interface, giving us robust, exact control over the omission logic for custom SDK types without needing to rely on arbitrary pointer wrappers.
* **Drop `url` tag:** The `url` tag in pagination structs are not known to be consume by another other software. This PR propose dropping them to cleanup the codebase and avoid any future confusion.

### Testing

```bash
make test-unit
```

```bash
make test-int
```