### PR TITLE
TPT-3391: Added distinction between Object Storage Bucket Access POST/PUT endpoints

### DIFF
--- a/object_storage_buckets.go
+++ b/object_storage_buckets.go
@@ -80,6 +80,12 @@ type ObjectStorageBucketCreateOptions struct {
 	CorsEnabled *bool            `json:"cors_enabled,omitzero"`
 }
 
+// ObjectStorageBucketModifyAccessOptions fields are those accepted by ModifyObjectStorageBucketAccess
+type ObjectStorageBucketModifyAccessOptions struct {
+	ACL         ObjectStorageACL `json:"acl,omitzero"`
+	CorsEnabled *bool            `json:"cors_enabled,omitzero"`
+}
+
 // ObjectStorageBucketUpdateAccessOptions fields are those accepted by UpdateObjectStorageBucketAccess
 type ObjectStorageBucketUpdateAccessOptions struct {
 	ACL         ObjectStorageACL `json:"acl,omitzero"`
@@ -126,10 +132,16 @@ func (c *Client) CreateObjectStorageBucket(ctx context.Context, opts ObjectStora
 	return doPOSTRequest[ObjectStorageBucket](ctx, c, "object-storage/buckets", opts)
 }
 
+// ModifyObjectStorageBucketAccess modifies the access configuration for an ObjectStorageBucket
+func (c *Client) ModifyObjectStorageBucketAccess(ctx context.Context, regionID, label string, opts ObjectStorageBucketModifyAccessOptions) error {
+	e := formatAPIPath("object-storage/buckets/%s/%s/access", regionID, label)
+	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
+}
+
 // UpdateObjectStorageBucketAccess updates the access configuration for an ObjectStorageBucket
 func (c *Client) UpdateObjectStorageBucketAccess(ctx context.Context, regionID, label string, opts ObjectStorageBucketUpdateAccessOptions) error {
 	e := formatAPIPath("object-storage/buckets/%s/%s/access", regionID, label)
-	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
+	return doPUTRequestNoResponseBody(ctx, c, e, opts)
 }
 
 // GetObjectStorageBucketAccess gets the current access config for a bucket

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -272,6 +272,19 @@ func doPUTRequest[T, O any](
 	return &resultType, nil
 }
 
+// doPUTRequestNoResponseBody runs a PUT request using the given client, API endpoint,
+// and options/body. It expects only empty response from the endpoint.
+func doPUTRequestNoResponseBody[T any](
+	ctx context.Context,
+	client *Client,
+	endpoint string,
+	options ...T,
+) error {
+	_, err := doPUTRequest[any, T](ctx, client, endpoint, options...)
+
+	return err
+}
+
 // doDELETERequest runs a DELETE request using the given client
 // and API endpoint.
 func doDELETERequest(

--- a/test/integration/fixtures/TestObjectStorageBucket_Access_Modify.yaml
+++ b/test/integration/fixtures/TestObjectStorageBucket_Access_Modify.yaml
@@ -14,31 +14,31 @@ interactions:
     url: https://api.linode.com/v4beta/object-storage/endpoints?page=1
     method: GET
   response:
-    body: '{"data": [{"region": "us-lax", "endpoint_type": "E1", "s3_endpoint": "us-lax-1.linodeobjects.com"},
-      {"region": "us-lax", "endpoint_type": "E3", "s3_endpoint": "us-lax-4.linodeobjects.com"},
+    body: '{"data": [{"region": "in-maa", "endpoint_type": "E1", "s3_endpoint": "in-maa-1.linodeobjects.com"},
+      {"region": "jp-tyo-3", "endpoint_type": "E3", "s3_endpoint": "jp-tyo-1.linodeobjects.com"},
       {"region": "us-southeast", "endpoint_type": "E0", "s3_endpoint": "us-southeast-1.linodeobjects.com"},
+      {"region": "eu-central", "endpoint_type": "E0", "s3_endpoint": "eu-central-1.linodeobjects.com"},
+      {"region": "jp-osa", "endpoint_type": "E1", "s3_endpoint": "jp-osa-1.linodeobjects.com"},
+      {"region": "nl-ams", "endpoint_type": "E1", "s3_endpoint": "nl-ams-1.linodeobjects.com"},
+      {"region": "us-iad", "endpoint_type": "E1", "s3_endpoint": "us-iad-1.linodeobjects.com"},
+      {"region": "fr-par", "endpoint_type": "E1", "s3_endpoint": "fr-par-1.linodeobjects.com"},
+      {"region": "it-mil", "endpoint_type": "E1", "s3_endpoint": "it-mil-1.linodeobjects.com"},
       {"region": "se-sto", "endpoint_type": "E1", "s3_endpoint": "se-sto-1.linodeobjects.com"},
+      {"region": "ap-south", "endpoint_type": "E0", "s3_endpoint": "ap-south-1.linodeobjects.com"},
+      {"region": "es-mad", "endpoint_type": "E1", "s3_endpoint": "es-mad-1.linodeobjects.com"},
+      {"region": "us-mia", "endpoint_type": "E1", "s3_endpoint": "us-mia-1.linodeobjects.com"},
+      {"region": "gb-lon", "endpoint_type": "E3", "s3_endpoint": "gb-lon-1.linodeobjects.com"},
+      {"region": "de-fra-2", "endpoint_type": "E3", "s3_endpoint": "de-fra-1.linodeobjects.com"},
+      {"region": "us-lax", "endpoint_type": "E3", "s3_endpoint": "us-lax-4.linodeobjects.com"},
+      {"region": "us-lax", "endpoint_type": "E1", "s3_endpoint": "us-lax-1.linodeobjects.com"},
+      {"region": "sg-sin-2", "endpoint_type": "E3", "s3_endpoint": "sg-sin-1.linodeobjects.com"},
       {"region": "us-ord", "endpoint_type": "E3", "s3_endpoint": "us-ord-10.linodeobjects.com"},
       {"region": "us-ord", "endpoint_type": "E1", "s3_endpoint": "us-ord-1.linodeobjects.com"},
-      {"region": "gb-lon", "endpoint_type": "E3", "s3_endpoint": "gb-lon-1.linodeobjects.com"},
-      {"region": "sg-sin-2", "endpoint_type": "E3", "s3_endpoint": "sg-sin-1.linodeobjects.com"},
-      {"region": "it-mil", "endpoint_type": "E1", "s3_endpoint": "it-mil-1.linodeobjects.com"},
-      {"region": "au-mel", "endpoint_type": "E2", "s3_endpoint": "au-mel-1.linodeobjects.com"},
-      {"region": "de-fra-2", "endpoint_type": "E3", "s3_endpoint": "de-fra-1.linodeobjects.com"},
-      {"region": "fr-par", "endpoint_type": "E1", "s3_endpoint": "fr-par-1.linodeobjects.com"},
-      {"region": "jp-osa", "endpoint_type": "E1", "s3_endpoint": "jp-osa-1.linodeobjects.com"},
-      {"region": "es-mad", "endpoint_type": "E1", "s3_endpoint": "es-mad-1.linodeobjects.com"},
-      {"region": "us-iad", "endpoint_type": "E1", "s3_endpoint": "us-iad-1.linodeobjects.com"},
-      {"region": "nl-ams", "endpoint_type": "E1", "s3_endpoint": "nl-ams-1.linodeobjects.com"},
-      {"region": "ap-south", "endpoint_type": "E0", "s3_endpoint": "ap-south-1.linodeobjects.com"},
-      {"region": "us-mia", "endpoint_type": "E1", "s3_endpoint": "us-mia-1.linodeobjects.com"},
-      {"region": "eu-central", "endpoint_type": "E0", "s3_endpoint": "eu-central-1.linodeobjects.com"},
       {"region": "br-gru", "endpoint_type": "E1", "s3_endpoint": "br-gru-1.linodeobjects.com"},
-      {"region": "jp-tyo-3", "endpoint_type": "E3", "s3_endpoint": "jp-tyo-1.linodeobjects.com"},
-      {"region": "us-east", "endpoint_type": "E0", "s3_endpoint": "us-east-1.linodeobjects.com"},
-      {"region": "id-cgk", "endpoint_type": "E1", "s3_endpoint": "id-cgk-1.linodeobjects.com"},
-      {"region": "in-maa", "endpoint_type": "E1", "s3_endpoint": "in-maa-1.linodeobjects.com"},
+      {"region": "au-mel", "endpoint_type": "E2", "s3_endpoint": "au-mel-1.linodeobjects.com"},
       {"region": "us-sea", "endpoint_type": "E1", "s3_endpoint": "us-sea-1.linodeobjects.com"},
+      {"region": "id-cgk", "endpoint_type": "E1", "s3_endpoint": "id-cgk-1.linodeobjects.com"},
+      {"region": "us-east", "endpoint_type": "E0", "s3_endpoint": "us-east-1.linodeobjects.com"},
       {"region": "us-iad-2", "endpoint_type": "E3", "s3_endpoint": null}], "page":
       1, "pages": 1, "results": 26}'
     headers:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 20:23:21 GMT
