### PR TITLE
TPT-3454: Refactor wait functions to use context for timeouts and polling

### DIFF
--- a/test/integration/databases_test.go
+++ b/test/integration/databases_test.go
@@ -66,7 +66,9 @@ func TestDatabase_Type(t *testing.T) {
 }
 
 func TestDatabase_List(t *testing.T) {
-	client, database, teardown, err := setupPostgresDatabase(t, nil, "fixtures/TestDatabase_List")
+	ctx := waitContext(t, 5400*time.Second)
+
+	client, database, teardown, err := setupPostgresDatabase(t, ctx, nil, "fixtures/TestDatabase_List")
 	if err != nil {
 		t.Error(err)
 	}
@@ -90,18 +92,18 @@ func TestDatabase_List(t *testing.T) {
 	}
 }
 
-func waitForDatabaseUpdated(t *testing.T, client *linodego.Client, dbID int,
+func waitForDatabaseUpdated(t *testing.T, ctx context.Context, client *linodego.Client, dbID int,
 	dbType linodego.DatabaseEngineType, minStart *time.Time,
 ) {
-	_, err := client.WaitForEventFinished(context.Background(), dbID, linodego.EntityDatabase,
-		linodego.ActionDatabaseUpdate, *minStart, 1200)
+	_, err := client.WaitForEventFinished(ctx, dbID, linodego.EntityDatabase,
+		linodego.ActionDatabaseUpdate, *minStart)
 	if err != nil {
 		t.Fatalf("failed to wait for database update: %s", err)
 	}
 
 	// Sometimes the event has finished but the status hasn't caught up
-	err = client.WaitForDatabaseStatus(context.Background(), dbID, dbType,
-		linodego.DatabaseStatusActive, 120)
+	err = client.WaitForDatabaseStatus(ctx, dbID, dbType,
+		linodego.DatabaseStatusActive)
 	if err != nil {
 		t.Fatalf("failed to wait for database active: %s", err)
 	}

--- a/test/integration/iam_io_ready_test.go
+++ b/test/integration/iam_io_ready_test.go
@@ -58,7 +58,7 @@ func setupVolumeAttachedToLinode(
 
 	teardown := func() {
 		if detachVolume {
-			// new a context because the context from t.Context() will be cancelled before cleanup run
+			// Use a fresh context here because the context returned by t.Context() is canceled before t.Cleanup callbacks run.
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 			defer cancel()
 

--- a/test/integration/iam_io_ready_test.go
+++ b/test/integration/iam_io_ready_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,7 @@ func findVolumeByID(volumes []linodego.Volume, id int) linodego.Volume {
 
 func setupVolumeAttachedToLinode(
 	t *testing.T,
+	ctx context.Context,
 	fixturesYaml string,
 	detachVolume bool,
 ) (*linodego.Client, *linodego.Volume, *linodego.Instance, func()) {
@@ -39,7 +41,7 @@ func setupVolumeAttachedToLinode(
 		require.NoErrorf(t, err, "Error deleting instance: %v", err)
 	}
 
-	instance, err = client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceRunning, 180)
+	instance, err = client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceRunning)
 	require.NoErrorf(t, err, "Error waiting for instance to be running: %v", err)
 
 	volume, teardownVolume, err := createVolume(t, client, func(l *linodego.Client, options *linodego.VolumeCreateOptions) {
@@ -51,7 +53,7 @@ func setupVolumeAttachedToLinode(
 	volume, err = client.AttachVolume(context.Background(), volume.ID, &linodego.VolumeAttachOptions{LinodeID: instance.ID})
 	require.NoErrorf(t, err, "Error attaching volume to instance: %v", err)
 
-	volume, err = client.WaitForVolumeIOReadyStatus(context.Background(), volume.ID, true, 45)
+	volume, err = client.WaitForVolumeIOReadyStatus(ctx, volume.ID, true)
 	require.NoErrorf(t, err, "Error waiting for IO Ready status of attached volume: %v", err)
 
 	teardown := func() {
@@ -59,7 +61,7 @@ func setupVolumeAttachedToLinode(
 			err = client.DetachVolume(context.Background(), volume.ID)
 			require.NoErrorf(t, err, "Error detaching volume: %v", err)
 
-			_, err = client.WaitForVolumeIOReadyStatus(context.Background(), volume.ID, false, 45)
+			_, err = client.WaitForVolumeIOReadyStatus(ctx, volume.ID, false)
 			require.NoErrorf(t, err, "Error waiting for IO Ready status of detached volume: %v", err)
 		}
 		teardownVolume()
@@ -96,6 +98,8 @@ func requireSingleAttachedInstanceVolume(t *testing.T, client *linodego.Client, 
 }
 
 func TestIAM_GetIOReadyForNotAttachedVolume(t *testing.T) {
+	ctx := waitContext(t, 30*time.Second)
+
 	client, recordStopper := createTestClient(t, "fixtures/TestIAM_GetIOReadyForNotAttachedVolume")
 	t.Cleanup(recordStopper)
 
@@ -105,7 +109,7 @@ func TestIAM_GetIOReadyForNotAttachedVolume(t *testing.T) {
 	t.Cleanup(teardown)
 	require.NoErrorf(t, err, "Error creating not attached volume: %v", err)
 
-	volume, err = client.WaitForVolumeStatus(context.Background(), volume.ID, linodego.VolumeActive, 30)
+	volume, err = client.WaitForVolumeStatus(ctx, volume.ID, linodego.VolumeActive)
 	require.NoErrorf(t, err, "Error waiting for volume to be active: %v", err)
 
 	volumeList, err := client.ListVolumes(context.Background(), nil)
@@ -128,7 +132,9 @@ func TestIAM_GetIOReadyForNotAttachedVolume(t *testing.T) {
 }
 
 func TestIAM_GetIOReadyForAttachedDetachedVolume(t *testing.T) {
-	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, "fixtures/TestIAM_GetIOReadyForAttachedDetachedVolume", false)
+	ctx := waitContext(t, 270*time.Second)
+
+	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, ctx, "fixtures/TestIAM_GetIOReadyForAttachedDetachedVolume", false)
 	t.Cleanup(teardown)
 	requireSingleAttachedInstanceVolume(t, client, instance)
 
@@ -139,7 +145,7 @@ func TestIAM_GetIOReadyForAttachedDetachedVolume(t *testing.T) {
 	err = client.DetachVolume(context.Background(), volume.ID)
 	require.NoErrorf(t, err, "Error detaching volume: %v", err)
 
-	_, err = client.WaitForVolumeIOReadyStatus(context.Background(), volume.ID, false, 45)
+	_, err = client.WaitForVolumeIOReadyStatus(ctx, volume.ID, false)
 	require.NoErrorf(t, err, "Error waiting for IO Ready status of detached volume: %v", err)
 
 	instanceVolumes, err := client.ListInstanceVolumes(context.Background(), instance.ID, nil)
@@ -154,7 +160,9 @@ func TestIAM_GetIOReadyForAttachedDetachedVolume(t *testing.T) {
 }
 
 func TestIAM_GetIOReadyForUpdatedVolume(t *testing.T) {
-	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, "fixtures/TestIAM_GetIOReadyForUpdatedVolume", true)
+	ctx := waitContext(t, 270*time.Second)
+
+	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, ctx, "fixtures/TestIAM_GetIOReadyForUpdatedVolume", true)
 	t.Cleanup(teardown)
 	assertVolumeAttachedToInstance(t, volume, instance)
 	assert.NotContains(t, "-updated", volume.Label)
@@ -182,7 +190,9 @@ func TestIAM_GetIOReadyForUpdatedVolume(t *testing.T) {
 }
 
 func TestIAM_GetIOReadyForClonedVolume(t *testing.T) {
-	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, "fixtures/TestIAM_GetIOReadyForClonedVolume", true)
+	ctx := waitContext(t, 300*time.Second)
+
+	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, ctx, "fixtures/TestIAM_GetIOReadyForClonedVolume", true)
 	t.Cleanup(teardown)
 	requireSingleAttachedInstanceVolume(t, client, instance)
 
@@ -195,7 +205,7 @@ func TestIAM_GetIOReadyForClonedVolume(t *testing.T) {
 	})
 	require.NoErrorf(t, err, "Error cloning volume: %v", err)
 
-	_, err = client.WaitForVolumeStatus(context.Background(), volumeCloned.ID, linodego.VolumeActive, 30)
+	_, err = client.WaitForVolumeStatus(ctx, volumeCloned.ID, linodego.VolumeActive)
 	require.NoErrorf(t, err, "Error waiting for IO Ready status of attached volume: %v", err)
 
 	volumeCloned, err = client.GetVolume(context.Background(), volumeCloned.ID)
@@ -212,7 +222,9 @@ func TestIAM_GetIOReadyForClonedVolume(t *testing.T) {
 }
 
 func TestIAM_GetIOReadyForResizedVolume(t *testing.T) {
-	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, "fixtures/TestIAM_GetIOReadyForResizedVolume", true)
+	ctx := waitContext(t, 300*time.Second)
+
+	client, volume, instance, teardown := setupVolumeAttachedToLinode(t, ctx, "fixtures/TestIAM_GetIOReadyForResizedVolume", true)
 	t.Cleanup(teardown)
 	assertVolumeAttachedToInstance(t, volume, instance)
 
@@ -221,7 +233,7 @@ func TestIAM_GetIOReadyForResizedVolume(t *testing.T) {
 	err := client.ResizeVolume(context.Background(), volume.ID, newSize)
 	require.NoErrorf(t, err, "Error resizing volume: %v", err)
 
-	_, err = client.WaitForVolumeStatus(context.Background(), volume.ID, linodego.VolumeActive, 30)
+	_, err = client.WaitForVolumeStatus(ctx, volume.ID, linodego.VolumeActive)
 	require.NoErrorf(t, err, "Error waiting for volume to be active: %v", err)
 
 	instanceVolume := requireSingleAttachedInstanceVolume(t, client, instance)

--- a/test/integration/iam_io_ready_test.go
+++ b/test/integration/iam_io_ready_test.go
@@ -58,10 +58,14 @@ func setupVolumeAttachedToLinode(
 
 	teardown := func() {
 		if detachVolume {
-			err = client.DetachVolume(context.Background(), volume.ID)
+			// new a context because the context from t.Context() will be cancelled before cleanup run
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
+
+			err = client.DetachVolume(cleanupCtx, volume.ID)
 			require.NoErrorf(t, err, "Error detaching volume: %v", err)
 
-			_, err = client.WaitForVolumeIOReadyStatus(ctx, volume.ID, false)
+			_, err = client.WaitForVolumeIOReadyStatus(cleanupCtx, volume.ID, false)
 			require.NoErrorf(t, err, "Error waiting for IO Ready status of detached volume: %v", err)
 		}
 		teardownVolume()

--- a/test/integration/image_sharegroups_test.go
+++ b/test/integration/image_sharegroups_test.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/require"
 )
 
 func TestImageSharing_Suite(t *testing.T) {
+	ctx := waitContext(t, 600*time.Second)
+
 	client, instance, teardown, err := setupInstance(
 		t, "fixtures/TestImageSharing_Suite", true,
 		func(client *linodego.Client, options *linodego.InstanceCreateOptions) {
@@ -42,7 +45,7 @@ func TestImageSharing_Suite(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	_, err = client.WaitForImageStatus(context.Background(), image.ID, linodego.ImageStatusAvailable, 600)
+	_, err = client.WaitForImageStatus(ctx, image.ID, linodego.ImageStatusAvailable)
 	require.NoError(t, err)
 
 	if image.IsShared {

--- a/test/integration/images_test.go
+++ b/test/integration/images_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/linode/linodego"
@@ -69,6 +70,8 @@ func TestImages_List_smoke(t *testing.T) {
 }
 
 func TestImage_Upload(t *testing.T) {
+	ctx := waitContext(t, 300*time.Second)
+
 	client, teardown := createTestClient(t, "fixtures/TestImage_Upload")
 	defer teardown()
 
@@ -90,7 +93,7 @@ func TestImage_Upload(t *testing.T) {
 		t.Errorf("Expected upload URL, got none")
 	}
 
-	if _, err := client.WaitForImageStatus(context.Background(), image.ID, ImageStatusPendingUpload, 60); err != nil {
+	if _, err := client.WaitForImageStatus(ctx, image.ID, ImageStatusPendingUpload); err != nil {
 		t.Errorf("Failed to wait for image pending upload status: %v", err)
 	}
 
@@ -101,7 +104,7 @@ func TestImage_Upload(t *testing.T) {
 		}
 	}
 
-	if _, err := client.WaitForImageStatus(context.Background(), image.ID, ImageStatusAvailable, 240); err != nil {
+	if _, err := client.WaitForImageStatus(ctx, image.ID, ImageStatusAvailable); err != nil {
 		t.Errorf("Failed to wait for image available upload status: %v", err)
 	}
 }
@@ -178,6 +181,8 @@ func TestImage_CloudInit(t *testing.T) {
 }
 
 func TestImage_Replicate(t *testing.T) {
+	ctx := waitContext(t, 460*time.Second)
+
 	client, teardown := createTestClient(t, "fixtures/TestImage_Replicate")
 	defer teardown()
 
@@ -201,7 +206,7 @@ func TestImage_Replicate(t *testing.T) {
 		t.Errorf("Expected upload URL, got none")
 	}
 
-	if _, err := client.WaitForImageStatus(context.Background(), image.ID, ImageStatusPendingUpload, 60); err != nil {
+	if _, err := client.WaitForImageStatus(ctx, image.ID, ImageStatusPendingUpload); err != nil {
 		t.Errorf("Failed to wait for image pending upload status: %v", err)
 	}
 
@@ -212,7 +217,7 @@ func TestImage_Replicate(t *testing.T) {
 		}
 	}
 
-	if _, err := client.WaitForImageStatus(context.Background(), image.ID, ImageStatusAvailable, 400); err != nil {
+	if _, err := client.WaitForImageStatus(ctx, image.ID, ImageStatusAvailable); err != nil {
 		t.Errorf("Failed to wait for image available upload status: %v", err)
 	}
 

--- a/test/integration/instance_config_test.go
+++ b/test/integration/instance_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	. "github.com/linode/linodego"
@@ -656,6 +657,8 @@ func TestInstance_Config_Update(t *testing.T) {
 }
 
 func TestInstance_Config_VolumeLimitExtension(t *testing.T) {
+	ctx := waitContext(t, 1000*time.Second)
+
 	client, instance, config, teardown, err := setupInstanceWithoutDisks(
 		t, "fixtures/TestInstance_Config_VolumeLimitExtension",
 		true,
@@ -705,10 +708,10 @@ func TestInstance_Config_VolumeLimitExtension(t *testing.T) {
 		RootDevice: "/dev/sdk",
 	}
 
-	_, err = client.WaitForVolumeStatus(context.Background(), volume1.ID, VolumeActive, 500)
+	_, err = client.WaitForVolumeStatus(ctx, volume1.ID, VolumeActive)
 	require.NoError(t, err)
 
-	_, err = client.WaitForVolumeStatus(context.Background(), volume2.ID, VolumeActive, 500)
+	_, err = client.WaitForVolumeStatus(ctx, volume2.ID, VolumeActive)
 	require.NoError(t, err)
 
 	updatedConfig, err := client.UpdateInstanceConfig(context.Background(), instance.ID, config.ID, configOpts)

--- a/test/integration/instance_snapshots_test.go
+++ b/test/integration/instance_snapshots_test.go
@@ -11,7 +11,9 @@ import (
 var testSnapshotLabel = "snapshot-linodego-testing"
 
 func TestInstanceBackups_List(t *testing.T) {
-	client, instance, backup, teardown, err := setupInstanceBackup(t, "fixtures/TestInstanceBackups_List")
+	ctx := waitContext(t, 1500*time.Second)
+
+	client, instance, backup, teardown, err := setupInstanceBackup(t, ctx, "fixtures/TestInstanceBackups_List")
 	defer teardown()
 	if err != nil {
 		t.Error(err)
@@ -52,7 +54,7 @@ func TestInstanceBackups_List(t *testing.T) {
 		t.Errorf("Expected snapshot did not match current snapshot: %v", backups.Snapshot.Current)
 	}
 
-	backup, err = client.WaitForSnapshotStatus(context.Background(), instance.ID, backup.ID, linodego.SnapshotSuccessful, 360)
+	backup, err = client.WaitForSnapshotStatus(ctx, instance.ID, backup.ID, linodego.SnapshotSuccessful)
 	if err != nil {
 		t.Errorf("Error waiting for snapshot: %v", err)
 	}
@@ -79,20 +81,24 @@ func TestInstanceBackups_List(t *testing.T) {
 	}
 
 	// wait for instnace to restore
-	_, err = client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionBackupsRestore, now, 360)
+	_, err = client.WaitForEventFinished(ctx, instance.ID, linodego.EntityLinode, linodego.ActionBackupsRestore, now)
 	if err != nil {
 		t.Errorf("Error waiting for snapshot to complete: %v", err)
 	}
 }
 
-func setupInstanceBackup(t *testing.T, fixturesYaml string) (*linodego.Client, *linodego.Instance, *linodego.InstanceSnapshot, func(), error) {
+func setupInstanceBackup(
+	t *testing.T,
+	ctx context.Context,
+	fixturesYaml string,
+) (*linodego.Client, *linodego.Instance, *linodego.InstanceSnapshot, func(), error) {
 	t.Helper()
 	client, instance, _, fixtureTeardown, err := setupInstanceWithoutDisks(t, fixturesYaml, true)
 	if err != nil {
 		t.Errorf("Error creating instance, got error %v", err)
 	}
 
-	client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, 180)
+	client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline)
 	createOpts := linodego.InstanceDiskCreateOptions{
 		Size:       18,
 		Label:      "linodego-disk-test",
@@ -104,7 +110,7 @@ func setupInstanceBackup(t *testing.T, fixturesYaml string) (*linodego.Client, *
 	}
 
 	// wait for disk to finish provisioning
-	event, err := client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionDiskCreate, *disk.Created, 240)
+	event, err := client.WaitForEventFinished(ctx, instance.ID, linodego.EntityLinode, linodego.ActionDiskCreate, *disk.Created)
 	if err != nil {
 		t.Errorf("Error waiting for instance snapshot: %v", err)
 	}
@@ -123,7 +129,7 @@ func setupInstanceBackup(t *testing.T, fixturesYaml string) (*linodego.Client, *
 		t.Errorf("Error creating instance snapshot: %v", err)
 	}
 
-	event, err = client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionLinodeSnapshot, *instance.Created, 360)
+	event, err = client.WaitForEventFinished(ctx, instance.ID, linodego.EntityLinode, linodego.ActionLinodeSnapshot, *instance.Created)
 	if err != nil {
 		t.Errorf("Error waiting for instance snapshot: %v", err)
 	}

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
@@ -124,6 +125,8 @@ func TestInstance_GetMonthlyTransfer(t *testing.T) {
 }
 
 func TestInstance_ResetPassword(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, instance, teardown, err := setupInstance(
 		t,
 		"fixtures/TestInstance_ResetPassword", true,
@@ -141,10 +144,9 @@ func TestInstance_ResetPassword(t *testing.T) {
 	}
 
 	instance, err = client.WaitForInstanceStatus(
-		context.Background(),
+		ctx,
 		instance.ID,
 		linodego.InstanceOffline,
-		180,
 	)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness for password reset: %s", err.Error())
@@ -163,6 +165,8 @@ func TestInstance_ResetPassword(t *testing.T) {
 }
 
 func TestInstance_Resize(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, instance, teardown, err := setupInstance(
 		t,
 		"fixtures/TestInstance_Resize", true,
@@ -179,10 +183,9 @@ func TestInstance_Resize(t *testing.T) {
 	}
 
 	instance, err = client.WaitForInstanceStatus(
-		context.Background(),
+		ctx,
 		instance.ID,
 		linodego.InstanceRunning,
-		180,
 	)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness for resize: %s", err.Error())
@@ -202,6 +205,8 @@ func TestInstance_Resize(t *testing.T) {
 }
 
 func TestInstance_Migrate(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, instance, teardown, err := setupInstance(
 		t,
 		"fixtures/TestInstance_Migrate", true,
@@ -218,10 +223,9 @@ func TestInstance_Migrate(t *testing.T) {
 	}
 
 	instance, err = client.WaitForInstanceStatus(
-		context.Background(),
+		ctx,
 		instance.ID,
 		linodego.InstanceRunning,
-		180,
 	)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness for migration: %s", err.Error())
@@ -244,6 +248,8 @@ func TestInstance_Migrate(t *testing.T) {
 }
 
 func TestInstance_MigrateToPG(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, clientTeardown := createTestClient(t, "fixtures/TestInstance_MigrateToPG")
 
 	defer func() {
@@ -282,10 +288,9 @@ func TestInstance_MigrateToPG(t *testing.T) {
 	}
 
 	instance, err = client.WaitForInstanceStatus(
-		context.Background(),
+		ctx,
 		instance.ID,
 		linodego.InstanceRunning,
-		180,
 	)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness for migration: %s", err.Error())
@@ -393,13 +398,15 @@ func TestInstance_Disks_List_WithEncryption(t *testing.T) {
 }
 
 func TestInstance_Disk_Resize(t *testing.T) {
+	ctx := waitContext(t, 360*time.Second)
+
 	client, instance, _, teardown, err := setupInstanceWithoutDisks(t, "fixtures/TestInstance_Disk_Resize", true)
 	defer teardown()
 	if err != nil {
 		t.Error(err)
 	}
 
-	instance, err = client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, 180)
+	instance, err = client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness for resize: %s", err)
 	}
@@ -413,7 +420,7 @@ func TestInstance_Disk_Resize(t *testing.T) {
 		t.Errorf("Error creating disk for resize: %s", err)
 	}
 
-	disk, err = client.WaitForInstanceDiskStatus(context.Background(), instance.ID, disk.ID, linodego.DiskReady, 180)
+	disk, err = client.WaitForInstanceDiskStatus(ctx, instance.ID, disk.ID, linodego.DiskReady)
 	if err != nil {
 		t.Errorf("Error waiting for disk readiness for resize: %s", err)
 	}
@@ -425,6 +432,8 @@ func TestInstance_Disk_Resize(t *testing.T) {
 }
 
 func TestInstance_Disk_ListMultiple(t *testing.T) {
+	ctx := waitContext(t, 840*time.Second)
+
 	// This is a long running test
 	client, instance1, teardown1, err := setupInstance(t, "fixtures/TestInstance_Disk_ListMultiple_Primary", true)
 	defer teardown1()
@@ -435,7 +444,7 @@ func TestInstance_Disk_ListMultiple(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	instance1, err = client.WaitForInstanceStatus(context.Background(), instance1.ID, linodego.InstanceRunning, 180)
+	instance1, err = client.WaitForInstanceStatus(ctx, instance1.ID, linodego.InstanceRunning)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness: %s", err)
 	}
@@ -445,7 +454,7 @@ func TestInstance_Disk_ListMultiple(t *testing.T) {
 		t.Error(err)
 	}
 
-	disk, err := client.WaitForInstanceDiskStatus(context.Background(), instance1.ID, disks[0].ID, linodego.DiskReady, 180)
+	disk, err := client.WaitForInstanceDiskStatus(ctx, instance1.ID, disks[0].ID, linodego.DiskReady)
 	if err != nil {
 		t.Errorf("Error waiting for disk readiness: %s", err)
 	}
@@ -464,12 +473,12 @@ func TestInstance_Disk_ListMultiple(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	instance2, err = client.WaitForInstanceStatus(context.Background(), instance2.ID, linodego.InstanceOffline, 180)
+	instance2, err = client.WaitForInstanceStatus(ctx, instance2.ID, linodego.InstanceOffline)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness: %s", err)
 	}
 
-	_, err = client.WaitForEventFinished(context.Background(), instance1.ID, linodego.EntityLinode, linodego.ActionDiskImagize, *disk.Created, 300)
+	_, err = client.WaitForEventFinished(ctx, instance1.ID, linodego.EntityLinode, linodego.ActionDiskImagize, *disk.Created)
 	if err != nil {
 		t.Errorf("Error waiting for imagize event: %s", err)
 	}
@@ -502,13 +511,15 @@ func TestInstance_Disk_ListMultiple(t *testing.T) {
 }
 
 func TestInstance_Disk_Clone(t *testing.T) {
+	ctx := waitContext(t, 540*time.Second)
+
 	client, instance, _, teardown, err := setupInstanceWithoutDisks(t, "fixtures/TestInstance_Disk_Clone", true)
 	defer teardown()
 	if err != nil {
 		t.Error(err)
 	}
 
-	instance, err = client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, 180)
+	instance, err = client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness for disk clone: %s", err)
 	}
@@ -524,11 +535,11 @@ func TestInstance_Disk_Clone(t *testing.T) {
 		t.Errorf("Error creating disk for disk clone: %s", err)
 	}
 
-	instance, err = client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, 180)
+	instance, err = client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness after creating disk for disk clone: %s", err)
 	}
-	disk, err = client.WaitForInstanceDiskStatus(context.Background(), instance.ID, disk.ID, linodego.DiskReady, 180)
+	disk, err = client.WaitForInstanceDiskStatus(ctx, instance.ID, disk.ID, linodego.DiskReady)
 	if err != nil {
 		t.Errorf("Error waiting for disk readiness for disk clone: %s", err)
 	}
@@ -542,13 +553,15 @@ func TestInstance_Disk_Clone(t *testing.T) {
 }
 
 func TestInstance_Disk_ResetPassword(t *testing.T) {
+	ctx := waitContext(t, 540*time.Second)
+
 	client, instance, _, teardown, err := setupInstanceWithoutDisks(t, "fixtures/TestInstance_Disk_ResetPassword", true)
 	defer teardown()
 	if err != nil {
 		t.Error(err)
 	}
 
-	instance, err = client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, 180)
+	instance, err = client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness for password reset: %s", err)
 	}
@@ -564,11 +577,11 @@ func TestInstance_Disk_ResetPassword(t *testing.T) {
 		t.Errorf("Error creating disk for password reset: %s", err)
 	}
 
-	instance, err = client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceOffline, 180)
+	instance, err = client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceOffline)
 	if err != nil {
 		t.Errorf("Error waiting for instance readiness after creating disk for password reset: %s", err)
 	}
-	disk, err = client.WaitForInstanceDiskStatus(context.Background(), instance.ID, disk.ID, linodego.DiskReady, 180)
+	disk, err = client.WaitForInstanceDiskStatus(ctx, instance.ID, disk.ID, linodego.DiskReady)
 	if err != nil {
 		t.Errorf("Error waiting for disk readiness for password reset: %s", err)
 	}
@@ -616,6 +629,8 @@ func TestInstance_NodeBalancers_List(t *testing.T) {
 }
 
 func TestInstance_Volumes_List(t *testing.T) {
+	ctx := waitContext(t, 500*time.Second)
+
 	client, instance, config, teardown, err := setupInstanceWithoutDisks(t, "fixtures/TestInstance_Volumes_List_Instance", true)
 	defer teardown()
 	if err != nil {
@@ -626,7 +641,7 @@ func TestInstance_Volumes_List(t *testing.T) {
 		options.Region = instance.Region
 	})
 
-	_, err = client.WaitForVolumeStatus(context.Background(), volume.ID, linodego.VolumeActive, 500)
+	_, err = client.WaitForVolumeStatus(ctx, volume.ID, linodego.VolumeActive)
 	if err != nil {
 		t.Errorf("Error waiting for volume to be active, %s", err)
 	}
@@ -684,6 +699,8 @@ func TestInstance_CreateUnderFirewall(t *testing.T) {
 }
 
 func TestInstance_Rebuild(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, instance, _, teardown, err := setupInstanceWithoutDisks(
 		t,
 		"fixtures/TestInstance_Rebuild", true,
@@ -697,7 +714,7 @@ func TestInstance_Rebuild(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionLinodeCreate, *instance.Created, 180)
+	_, err = client.WaitForEventFinished(ctx, instance.ID, linodego.EntityLinode, linodego.ActionLinodeCreate, *instance.Created)
 	if err != nil {
 		t.Errorf("Error waiting for instance created: %s", err)
 	}
@@ -721,6 +738,8 @@ func TestInstance_Rebuild(t *testing.T) {
 }
 
 func TestInstance_RebuildWithEncryption(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, instance, _, teardown, err := setupInstanceWithoutDisks(
 		t,
 		"fixtures/TestInstance_RebuildWithEncryption",
@@ -736,7 +755,7 @@ func TestInstance_RebuildWithEncryption(t *testing.T) {
 		t.Error(err)
 	}
 
-	_, err = client.WaitForEventFinished(context.Background(), instance.ID, linodego.EntityLinode, linodego.ActionLinodeCreate, *instance.Created, 180)
+	_, err = client.WaitForEventFinished(ctx, instance.ID, linodego.EntityLinode, linodego.ActionLinodeCreate, *instance.Created)
 	if err != nil {
 		t.Errorf("Error waiting for instance created: %s", err)
 	}
@@ -758,6 +777,8 @@ func TestInstance_RebuildWithEncryption(t *testing.T) {
 }
 
 func TestInstance_Clone(t *testing.T) {
+	ctx := waitContext(t, 420*time.Second)
+
 	var targetRegion string
 
 	client, instance, teardownOriginalLinode, err := setupInstance(
@@ -773,12 +794,11 @@ func TestInstance_Clone(t *testing.T) {
 	t.Cleanup(teardownOriginalLinode)
 
 	_, err = client.WaitForEventFinished(
-		context.Background(),
+		ctx,
 		instance.ID,
 		linodego.EntityLinode,
 		linodego.ActionLinodeCreate,
 		*instance.Created,
-		180,
 	)
 	if err != nil {
 		t.Errorf("Error waiting for instance created: %s", err)
@@ -806,17 +826,12 @@ func TestInstance_Clone(t *testing.T) {
 		client.DeleteInstance(context.Background(), clonedInstance.ID)
 	})
 
-	if err != nil {
-		t.Error(err)
-	}
-
 	_, err = client.WaitForEventFinished(
-		context.Background(),
+		ctx,
 		instance.ID,
 		linodego.EntityLinode,
 		linodego.ActionLinodeClone,
 		*clonedInstance.Created,
-		240,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1178,6 +1193,8 @@ func TestExpectedErrorIfFieldsAuthorizedUsersAuthorizedKeysRootPassAreNotSet(t *
 }
 
 func TestCreateLinodeWithKernelAndBootSizeThenAddDiskAndRebuild(t *testing.T) {
+	ctx := waitContext(t, 360*time.Second)
+
 	client, teardown := createTestClient(t,
 		"fixtures/TestInstance_TestCreateLinodeWithKernelAndBootSizeThenAddDiskAndRebuild")
 	defer teardown()
@@ -1208,12 +1225,11 @@ func TestCreateLinodeWithKernelAndBootSizeThenAddDiskAndRebuild(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "linode/debian12", instance.Image)
 	_, err = client.WaitForEventFinished(
-		context.Background(),
+		ctx,
 		instance.ID,
 		linodego.EntityLinode,
 		linodego.ActionLinodeCreate,
 		*instance.Created,
-		180,
 	)
 	require.NoErrorf(t, err, "Error waiting for instance created: %s", err)
 
@@ -1225,7 +1241,7 @@ func TestCreateLinodeWithKernelAndBootSizeThenAddDiskAndRebuild(t *testing.T) {
 		RootPass:   randPassword(),
 	})
 	require.NoError(t, errCreateDisk)
-	createDiskResponse, err = client.WaitForInstanceDiskStatus(context.Background(), instance.ID, createDiskResponse.ID, linodego.DiskReady, 180)
+	createDiskResponse, err = client.WaitForInstanceDiskStatus(ctx, instance.ID, createDiskResponse.ID, linodego.DiskReady)
 	require.NoError(t, err)
 	assert.Equal(t, linodego.DiskReady, createDiskResponse.Status)
 

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -171,6 +171,15 @@ func createTestClient(t *testing.T, fixturesYaml string) (*linodego.Client, func
 	return &c, recordStopper
 }
 
+func waitContext(t *testing.T, timeout time.Duration) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	t.Cleanup(cancel)
+
+	return ctx
+}
+
 // transportRecordWrapper returns a tranport.WrapperFunc which provides the test
 // recorder as an http.RoundTripper.
 func transportRecorderWrapper(t *testing.T, fixtureYaml string) (transport.WrapperFunc, func()) {

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	k8scondition "github.com/linode/linodego/k8s/pkg/condition"
@@ -30,6 +31,8 @@ func TestLKECluster_GetMissing(t *testing.T) {
 }
 
 func TestLKECluster_WaitForReady(t *testing.T) {
+	ctx := waitContext(t, 10*60*time.Second)
+
 	client, cluster, teardown, err := setupLKECluster(t, []clusterModifier{func(createOpts *linodego.LKEClusterCreateOptions) {
 		createOpts.Label = "go-lke-test-wait"
 		createOpts.NodePools = []linodego.LKENodePoolCreateOptions{
@@ -41,9 +44,8 @@ func TestLKECluster_WaitForReady(t *testing.T) {
 	wrapper, teardownClusterClient := transportRecorderWrapper(t, "fixtures/TestLKECluster_WaitForReady_Cluster")
 	defer teardownClusterClient()
 
-	if err = k8scondition.WaitForLKEClusterReady(context.Background(), *client, cluster.ID, linodego.LKEClusterPollOptions{
+	if err = k8scondition.WaitForLKEClusterReady(ctx, *client, cluster.ID, linodego.LKEClusterPollOptions{
 		Retry:            true,
-		TimeoutSeconds:   10 * 60,
 		TransportWrapper: wrapper,
 	}); err != nil {
 		t.Errorf("Error waiting for the LKE cluster pools to be ready: %s", err)
@@ -205,12 +207,14 @@ func TestLKECluster_APIEndpoints_List(t *testing.T) {
 }
 
 func TestLKECluster_Kubeconfig_Get(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, lkeCluster, teardown, err := setupLKECluster(t, []clusterModifier{func(createOpts *linodego.LKEClusterCreateOptions) {
 		createOpts.Label = "go-lke-test-kube-get"
 	}}, "fixtures/TestLKECluster_Kubeconfig_Get")
 	defer teardown()
 
-	_, err = client.WaitForLKEClusterStatus(context.Background(), lkeCluster.ID, linodego.LKEClusterReady, 180)
+	_, err = client.WaitForLKEClusterStatus(ctx, lkeCluster.ID, linodego.LKEClusterReady)
 	if err != nil {
 		t.Errorf("Error waiting for LKECluster readiness: %s", err)
 	}
@@ -224,12 +228,14 @@ func TestLKECluster_Kubeconfig_Get(t *testing.T) {
 }
 
 func TestLKECluster_Kubeconfig_Delete(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, lkeCluster, teardown, err := setupLKECluster(t, []clusterModifier{func(createOpts *linodego.LKEClusterCreateOptions) {
 		createOpts.Label = "go-lke-test-kube-delete"
 	}}, "fixtures/TestLKECluster_Kubeconfig_Delete")
 	defer teardown()
 
-	_, err = client.WaitForLKEClusterStatus(context.Background(), lkeCluster.ID, linodego.LKEClusterReady, 180)
+	_, err = client.WaitForLKEClusterStatus(ctx, lkeCluster.ID, linodego.LKEClusterReady)
 	if err != nil {
 		t.Errorf("Error waiting for LKECluster readiness: %s", err)
 	}
@@ -248,12 +254,14 @@ func TestLKECluster_Kubeconfig_Delete(t *testing.T) {
 }
 
 func TestLKECluster_Dashboard_Get(t *testing.T) {
+	ctx := waitContext(t, 180*time.Second)
+
 	client, lkeCluster, teardown, err := setupLKECluster(t, []clusterModifier{func(createOpts *linodego.LKEClusterCreateOptions) {
 		createOpts.Label = "go-lke-test-dash"
 	}}, "fixtures/TestLKECluster_Dashboard_Get")
 	defer teardown()
 
-	_, err = client.WaitForLKEClusterStatus(context.Background(), lkeCluster.ID, linodego.LKEClusterReady, 180)
+	_, err = client.WaitForLKEClusterStatus(ctx, lkeCluster.ID, linodego.LKEClusterReady)
 	if err != nil {
 		t.Errorf("Error waiting for LKECluster readiness: %s", err)
 	}

--- a/test/integration/lke_node_pools_test.go
+++ b/test/integration/lke_node_pools_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/linode/linodego"
@@ -41,13 +42,15 @@ func TestLKENodePool_GetMissing(t *testing.T) {
 }
 
 func TestLKENodePool_GetFound(t *testing.T) {
+	ctx := waitContext(t, 10*time.Minute)
+
 	client, lkeCluster, pool, teardown, err := setupLKENodePool(t, "fixtures/TestLKENodePool_GetFound", &testLKENodePoolCreateOpts)
 	if err != nil {
 		t.Error(err)
 	}
 	defer teardown()
 
-	i, err := client.GetLKENodePool(context.Background(), lkeCluster.ID, pool.ID)
+	i, err := client.GetLKENodePool(ctx, lkeCluster.ID, pool.ID)
 	if err != nil {
 		t.Errorf("Error getting LKENodePool, expected struct, got %v and error %v", i, err)
 	}
@@ -79,21 +82,20 @@ func TestLKENodePool_GetFound(t *testing.T) {
 	wrapper, teardownClusterClient := transportRecorderWrapper(t, "fixtures/TestLKENodePool_GetFound_k8s")
 	defer teardownClusterClient()
 
-	if err := k8scondition.WaitForLKEClusterAndNodesReady(context.TODO(), *client, lkeCluster.ID, linodego.LKEClusterPollOptions{
+	if err := k8scondition.WaitForLKEClusterAndNodesReady(ctx, *client, lkeCluster.ID, linodego.LKEClusterPollOptions{
 		Retry:            true,
-		TimeoutSeconds:   0,
 		TransportWrapper: wrapper,
 	}); err != nil {
 		t.Fatalf("got err waiting for LKE cluster and nodes to be ready, err: %v", err)
 	}
 
-	i, err = client.GetLKENodePool(context.TODO(), lkeCluster.ID, pool.ID)
+	i, err = client.GetLKENodePool(ctx, lkeCluster.ID, pool.ID)
 	if err != nil {
 		t.Fatalf("failed to get lke node pool, got err: %v", err)
 	}
 
 	for _, node := range i.Linodes {
-		instance, err := client.GetInstance(context.Background(), node.InstanceID)
+		instance, err := client.GetInstance(ctx, node.InstanceID)
 		if err != nil {
 			t.Errorf("failed to get Linode, got err: %v", err)
 		}

--- a/test/integration/monitor_alert_definitions_test.go
+++ b/test/integration/monitor_alert_definitions_test.go
@@ -18,6 +18,8 @@ const (
 )
 
 func TestMonitorAlertDefinition_smoke(t *testing.T) {
+	ctx := waitContext(t, 300*time.Second)
+
 	client, teardown := createTestClient(t, "fixtures/TestMonitorAlertDefinition")
 	defer teardown()
 
@@ -154,11 +156,10 @@ func TestMonitorAlertDefinition_smoke(t *testing.T) {
 	}
 	// wait for 1 minute before update for create to complete
 	_, err = client.WaitForAlertDefinitionStatus(
-		context.Background(),
+		ctx,
 		linodego.AlertDefinitionStatusEnabled,
 		testMonitorAlertDefinitionServiceType,
 		createdAlert.ID,
-		300, // timeout in seconds (5 minutes)
 	)
 	if err != nil {
 		t.Logf("failed to wait for alert definition to be enabled: %s", err)

--- a/test/integration/monitor_api_service_test.go
+++ b/test/integration/monitor_api_service_test.go
@@ -3,12 +3,15 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 )
 
 func TestMonitorAPI_Fetch_Entity_Metrics(t *testing.T) {
-	mClient, entityIDs, teardown, err := setup(t, "fixtures/TestMonitorAPI_Get_Entity_Metrics")
+	ctx := waitContext(t, 5400*time.Second)
+
+	mClient, entityIDs, teardown, err := setup(t, ctx, "fixtures/TestMonitorAPI_Get_Entity_Metrics")
 	if err != nil {
 		t.Error(err)
 	}
@@ -38,7 +41,7 @@ func TestMonitorAPI_Fetch_Entity_Metrics(t *testing.T) {
 	}
 }
 
-func setup(t *testing.T, fixturesYaml string) (*linodego.MonitorClient, []any, func(), error) {
+func setup(t *testing.T, ctx context.Context, fixturesYaml string) (*linodego.MonitorClient, []any, func(), error) {
 	t.Helper()
 
 	client, clientFixtureTeardown := createTestClient(t, "fixtures/TestMonitorAPI_Get_Entity_Metrics_ListDB")
@@ -51,7 +54,7 @@ func setup(t *testing.T, fixturesYaml string) (*linodego.MonitorClient, []any, f
 	var teardown func()
 	if len(dbs) < 1 {
 		// create a DB entity to generate token
-		client, _, teardown, err = setupPostgresDatabase(t, nil, "fixtures/TestMonitorAPI_Get_Entity_Metrics_setupPostgres")
+		client, _, teardown, err = setupPostgresDatabase(t, ctx, nil, "fixtures/TestMonitorAPI_Get_Entity_Metrics_setupPostgres")
 		if err != nil {
 			t.Error(err)
 		}

--- a/test/integration/monitor_services_token_creation_test.go
+++ b/test/integration/monitor_services_token_creation_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
@@ -10,7 +11,9 @@ import (
 )
 
 func TestMonitorServicesTokenCreation_Get_smoke(t *testing.T) {
-	client, _, teardown, err := setupPostgresDatabase(t, nil, "fixtures/TestMonitorServicesTokenCreation_Get")
+	ctx := waitContext(t, 5400*time.Second)
+
+	client, _, teardown, err := setupPostgresDatabase(t, ctx, nil, "fixtures/TestMonitorServicesTokenCreation_Get")
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/mysql_db_config_test.go
+++ b/test/integration/mysql_db_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
@@ -195,12 +196,15 @@ func TestDatabaseMySQL_EngineConfig_Get(t *testing.T) {
 }
 
 func TestDatabaseMySQL_EngineConfig_Suite(t *testing.T) {
+	ctx := waitContext(t, 6720*time.Second)
+
 	databaseModifiers := []mysqlDatabaseModifier{
 		createMySQLOptionsModifier(),
 	}
 
 	client, database, teardown, err := setupMySQLDatabase(
 		t,
+		ctx,
 		databaseModifiers,
 		"fixtures/TestDatabaseMySQL_EngineConfig_Suite",
 	)
@@ -237,7 +241,7 @@ func TestDatabaseMySQL_EngineConfig_Suite(t *testing.T) {
 		t.Errorf("failed to update db %d: %v", database.ID, err)
 	}
 
-	waitForDatabaseUpdated(t, client, updatedDB.ID, linodego.DatabaseEngineTypeMySQL, updatedDB.Created)
+	waitForDatabaseUpdated(t, ctx, client, updatedDB.ID, linodego.DatabaseEngineTypeMySQL, updatedDB.Created)
 
 	assertUpdatedSQLFields(t, updatedDB.EngineConfig.MySQL)
 }

--- a/test/integration/mysql_test.go
+++ b/test/integration/mysql_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestDatabase_MySQL_Suite(t *testing.T) {
-	client, database, teardown, err := setupMySQLDatabase(t, nil, "fixtures/TestDatabase_MySQL_Suite")
+	ctx := waitContext(t, 12000*time.Second)
+
+	client, database, teardown, err := setupMySQLDatabase(t, ctx, nil, "fixtures/TestDatabase_MySQL_Suite")
 	if err != nil {
 		t.Error(err)
 	}
@@ -64,7 +66,7 @@ func TestDatabase_MySQL_Suite(t *testing.T) {
 		t.Errorf("failed to update db %d: %v", database.ID, err)
 	}
 
-	waitForDatabaseUpdated(t, client, db.ID, linodego.DatabaseEngineTypeMySQL, db.Created)
+	waitForDatabaseUpdated(t, ctx, client, db.ID, linodego.DatabaseEngineTypeMySQL, db.Created)
 
 	if db.ID != database.ID {
 		t.Errorf("updated db does not match original id")
@@ -117,15 +119,15 @@ func TestDatabase_MySQL_Suite(t *testing.T) {
 
 	// Wait for the DB to enter updating status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypeMySQL,
-		linodego.DatabaseStatusUpdating, 240); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypeMySQL,
+		linodego.DatabaseStatusUpdating); err != nil {
 		t.Fatalf("failed to wait for database updating: %s", err)
 	}
 
 	// Wait for the DB to re-enter active status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypeMySQL,
-		linodego.DatabaseStatusActive, 2400); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypeMySQL,
+		linodego.DatabaseStatusActive); err != nil {
 		t.Fatalf("failed to wait for database active: %s", err)
 	}
 
@@ -135,8 +137,8 @@ func TestDatabase_MySQL_Suite(t *testing.T) {
 
 	// Wait for the DB to enter suspended status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypeMySQL,
-		linodego.DatabaseStatusSuspended, 240); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypeMySQL,
+		linodego.DatabaseStatusSuspended); err != nil {
 		t.Fatalf("failed to wait for database suspended: %s", err)
 	}
 
@@ -146,8 +148,8 @@ func TestDatabase_MySQL_Suite(t *testing.T) {
 
 	// Wait for the DB to re-enter active status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypeMySQL,
-		linodego.DatabaseStatusActive, 2400); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypeMySQL,
+		linodego.DatabaseStatusActive); err != nil {
 		t.Fatalf("failed to wait for database active: %s", err)
 	}
 }
@@ -208,7 +210,7 @@ func createMySQLDatabase(t *testing.T, client *linodego.Client,
 	return database, teardown, nil
 }
 
-func setupMySQLDatabase(t *testing.T, databaseMofidiers []mysqlDatabaseModifier,
+func setupMySQLDatabase(t *testing.T, ctx context.Context, databaseMofidiers []mysqlDatabaseModifier,
 	fixturesYaml string,
 ) (*linodego.Client, *linodego.MySQLDatabase, func(), error) {
 	t.Helper()
@@ -219,8 +221,8 @@ func setupMySQLDatabase(t *testing.T, databaseMofidiers []mysqlDatabaseModifier,
 		t.Fatalf("failed to create db: %s", err)
 	}
 
-	_, err = client.WaitForEventFinished(context.Background(), database.ID, linodego.EntityDatabase,
-		linodego.ActionDatabaseCreate, now, 5400)
+	_, err = client.WaitForEventFinished(ctx, database.ID, linodego.EntityDatabase,
+		linodego.ActionDatabaseCreate, now)
 	if err != nil {
 		t.Fatalf("failed to wait for db create event: %s", err)
 	}

--- a/test/integration/postgres_db_config_test.go
+++ b/test/integration/postgres_db_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
@@ -273,11 +274,13 @@ func TestDatabasePostgres_EngineConfig_Get(t *testing.T) {
 }
 
 func TestDatabasePostgres_EngineConfig_Suite(t *testing.T) {
+	ctx := waitContext(t, 6720*time.Second)
+
 	databaseModifiers := []postgresDatabaseModifier{
 		createPostgresOptionsModifier(),
 	}
 
-	client, database, teardown, err := setupPostgresDatabase(t, databaseModifiers, "fixtures/TestDatabasePostgres_EngineConfig_Suite")
+	client, database, teardown, err := setupPostgresDatabase(t, ctx, databaseModifiers, "fixtures/TestDatabasePostgres_EngineConfig_Suite")
 	if err != nil {
 		t.Error(err)
 	}
@@ -308,7 +311,7 @@ func TestDatabasePostgres_EngineConfig_Suite(t *testing.T) {
 		t.Errorf("failed to update db %d: %v", database.ID, err)
 	}
 
-	waitForDatabaseUpdated(t, client, updatedDB.ID, linodego.DatabaseEngineTypePostgres, updatedDB.Created)
+	waitForDatabaseUpdated(t, ctx, client, updatedDB.ID, linodego.DatabaseEngineTypePostgres, updatedDB.Created)
 
 	assertUpdatedPostgresFields(t, updatedDB.EngineConfig.PG)
 }

--- a/test/integration/postgres_test.go
+++ b/test/integration/postgres_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestDatabase_Postgres_Suite(t *testing.T) {
-	client, database, teardown, err := setupPostgresDatabase(t, nil, "fixtures/TestDatabase_Postgres_Suite")
+	ctx := waitContext(t, 14160*time.Second)
+
+	client, database, teardown, err := setupPostgresDatabase(t, ctx, nil, "fixtures/TestDatabase_Postgres_Suite")
 	if err != nil {
 		t.Error(err)
 	}
@@ -64,7 +66,7 @@ func TestDatabase_Postgres_Suite(t *testing.T) {
 		t.Errorf("failed to update db %d: %v", database.ID, err)
 	}
 
-	waitForDatabaseUpdated(t, client, db.ID, linodego.DatabaseEngineTypePostgres, db.Created)
+	waitForDatabaseUpdated(t, ctx, client, db.ID, linodego.DatabaseEngineTypePostgres, db.Created)
 
 	if db.ID != database.ID {
 		t.Errorf("updated db does not match original id")
@@ -121,15 +123,15 @@ func TestDatabase_Postgres_Suite(t *testing.T) {
 
 	// Wait for the DB to enter updating status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypePostgres,
-		linodego.DatabaseStatusUpdating, 240); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypePostgres,
+		linodego.DatabaseStatusUpdating); err != nil {
 		t.Fatalf("failed to wait for database updating: %s", err)
 	}
 
 	// Wait for the DB to re-enter active status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypePostgres,
-		linodego.DatabaseStatusActive, 2400); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypePostgres,
+		linodego.DatabaseStatusActive); err != nil {
 		t.Fatalf("failed to wait for database updating: %s", err)
 	}
 
@@ -139,8 +141,8 @@ func TestDatabase_Postgres_Suite(t *testing.T) {
 
 	// Wait for the DB to enter suspended status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypePostgres,
-		linodego.DatabaseStatusSuspended, 2400); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypePostgres,
+		linodego.DatabaseStatusSuspended); err != nil {
 		t.Fatalf("failed to wait for database suspended: %s", err)
 	}
 
@@ -150,8 +152,8 @@ func TestDatabase_Postgres_Suite(t *testing.T) {
 
 	// Wait for the DB to re-enter active status
 	if err := client.WaitForDatabaseStatus(
-		context.Background(), database.ID, linodego.DatabaseEngineTypePostgres,
-		linodego.DatabaseStatusActive, 2400); err != nil {
+		ctx, database.ID, linodego.DatabaseEngineTypePostgres,
+		linodego.DatabaseStatusActive); err != nil {
 		t.Fatalf("failed to wait for database active: %s", err)
 	}
 }
@@ -211,7 +213,7 @@ func createPostgresDatabase(t *testing.T, client *linodego.Client,
 	return database, teardown, nil
 }
 
-func setupPostgresDatabase(t *testing.T, databaseMofidiers []postgresDatabaseModifier,
+func setupPostgresDatabase(t *testing.T, ctx context.Context, databaseMofidiers []postgresDatabaseModifier,
 	fixturesYaml string,
 ) (*linodego.Client, *linodego.PostgresDatabase, func(), error) {
 	t.Helper()
@@ -222,8 +224,8 @@ func setupPostgresDatabase(t *testing.T, databaseMofidiers []postgresDatabaseMod
 		t.Fatalf("failed to create db: %s", err)
 	}
 
-	_, err = client.WaitForEventFinished(context.Background(), database.ID, linodego.EntityDatabase,
-		linodego.ActionDatabaseCreate, now, 5400)
+	_, err = client.WaitForEventFinished(ctx, database.ID, linodego.EntityDatabase,
+		linodego.ActionDatabaseCreate, now)
 	if err != nil {
 		t.Fatalf("failed to wait for db create event: %s", err)
 	}

--- a/test/integration/vlans_test.go
+++ b/test/integration/vlans_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 )
 
 func TestVLANs_List_smoke(t *testing.T) {
+	ctx := waitContext(t, 240*time.Second)
+
 	vlanName := "go-vlan-test-list"
 	instancePrefix := "go-ins-test-list"
 
@@ -28,7 +31,7 @@ func TestVLANs_List_smoke(t *testing.T) {
 	}
 
 	for _, instance := range instances {
-		if _, err := client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceRunning, 240); err != nil {
+		if _, err := client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceRunning); err != nil {
 			t.Error(err)
 		}
 	}
@@ -52,6 +55,8 @@ func TestVLANs_List_smoke(t *testing.T) {
 }
 
 func TestVLANs_GetIPAMAddress(t *testing.T) {
+	ctx := waitContext(t, 240*time.Second)
+
 	vlanName := "go-vlan-test-ipam"
 	instancePrefix := "go-ins-test-ipam"
 
@@ -64,7 +69,7 @@ func TestVLANs_GetIPAMAddress(t *testing.T) {
 	}
 	defer instanceTeardown()
 
-	_, err = client.WaitForInstanceStatus(context.Background(), instance.ID, linodego.InstanceRunning, 240)
+	_, err = client.WaitForInstanceStatus(ctx, instance.ID, linodego.InstanceRunning)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -67,6 +67,8 @@ func TestVolume_Create_withEncryption(t *testing.T) {
 }
 
 func TestVolume_Resize(t *testing.T) {
+	ctx := waitContext(t, 500*time.Second)
+
 	client, volume, teardown, err := setupVolume(t, "fixtures/TestVolume_Resize")
 	defer teardown()
 
@@ -74,7 +76,7 @@ func TestVolume_Resize(t *testing.T) {
 		t.Errorf("Error setting up volume test, %s", err)
 	}
 
-	_, err = client.WaitForVolumeStatus(context.Background(), volume.ID, linodego.VolumeActive, 500)
+	_, err = client.WaitForVolumeStatus(ctx, volume.ID, linodego.VolumeActive)
 	if err != nil {
 		t.Errorf("Error waiting for volume to be active, %s", err)
 	}
@@ -171,19 +173,23 @@ func TestVolume_Get_withEncryption(t *testing.T) {
 }
 
 func TestVolume_WaitForLinodeID_nil(t *testing.T) {
+	ctx := waitContext(t, 20*time.Second)
+
 	client, volume, teardown, err := setupVolume(t, "fixtures/TestVolume_WaitForLinodeID_nil")
 	defer teardown()
 
 	if err != nil {
 		t.Errorf("Error setting up volume test, %s", err)
 	}
-	_, err = client.WaitForVolumeLinodeID(context.Background(), volume.ID, nil, 20)
+	_, err = client.WaitForVolumeLinodeID(ctx, volume.ID, nil)
 	if err != nil {
 		t.Errorf("Error getting volume %d, expected *LinodeVolume, got error %v", volume.ID, err)
 	}
 }
 
 func TestVolume_WaitForLinodeID(t *testing.T) {
+	ctx := waitContext(t, 40*time.Second)
+
 	client, instance, teardownInstance, errInstance := setupInstance(t, "fixtures/TestVolume_WaitForLinodeID_linode", true)
 	if errInstance != nil {
 		t.Errorf("Error setting up instance for volume test, %s", errInstance)
@@ -213,7 +219,7 @@ func TestVolume_WaitForLinodeID(t *testing.T) {
 		t.Errorf("Could not attach test volume to test instance")
 	}
 
-	_, errWait := client.WaitForVolumeLinodeID(context.Background(), volume.ID, nil, 20)
+	_, errWait := client.WaitForVolumeLinodeID(ctx, volume.ID, nil)
 	if errWait == nil {
 		t.Errorf("Expected to timeout waiting for nil LinodeID on volume %d : %s", volume.ID, errWait)
 	}
@@ -221,7 +227,7 @@ func TestVolume_WaitForLinodeID(t *testing.T) {
 	client, teardownWait := createTestClient(t, "fixtures/TestVolume_WaitForLinodeID_waiting")
 	defer teardownWait()
 
-	v, errWait := client.WaitForVolumeLinodeID(context.Background(), volume.ID, &instance.ID, 20)
+	v, errWait := client.WaitForVolumeLinodeID(ctx, volume.ID, &instance.ID)
 	if errWait != nil {
 		t.Errorf("Error waiting for volume %d to attach to instance %d: %s", volume.ID, instance.ID, errWait)
 	}

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/linode/linodego"
 )
 
 func TestEventPoller_InstancePower(t *testing.T) {
+	ctx := waitContext(t, 520*time.Second)
+
 	client, fixtureTeardown := createTestClient(t, "fixtures/TestEventPoller_InstancePower")
 	t.Cleanup(fixtureTeardown)
 
@@ -37,7 +40,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 
 	p.EntityID = instance.ID
 
-	if _, err := p.WaitForFinished(context.Background(), 120); err != nil {
+	if _, err := p.WaitForFinished(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -52,7 +55,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	event, err := p.WaitForFinished(context.Background(), 200)
+	event, err := p.WaitForFinished(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +80,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	event, err = p.WaitForFinished(context.Background(), 200)
+	event, err = p.WaitForFinished(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,6 +100,8 @@ func TestEventPoller_InstancePower(t *testing.T) {
 }
 
 func TestWaitForResourceFree(t *testing.T) {
+	ctx := waitContext(t, 240*time.Second)
+
 	client, fixtureTeardown := createTestClient(t, "fixtures/TestWaitForResourceFree")
 	t.Cleanup(fixtureTeardown)
 
@@ -119,7 +124,7 @@ func TestWaitForResourceFree(t *testing.T) {
 	})
 
 	// Wait for the instance to be done with all events
-	err = client.WaitForResourceFree(context.Background(), linodego.EntityLinode, instance.ID, 240)
+	err = client.WaitForResourceFree(ctx, linodego.EntityLinode, instance.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,6 +141,8 @@ func TestWaitForResourceFree(t *testing.T) {
 }
 
 func TestEventPoller_Secondary(t *testing.T) {
+	ctx := waitContext(t, 240*time.Second)
+
 	client, fixtureTeardown := createTestClient(t, "fixtures/TestEventPoller_Secondary")
 	defer fixtureTeardown()
 
@@ -162,7 +169,7 @@ func TestEventPoller_Secondary(t *testing.T) {
 
 	createPoller.EntityID = instance.ID
 
-	if _, err := createPoller.WaitForFinished(context.Background(), 120); err != nil {
+	if _, err := createPoller.WaitForFinished(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -211,7 +218,7 @@ func TestEventPoller_Secondary(t *testing.T) {
 	}
 
 	// Wait for the first disk to be deleted
-	deleteEvent, err := diskPoller.WaitForFinished(context.Background(), 60)
+	deleteEvent, err := diskPoller.WaitForFinished(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +226,7 @@ func TestEventPoller_Secondary(t *testing.T) {
 	// Poll for the second disk to be deleted.
 	// This is necessary to cover an edge case that triggers a panic
 	// when other deletion events with a null SecondaryEntity are discovered.
-	if _, err := diskPoller2.WaitForFinished(context.Background(), 60); err != nil {
+	if _, err := diskPoller2.WaitForFinished(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/unit/waitfor_test.go
+++ b/test/unit/waitfor_test.go
@@ -1,0 +1,144 @@
+package unit
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/linode/linodego"
+)
+
+func TestWaitForInstanceStatusUsesContextDeadline(t *testing.T) {
+	client := createMockClient(t)
+	client.SetPollDelay(time.Millisecond)
+
+	httpmock.RegisterRegexpResponder("GET", mockRequestURL(t, "linode/instances/123"),
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(http.StatusOK, linodego.Instance{ID: 123, Status: linodego.InstanceProvisioning})
+		})
+
+	_, err := client.WaitForInstanceStatus(waitTestContext(t, 5*time.Millisecond), 123, linodego.InstanceRunning)
+	if err == nil {
+		t.Fatal("expected deadline error")
+	}
+}
+
+func TestWaitForVolumeStatusSuccess(t *testing.T) {
+	client := createMockClient(t)
+	client.SetPollDelay(time.Millisecond)
+
+	step := 0
+	httpmock.RegisterRegexpResponder("GET", mockRequestURL(t, "volumes/123"),
+		func(_ *http.Request) (*http.Response, error) {
+			step++
+
+			status := linodego.VolumeCreating
+			if step == 2 {
+				status = linodego.VolumeActive
+			}
+
+			return httpmock.NewJsonResponse(http.StatusOK, linodego.Volume{ID: 123, Status: status})
+		})
+
+	volume, err := client.WaitForVolumeStatus(waitTestContext(t, time.Second), 123, linodego.VolumeActive)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if volume.Status != linodego.VolumeActive {
+		t.Fatalf("expected volume to be active, got %s", volume.Status)
+	}
+
+	if step != 2 {
+		t.Fatalf("expected 2 polls, got %d", step)
+	}
+}
+
+func TestWaitForVolumeLinodeIDNil(t *testing.T) {
+	client := createMockClient(t)
+	client.SetPollDelay(time.Millisecond)
+
+	httpmock.RegisterRegexpResponder("GET", mockRequestURL(t, "volumes/123"),
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(http.StatusOK, linodego.Volume{ID: 123, LinodeID: nil})
+		})
+
+	volume, err := client.WaitForVolumeLinodeID(waitTestContext(t, time.Second), 123, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if volume.LinodeID != nil {
+		t.Fatalf("expected nil LinodeID, got %v", volume.LinodeID)
+	}
+}
+
+func TestEventPollerWaitForFinished(t *testing.T) {
+	client := createMockClient(t)
+	client.SetPollDelay(time.Millisecond)
+
+	listEventsCount := 0
+	httpmock.RegisterRegexpResponder("GET", regexp.MustCompile(`/[a-zA-Z0-9]+/account/events(\?.*)?$`),
+		func(_ *http.Request) (*http.Response, error) {
+			listEventsCount++
+
+			events := []linodego.Event{{
+				ID:     111,
+				Status: linodego.EventFinished,
+				Action: linodego.ActionLinodeBoot,
+				Entity: &linodego.EventEntity{ID: 123, Type: linodego.EntityLinode},
+			}}
+
+			if listEventsCount > 1 {
+				events = append(events, linodego.Event{
+					ID:     456,
+					Status: linodego.EventStarted,
+					Action: linodego.ActionLinodeBoot,
+					Entity: &linodego.EventEntity{ID: 123, Type: linodego.EntityLinode},
+				})
+			}
+
+			return httpmock.NewJsonResponse(http.StatusOK, map[string]any{
+				"data":    events,
+				"page":    1,
+				"pages":   1,
+				"results": len(events),
+			})
+		})
+
+	poller, err := client.NewEventPoller(
+		context.Background(),
+		123,
+		linodego.EntityLinode,
+		linodego.ActionLinodeBoot,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpmock.RegisterRegexpResponder("GET", regexp.MustCompile(`/[a-zA-Z0-9]+/account/events/456$`),
+		func(_ *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(http.StatusOK, linodego.Event{ID: 456, Status: linodego.EventFinished})
+		})
+
+	event, err := poller.WaitForFinished(waitTestContext(t, time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if event.Status != linodego.EventFinished {
+		t.Fatalf("expected event to be finished, got %s", event.Status)
+	}
+}
+
+func waitTestContext(t *testing.T, timeout time.Duration) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	t.Cleanup(cancel)
+
+	return ctx
+}

--- a/waitfor.go
+++ b/waitfor.go
@@ -465,11 +465,10 @@ func (client Client) NewEventPoller(
 		EntityType: entityType,
 		Action:     action,
 
-		client:         client,
-		previousEvents: make(map[int]bool),
+		client: client,
 	}
 
-	if err := result.PreTask(ctx); err != nil {
+	if err := result.preTask(ctx); err != nil {
 		return nil, fmt.Errorf("failed to run pretask: %w", err)
 	}
 
@@ -509,40 +508,6 @@ func (client Client) NewEventPollerWithoutEntity(entityType EntityType, action E
 	}
 
 	return &result, nil
-}
-
-// PreTask stores all current events for the given entity to prevent them from being
-// processed on subsequent runs.
-func (p *EventPoller) PreTask(ctx context.Context) error {
-	f := Filter{
-		OrderBy: "created",
-		Order:   Descending,
-	}
-	f.AddField(Eq, "entity.type", p.EntityType)
-	f.AddField(Eq, "entity.id", p.EntityID)
-	f.AddField(Eq, "action", p.Action)
-
-	fBytes, err := f.MarshalJSON()
-	if err != nil {
-		return err
-	}
-
-	events, err := p.client.ListEvents(ctx, &ListOptions{
-		Filter:      string(fBytes),
-		PageOptions: &PageOptions{Page: 1},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list events: %w", err)
-	}
-
-	eventIDs := make(map[int]bool, len(events))
-	for _, event := range events {
-		eventIDs[event.ID] = true
-	}
-
-	p.previousEvents = eventIDs
-
-	return nil
 }
 
 // WaitForLatestUnknownEvent waits for the next event not observed by this poller.
@@ -739,6 +704,40 @@ func (client Client) WaitForVolumeIOReadyStatus(
 			return fmt.Errorf("failed to wait for Volume %d IO Ready status %t: %w", volumeID, status, ctx.Err())
 		},
 	)
+}
+
+// preTask stores all current events for the given entity to prevent them from being
+// processed on subsequent runs.
+func (p *EventPoller) preTask(ctx context.Context) error {
+	f := Filter{
+		OrderBy: "created",
+		Order:   Descending,
+	}
+	f.AddField(Eq, "entity.type", p.EntityType)
+	f.AddField(Eq, "entity.id", p.EntityID)
+	f.AddField(Eq, "action", p.Action)
+
+	fBytes, err := f.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	events, err := p.client.ListEvents(ctx, &ListOptions{
+		Filter:      string(fBytes),
+		PageOptions: &PageOptions{Page: 1},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list events: %w", err)
+	}
+
+	eventIDs := make(map[int]bool, len(events))
+	for _, event := range events {
+		eventIDs[event.ID] = true
+	}
+
+	p.previousEvents = eventIDs
+
+	return nil
 }
 
 // poll runs check on each tick until check reports done, returns an error, or ctx is canceled.

--- a/waitfor.go
+++ b/waitfor.go
@@ -741,6 +741,9 @@ func (client Client) WaitForVolumeIOReadyStatus(
 	)
 }
 
+// poll runs check on each tick until check reports done, returns an error, or ctx is canceled.
+//
+//nolint:ireturn // false positive: returning a generic concrete type, not an interface
 func poll[T any](
 	ctx context.Context,
 	client *Client,

--- a/waitfor.go
+++ b/waitfor.go
@@ -730,7 +730,7 @@ func (client Client) WaitForVolumeIOReadyStatus(
 		func(ctx context.Context) (*Volume, bool, error) {
 			volume, err := client.GetVolume(ctx, volumeID)
 			if err != nil {
-				return volume, false, err
+				return volume, false, fmt.Errorf("failed to get volume %w", err)
 			}
 
 			return volume, volume.IOReady == status, nil

--- a/waitfor.go
+++ b/waitfor.go
@@ -15,6 +15,7 @@ import (
 
 var englishTitle = cases.Title(language.English)
 
+// EventPoller waits for events associated with a given entity and action.
 type EventPoller struct {
 	EntityID   any
 	EntityType EntityType
@@ -30,189 +31,137 @@ type EventPoller struct {
 }
 
 // WaitForInstanceStatus waits for the Linode instance to reach the desired state
-// before returning. It will timeout with an error after timeoutSeconds.
-func (client Client) WaitForInstanceStatus(ctx context.Context, instanceID int, status InstanceStatus, timeoutSeconds int) (*Instance, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+// before returning.
+func (client Client) WaitForInstanceStatus(ctx context.Context, instanceID int, status InstanceStatus) (*Instance, error) {
+	return poll(ctx, &client,
+		func(ctx context.Context) (*Instance, bool, error) {
 			instance, err := client.GetInstance(ctx, instanceID)
 			if err != nil {
-				return instance, err
+				return instance, false, err
 			}
 
-			complete := (instance.Status == status)
-
-			if complete {
-				return instance, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Instance %d status %s: %w", instanceID, status, ctx.Err())
-		}
-	}
+			return instance, instance.Status == status, nil
+		},
+		func() error {
+			return fmt.Errorf("Error waiting for Instance %d status %s: %w", instanceID, status, ctx.Err())
+		},
+	)
 }
 
 // WaitForInstanceDiskStatus waits for the Linode instance disk to reach the desired state
-// before returning. It will timeout with an error after timeoutSeconds.
-func (client Client) WaitForInstanceDiskStatus(ctx context.Context, instanceID int, diskID int, status DiskStatus, timeoutSeconds int) (*InstanceDisk, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			// GetInstanceDisk will 404 on newly created disks. use List instead.
-			// disk, err := client.GetInstanceDisk(ctx, instanceID, diskID)
+// before returning.
+func (client Client) WaitForInstanceDiskStatus(ctx context.Context, instanceID int, diskID int, status DiskStatus) (*InstanceDisk, error) {
+	return poll(ctx, &client,
+		func(ctx context.Context) (*InstanceDisk, bool, error) {
+			// GetInstanceDisk will 404 on newly created disks. Use List instead.
 			disks, err := client.ListInstanceDisks(ctx, instanceID, nil)
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 
 			for _, disk := range disks {
 				if disk.ID == diskID {
-					complete := (disk.Status == status)
-					if complete {
-						return &disk, nil
+					if disk.Status == status {
+						return &disk, true, nil
 					}
 
 					break
 				}
 			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Instance %d Disk %d status %s: %w", instanceID, diskID, status, ctx.Err())
-		}
-	}
+
+			return nil, false, nil
+		},
+		func() error {
+			return fmt.Errorf("Error waiting for Instance %d Disk %d status %s: %w", instanceID, diskID, status, ctx.Err())
+		},
+	)
 }
 
 // WaitForVolumeStatus waits for the Volume to reach the desired state
-// before returning. It will timeout with an error after timeoutSeconds.
-func (client Client) WaitForVolumeStatus(ctx context.Context, volumeID int, status VolumeStatus, timeoutSeconds int) (*Volume, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+// before returning.
+func (client Client) WaitForVolumeStatus(ctx context.Context, volumeID int, status VolumeStatus) (*Volume, error) {
+	return poll(ctx, &client,
+		func(ctx context.Context) (*Volume, bool, error) {
 			volume, err := client.GetVolume(ctx, volumeID)
 			if err != nil {
-				return volume, err
+				return volume, false, err
 			}
 
-			complete := (volume.Status == status)
-
-			if complete {
-				return volume, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Volume %d status %s: %w", volumeID, status, ctx.Err())
-		}
-	}
+			return volume, volume.Status == status, nil
+		},
+		func() error {
+			return fmt.Errorf("Error waiting for Volume %d status %s: %w", volumeID, status, ctx.Err())
+		},
+	)
 }
 
 // WaitForSnapshotStatus waits for the Snapshot to reach the desired state
-// before returning. It will timeout with an error after timeoutSeconds.
+// before returning.
 func (client Client) WaitForSnapshotStatus(
 	ctx context.Context,
 	instanceID int,
 	snapshotID int,
 	status InstanceSnapshotStatus,
-	timeoutSeconds int,
 ) (*InstanceSnapshot, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+	return poll(ctx, &client,
+		func(ctx context.Context) (*InstanceSnapshot, bool, error) {
 			snapshot, err := client.GetInstanceSnapshot(ctx, instanceID, snapshotID)
 			if err != nil {
-				return snapshot, err
+				return snapshot, false, err
 			}
 
-			complete := (snapshot.Status == status)
-
-			if complete {
-				return snapshot, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Instance %d Snapshot %d status %s: %w", instanceID, snapshotID, status, ctx.Err())
-		}
-	}
+			return snapshot, snapshot.Status == status, nil
+		},
+		func() error {
+			return fmt.Errorf("Error waiting for Instance %d Snapshot %d status %s: %w", instanceID, snapshotID, status, ctx.Err())
+		},
+	)
 }
 
 // WaitForVolumeLinodeID waits for the Volume to match the desired LinodeID
 // before returning. An active Instance will not immediately attach or detach a volume, so
 // the LinodeID must be polled to determine volume readiness from the API.
-// WaitForVolumeLinodeID will timeout with an error after timeoutSeconds.
-func (client Client) WaitForVolumeLinodeID(ctx context.Context, volumeID int, linodeID *int, timeoutSeconds int) (*Volume, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+func (client Client) WaitForVolumeLinodeID(ctx context.Context, volumeID int, linodeID *int) (*Volume, error) {
+	return poll(ctx, &client,
+		func(ctx context.Context) (*Volume, bool, error) {
 			volume, err := client.GetVolume(ctx, volumeID)
 			if err != nil {
-				return volume, err
+				return volume, false, err
 			}
 
 			switch {
 			case linodeID == nil && volume.LinodeID == nil:
-				return volume, nil
+				return volume, true, nil
 			case linodeID == nil || volume.LinodeID == nil:
-				// continue waiting
+				// Continue waiting.
 			case *volume.LinodeID == *linodeID:
-				return volume, nil
+				return volume, true, nil
 			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Volume %d to have Instance %v: %w", volumeID, linodeID, ctx.Err())
-		}
-	}
+
+			return volume, false, nil
+		},
+		func() error {
+			return fmt.Errorf("Error waiting for Volume %d to have Instance %v: %w", volumeID, linodeID, ctx.Err())
+		},
+	)
 }
 
 // WaitForLKEClusterStatus waits for the LKECluster to reach the desired state
-// before returning. It will timeout with an error after timeoutSeconds.
-func (client Client) WaitForLKEClusterStatus(ctx context.Context, clusterID int, status LKEClusterStatus, timeoutSeconds int) (*LKECluster, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+// before returning.
+func (client Client) WaitForLKEClusterStatus(ctx context.Context, clusterID int, status LKEClusterStatus) (*LKECluster, error) {
+	return poll(ctx, &client,
+		func(ctx context.Context) (*LKECluster, bool, error) {
 			cluster, err := client.GetLKECluster(ctx, clusterID)
 			if err != nil {
-				return cluster, err
+				return cluster, false, err
 			}
 
-			complete := (cluster.Status == status)
-
-			if complete {
-				return cluster, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("Error waiting for Cluster %d status %s: %w", clusterID, status, ctx.Err())
-		}
-	}
+			return cluster, cluster.Status == status, nil
+		},
+		func() error {
+			return fmt.Errorf("Error waiting for Cluster %d status %s: %w", clusterID, status, ctx.Err())
+		},
+	)
 }
 
 // LKEClusterPollOptions configures polls against LKE Clusters.
@@ -220,15 +169,12 @@ type LKEClusterPollOptions struct {
 	// Retry will cause the Poll to ignore interimittent errors
 	Retry bool
 
-	// TimeoutSeconds is the number of Seconds to wait for the poll to succeed
-	// before exiting.
-	TimeoutSeconds int
-
 	// TansportWrapper allows adding a transport middleware function that will
 	// wrap the LKE Cluster client's underlying http.RoundTripper.
 	TransportWrapper func(http.RoundTripper) http.RoundTripper
 }
 
+// ClusterConditionOptions configures LKE cluster condition checks.
 type ClusterConditionOptions struct {
 	LKEClusterKubeconfig *LKEClusterKubeconfig
 	TransportWrapper     func(http.RoundTripper) http.RoundTripper
@@ -245,18 +191,12 @@ func (client Client) WaitForLKEClusterConditions(
 	options LKEClusterPollOptions,
 	conditions ...ClusterConditionFunc,
 ) error {
-	ctx, cancel := context.WithCancel(ctx)
-	if options.TimeoutSeconds != 0 {
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(options.TimeoutSeconds)*time.Second)
-	}
-	defer cancel()
-
 	lkeKubeConfig, err := client.GetLKEClusterKubeconfig(ctx, clusterID)
 	if err != nil {
 		return fmt.Errorf("failed to get Kubeconfig for LKE cluster %d: %w", clusterID, err)
 	}
 
-	ticker := time.NewTicker(client.pollInterval)
+	ticker := newTicker(&client)
 	defer ticker.Stop()
 
 	conditionOptions := ClusterConditionOptions{LKEClusterKubeconfig: lkeKubeConfig, TransportWrapper: options.TransportWrapper}
@@ -289,7 +229,7 @@ func (client Client) WaitForLKEClusterConditions(
 }
 
 // WaitForEventFinished waits for an entity action to reach the 'finished' state
-// before returning. It will timeout with an error after timeoutSeconds.
+// before returning.
 // If the event indicates a failure both the failed event and the error will be returned.
 // nolint
 func (client Client) WaitForEventFinished(
@@ -298,7 +238,6 @@ func (client Client) WaitForEventFinished(
 	entityType EntityType,
 	action EventAction,
 	minStart time.Time,
-	timeoutSeconds int,
 ) (*Event, error) {
 	titledEntityType := englishTitle.String(string(entityType))
 	filter := Filter{
@@ -326,15 +265,11 @@ func (client Client) WaitForEventFinished(
 		filter.AddField(Eq, "entity.type", entityType)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
 	if deadline, ok := ctx.Deadline(); ok {
-		duration := time.Until(deadline)
-		log.Printf("[INFO] Waiting %d seconds for %s events since %v for %s %v", int(duration.Seconds()), action, minStart, titledEntityType, id)
+		log.Printf("[INFO] Waiting %d seconds for %s events since %v for %s %v", int(time.Until(deadline).Seconds()), action, minStart, titledEntityType, id)
 	}
 
-	ticker := time.NewTicker(client.pollInterval)
+	ticker := newTicker(&client)
 
 	// avoid repeating log messages
 	nextLog := ""
@@ -363,8 +298,6 @@ func (client Client) WaitForEventFinished(
 
 			// If there are events for this instance + action, inspect them
 			for _, event := range events {
-				event := event
-
 				if event.Entity == nil || event.Entity.Type != entityType {
 					// log.Println("type mismatch", event.Entity.Type, entityType)
 					continue
@@ -382,6 +315,7 @@ func (client Client) WaitForEventFinished(
 				}
 
 				var findID string
+
 				switch id := id.(type) {
 				case float64, float32:
 					findID = fmt.Sprintf("%.f", id)
@@ -428,45 +362,31 @@ func (client Client) WaitForEventFinished(
 }
 
 // WaitForImageStatus waits for the Image to reach the desired state
-// before returning. It will timeout with an error after timeoutSeconds.
-func (client Client) WaitForImageStatus(ctx context.Context, imageID string, status ImageStatus, timeoutSeconds int) (*Image, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+// before returning.
+func (client Client) WaitForImageStatus(ctx context.Context, imageID string, status ImageStatus) (*Image, error) {
+	return poll(ctx, &client,
+		func(ctx context.Context) (*Image, bool, error) {
 			image, err := client.GetImage(ctx, imageID)
 			if err != nil {
-				return image, err
+				return image, false, err
 			}
 
-			complete := image.Status == status
-
-			if complete {
-				return image, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for Image %s status %s: %w", imageID, status, ctx.Err())
-		}
-	}
+			return image, image.Status == status, nil
+		},
+		func() error {
+			return fmt.Errorf("failed to wait for Image %s status %s: %w", imageID, status, ctx.Err())
+		},
+	)
 }
 
 // WaitForImageRegionStatus waits for an Image's replica to reach the desired state
 // before returning.
 func (client Client) WaitForImageRegionStatus(ctx context.Context, imageID, region string, status ImageRegionStatus) (*Image, error) {
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+	return poll(ctx, &client,
+		func(ctx context.Context) (*Image, bool, error) {
 			image, err := client.GetImage(ctx, imageID)
 			if err != nil {
-				return image, err
+				return image, false, err
 			}
 
 			replicaIdx := slices.IndexFunc(
@@ -476,17 +396,16 @@ func (client Client) WaitForImageRegionStatus(ctx context.Context, imageID, regi
 				},
 			)
 
-			// If no replica was found or the status doesn't match, try again
 			if replicaIdx < 0 || image.Regions[replicaIdx].Status != status {
-				continue
+				return image, false, nil
 			}
 
-			return image, nil
-
-		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for Image %s status %s: %w", imageID, status, ctx.Err())
-		}
-	}
+			return image, true, nil
+		},
+		func() error {
+			return fmt.Errorf("failed to wait for Image %s status %s: %w", imageID, status, ctx.Err())
+		},
+	)
 }
 
 type databaseStatusFunc func(ctx context.Context, client Client, dbID int) (DatabaseStatus, error)
@@ -512,34 +431,28 @@ var databaseStatusHandlers = map[DatabaseEngineType]databaseStatusFunc{
 
 // WaitForDatabaseStatus waits for the provided database to have the given status.
 func (client Client) WaitForDatabaseStatus(
-	ctx context.Context, dbID int, dbEngine DatabaseEngineType, status DatabaseStatus, timeoutSeconds int,
+	ctx context.Context, dbID int, dbEngine DatabaseEngineType, status DatabaseStatus,
 ) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+	_, err := poll(ctx, &client,
+		func(ctx context.Context) (struct{}, bool, error) {
 			statusHandler, ok := databaseStatusHandlers[dbEngine]
 			if !ok {
-				return fmt.Errorf("invalid db engine: %s", dbEngine)
+				return struct{}{}, false, fmt.Errorf("invalid db engine: %s", dbEngine)
 			}
 
 			currentStatus, err := statusHandler(ctx, client, dbID)
 			if err != nil {
-				return fmt.Errorf("failed to get db status: %w", err)
+				return struct{}{}, false, fmt.Errorf("failed to get db status: %w", err)
 			}
 
-			if currentStatus == status {
-				return nil
-			}
-		case <-ctx.Done():
+			return struct{}{}, currentStatus == status, nil
+		},
+		func() error {
 			return fmt.Errorf("failed to wait for database %d status: %w", dbID, ctx.Err())
-		}
-	}
+		},
+	)
+
+	return err
 }
 
 // NewEventPoller initializes a new Linode event poller. This should be run before the event is triggered as it stores
@@ -552,7 +465,8 @@ func (client Client) NewEventPoller(
 		EntityType: entityType,
 		Action:     action,
 
-		client: client,
+		client:         client,
+		previousEvents: make(map[int]bool),
 	}
 
 	if err := result.PreTask(ctx); err != nil {
@@ -631,8 +545,9 @@ func (p *EventPoller) PreTask(ctx context.Context) error {
 	return nil
 }
 
+// WaitForLatestUnknownEvent waits for the next event not observed by this poller.
 func (p *EventPoller) WaitForLatestUnknownEvent(ctx context.Context) (*Event, error) {
-	ticker := time.NewTicker(p.client.pollInterval)
+	ticker := newTicker(&p.client)
 	defer ticker.Stop()
 
 	f := Filter{
@@ -681,13 +596,8 @@ func (p *EventPoller) WaitForLatestUnknownEvent(ctx context.Context) (*Event, er
 }
 
 // WaitForFinished waits for a new event to be finished.
-func (p *EventPoller) WaitForFinished(
-	ctx context.Context, timeoutSeconds int,
-) (*Event, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(p.client.pollInterval)
+func (p *EventPoller) WaitForFinished(ctx context.Context) (*Event, error) {
+	ticker := newTicker(&p.client)
 	defer ticker.Stop()
 
 	event, err := p.WaitForLatestUnknownEvent(ctx)
@@ -719,7 +629,7 @@ func (p *EventPoller) WaitForFinished(
 
 // WaitForResourceFree waits for a resource to have no running events.
 func (client Client) WaitForResourceFree(
-	ctx context.Context, entityType EntityType, entityID any, timeoutSeconds int,
+	ctx context.Context, entityType EntityType, entityID any,
 ) error {
 	apiFilter := Filter{
 		Order:   Descending,
@@ -733,10 +643,7 @@ func (client Client) WaitForResourceFree(
 		return fmt.Errorf("failed to create filter: %s", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
+	ticker := newTicker(&client)
 	defer ticker.Stop()
 
 	// A helper function to determine whether a resource is busy
@@ -796,29 +703,20 @@ func (client Client) WaitForAlertDefinitionStatus(
 	status AlertDefinitionStatus,
 	serviceType string,
 	alertID int,
-	timeoutSeconds int,
 ) (*AlertDefinition, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(client.pollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
+	return poll(ctx, &client,
+		func(ctx context.Context) (*AlertDefinition, bool, error) {
 			alertDef, err := client.GetMonitorAlertDefinition(ctx, serviceType, alertID)
 			if err != nil {
-				return alertDef, err
+				return alertDef, false, err
 			}
 
-			if alertDef.Status == status {
-				return alertDef, nil
-			}
-		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for AlertDefinition %d status %s: %w", alertID, status, ctx.Err())
-		}
-	}
+			return alertDef, alertDef.Status == status, nil
+		},
+		func() error {
+			return fmt.Errorf("failed to wait for AlertDefinition %d status %s: %w", alertID, status, ctx.Err())
+		},
+	)
 }
 
 // WaitForVolumeIOReadyStatus waits for the io_ready status to verify whether the volume is
@@ -827,28 +725,49 @@ func (client Client) WaitForVolumeIOReadyStatus(
 	ctx context.Context,
 	volumeID int,
 	status bool,
-	timeoutSeconds int,
 ) (*Volume, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
-	defer cancel()
+	return poll(ctx, &client,
+		func(ctx context.Context) (*Volume, bool, error) {
+			volume, err := client.GetVolume(ctx, volumeID)
+			if err != nil {
+				return volume, false, err
+			}
 
-	ticker := time.NewTicker(client.pollInterval)
+			return volume, volume.IOReady == status, nil
+		},
+		func() error {
+			return fmt.Errorf("failed to wait for Volume %d IO Ready status %t: %w", volumeID, status, ctx.Err())
+		},
+	)
+}
+
+func poll[T any](
+	ctx context.Context,
+	client *Client,
+	check func(context.Context) (T, bool, error),
+	timeoutErr func() error,
+) (T, error) {
+	ticker := newTicker(client)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			volume, err := client.GetVolume(ctx, volumeID)
+			result, done, err := check(ctx)
 			if err != nil {
-				return volume, err
+				return result, err
 			}
 
-			if volume.IOReady == status {
-				return volume, nil
+			if done {
+				return result, nil
 			}
-
 		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to wait for Volume %d IO Ready status %t: %w", volumeID, status, ctx.Err())
+			var zero T
+			return zero, timeoutErr()
 		}
 	}
+}
+
+func newTicker(client *Client) *time.Ticker {
+	return time.NewTicker(client.GetPollDelay())
 }

--- a/waitfor.go
+++ b/waitfor.go
@@ -695,7 +695,7 @@ func (client Client) WaitForVolumeIOReadyStatus(
 		func(ctx context.Context) (*Volume, bool, error) {
 			volume, err := client.GetVolume(ctx, volumeID)
 			if err != nil {
-				return volume, false, fmt.Errorf("failed to get volume %w", err)
+				return volume, false, fmt.Errorf("failed to get volume: %w", err)
 			}
 
 			return volume, volume.IOReady == status, nil


### PR DESCRIPTION
## 📝 Description

Require timeout to be passed in context for the `WaitFor...` functions and intentionally remove `timeoutSeconds` from functions' parameters.

## ✔️ How to Test

```
make test-int
```