+      - Tue, 05 May 2026 20:24:35 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -89,7 +89,7 @@ interactions:
     code: 200
     duration: ""
 - request:
-    body: '{"region":"us-lax","label":"go-bucket-test-def","endpoint_type":"E1"}'
+    body: '{"region":"in-maa","label":"go-bucket-test-def","endpoint_type":"E1"}'
     form: {}
     headers:
       Accept:
@@ -101,10 +101,10 @@ interactions:
     url: https://api.linode.com/v4beta/object-storage/buckets
     method: POST
   response:
-    body: '{"hostname": "go-bucket-test-def.us-lax-1.linodeobjects.com", "label":
-      "go-bucket-test-def", "created": "2018-01-02T03:04:05", "region": "us-lax",
-      "cluster": "us-lax-1", "size": 0, "objects": 0, "endpoint_type": "E1", "s3_endpoint":
-      "us-lax-1.linodeobjects.com"}'
+    body: '{"hostname": "go-bucket-test-def.in-maa-1.linodeobjects.com", "label":
+      "go-bucket-test-def", "created": "2018-01-02T03:04:05", "region": "in-maa",
+      "cluster": "in-maa-1", "size": 0, "objects": 0, "endpoint_type": "E1", "s3_endpoint":
+      "in-maa-1.linodeobjects.com"}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -129,7 +129,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 20:23:23 GMT
+      - Tue, 05 May 2026 20:24:39 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -162,8 +162,8 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/object-storage/buckets/us-lax/go-bucket-test-def/access
-    method: PUT
+    url: https://api.linode.com/v4beta/object-storage/buckets/in-maa/go-bucket-test-def/access
+    method: POST
   response:
     body: '{}'
     headers:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 20:23:27 GMT
+      - Tue, 05 May 2026 20:24:43 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -223,7 +223,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/object-storage/buckets/us-lax/go-bucket-test-def/access
+    url: https://api.linode.com/v4beta/object-storage/buckets/in-maa/go-bucket-test-def/access
     method: GET
   response:
     body: '{"acl": "private", "acl_xml": "<AccessControlPolicy xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Owner><ID>640757b5-ebe9-45b1-abd5-581f215ef89e</ID><DisplayName>640757b5-ebe9-45b1-abd5-581f215ef89e</DisplayName></Owner><AccessControlList><Grant><Grantee
@@ -253,7 +253,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 20:23:30 GMT
+      - Tue, 05 May 2026 20:24:48 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -287,7 +287,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/object-storage/buckets/us-lax/go-bucket-test-def
+    url: https://api.linode.com/v4beta/object-storage/buckets/in-maa/go-bucket-test-def
     method: DELETE
   response:
     body: '{}'
@@ -315,7 +315,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 20:23:33 GMT
+      - Tue, 05 May 2026 20:24:53 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/object_storage_buckets_test.go
+++ b/test/integration/object_storage_buckets_test.go
@@ -152,6 +152,41 @@ func TestObjectStorageBucket_Access_Get(t *testing.T) {
 	}
 }
 
+func TestObjectStorageBucket_Access_Modify(t *testing.T) {
+	endpointType := linodego.ObjectStorageEndpointE1
+	client, bucket, teardown, err := setupObjectStorageBucket(t,
+		nil,
+		"fixtures/TestObjectStorageBucket_Access_Modify",
+		nil, nil, &endpointType,
+	)
+	defer teardown()
+
+	corsEnabled := false
+
+	opts := ObjectStorageBucketModifyAccessOptions{
+		ACL:         ACLPrivate,
+		CorsEnabled: &corsEnabled,
+	}
+
+	err = client.ModifyObjectStorageBucketAccess(context.Background(), bucket.Region, bucket.Label, opts)
+	if err != nil {
+		t.Errorf("Error modifying ObjectStorageBucket access, got error %s", err)
+	}
+
+	newBucket, err := client.GetObjectStorageBucketAccess(context.Background(), bucket.Region, bucket.Label)
+	if err != nil {
+		t.Errorf("Error getting ObjectStorageBucket access, got error %s", err)
+	}
+
+	if *newBucket.CorsEnabled != corsEnabled {
+		t.Errorf("ObjectStorageBucket access CORS does not match modification, expected %t, got %t", corsEnabled, *newBucket.CorsEnabled)
+	}
+
+	if newBucket.ACL != opts.ACL {
+		t.Errorf("ObjectStorageBucket access ACL does not match modification, expected %s, got %s", opts.ACL, newBucket.ACL)
+	}
+}
+
 func TestObjectStorageBucket_Access_Update(t *testing.T) {
 	endpointType := linodego.ObjectStorageEndpointE1
 	client, bucket, teardown, err := setupObjectStorageBucket(t,

--- a/test/unit/object_storage_bucket_test.go
+++ b/test/unit/object_storage_bucket_test.go
@@ -120,6 +120,24 @@ func TestObjectStorageBucket_GetAccess(t *testing.T) {
 	assert.Equal(t, linodego.ACLPublicRead, access.ACL)
 }
 
+func TestObjectStorageBucket_ModifyAccess(t *testing.T) {
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	regionID := "us-east"
+	bucketLabel := "my-bucket"
+
+	modifyOpts := linodego.ObjectStorageBucketModifyAccessOptions{
+		ACL: linodego.ACLPrivate,
+	}
+
+	base.MockPost("object-storage/buckets/"+regionID+"/"+bucketLabel+"/access", nil)
+
+	err := base.Client.ModifyObjectStorageBucketAccess(context.Background(), regionID, bucketLabel, modifyOpts)
+	assert.NoError(t, err)
+}
+
 func TestObjectStorageBucket_UpdateAccess(t *testing.T) {
 	var base ClientBaseCase
 	base.SetUp(t)
@@ -132,7 +150,7 @@ func TestObjectStorageBucket_UpdateAccess(t *testing.T) {
 		ACL: linodego.ACLPrivate,
 	}
 
-	base.MockPost("object-storage/buckets/"+regionID+"/"+bucketLabel+"/access", nil)
+	base.MockPut("object-storage/buckets/"+regionID+"/"+bucketLabel+"/access", nil)
 
 	err := base.Client.UpdateObjectStorageBucketAccess(context.Background(), regionID, bucketLabel, updateOpts)
 	assert.NoError(t, err)


### PR DESCRIPTION
## 📝 Description

Added `ModifyObjectStorageBucketAccess` struct and swapped it with `UpdateObjectStorageBucketAccess` such that Modify is for the POST endpoint and Update is for the PUT endpoint to avoid confusion.

As of right now, both endpoints do the same exact thing but we want separate structs in case this changes in the future.

## ✔️ How to Test

`make test-unit`
`make test-int`