### PR TITLE
TPT-3483: Update NewClient method to return an error rather than just logging errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ func main() {
 		},
 	}
 
-	linodeClient := linodego.NewClient(oauth2Client)
+	linodeClient, err := linodego.NewClient(oauth2Client)
+	if err != nil {
+		log.Fatal(err)
+	}
 	linodeClient.SetDebug(true)
 
 	res, err := linodeClient.GetInstance(context.Background(), 4090913)

--- a/client.go
+++ b/client.go
@@ -154,9 +154,9 @@ func init() {
 	}
 }
 
-// NewClient factory to create new Client struct
+// NewClient factory to create new Client struct.
 // nolint:funlen
-func NewClient(hc *http.Client) (client Client) {
+func NewClient(hc *http.Client) (client Client, err error) {
 	if hc != nil {
 		client.httpClient = hc
 	} else {
@@ -199,7 +199,9 @@ func NewClient(hc *http.Client) (client Client) {
 
 	certPath, certPathExists := os.LookupEnv(APIHostCert)
 	if certPathExists {
-		client.SetRootCertificate(certPath)
+		if err := client.SetRootCertificate(certPath); err != nil {
+			return Client{}, err
+		}
 
 		if envDebug {
 			log.Printf("[DEBUG] Set API root certificate to %s\n", certPath)
@@ -214,13 +216,16 @@ func NewClient(hc *http.Client) (client Client) {
 		SetDebug(envDebug).
 		enableLogSanitization()
 
-	return client
+	return client, nil
 }
 
 // NewClientFromEnv creates a Client and initializes it with values
 // from the LINODE_CONFIG file and the LINODE_TOKEN environment variable.
 func NewClientFromEnv(hc *http.Client) (*Client, error) {
-	client := NewClient(hc)
+	client, err := NewClient(hc)
+	if err != nil {
+		return nil, err
+	}
 
 	// Users are expected to chain NewClient(...) and LoadConfig(...) to customize these options
 	configPath, err := resolveValidConfigPath()
@@ -283,12 +288,11 @@ func (c *Client) ErrorAndLogf(format string, args ...any) error {
 	return fmt.Errorf(format, args...)
 }
 
-// SetRootCertificate adds a root certificate to the underlying TLS client config
-func (c *Client) SetRootCertificate(certPath string) *Client {
+// SetRootCertificate adds a root certificate to the underlying TLS client config.
+func (c *Client) SetRootCertificate(certPath string) error {
 	config, err := c.tlsConfig()
 	if err != nil {
-		log.Println("[WARN] Custom transport is not allowed with a custom root CA")
-		return c
+		return fmt.Errorf("custom transport is not allowed with a custom root CA: %w", err)
 	}
 
 	if config.RootCAs == nil {
@@ -297,13 +301,12 @@ func (c *Client) SetRootCertificate(certPath string) *Client {
 
 	pem, err := os.ReadFile(filepath.Clean(certPath))
 	if err != nil {
-		log.Printf("[ERROR] Failed to read root certificate at %s: %s\n", certPath, err.Error())
-		return c
+		return fmt.Errorf("failed to read root certificate at %s: %w", certPath, err)
 	}
 
 	config.RootCAs.AppendCertsFromPEM(pem)
 
-	return c
+	return nil
 }
 
 // SetToken sets the API token for all requests from this client

--- a/client_monitor.go
+++ b/client_monitor.go
@@ -128,12 +128,16 @@ func (mc *MonitorClient) SetAPIVersion(apiVersion string) *MonitorClient {
 	return mc
 }
 
-// SetRootCertificate adds a root certificate to the underlying TLS client config
-func (mc *MonitorClient) SetRootCertificate(certPath string) *MonitorClient {
+// SetRootCertificate adds a root certificate to the underlying TLS client config.
+func (mc *MonitorClient) SetRootCertificate(certPath string) error {
 	transport, ok := mc.httpClient.Transport.(*http.Transport)
 	if !ok {
-		mc.logger.Errorf("current transport is not an *http.Transport instance")
-		return mc
+		err := fmt.Errorf("current transport is not an *http.Transport instance")
+		if mc.logger != nil {
+			mc.logger.Errorf("%s", err)
+		}
+
+		return err
 	}
 
 	if transport.TLSClientConfig == nil {
@@ -148,13 +152,16 @@ func (mc *MonitorClient) SetRootCertificate(certPath string) *MonitorClient {
 
 	pem, err := os.ReadFile(filepath.Clean(certPath))
 	if err != nil {
-		mc.logger.Errorf("Failed to read root certificate at %s: %s", certPath, err.Error())
-		return mc
+		if mc.logger != nil {
+			mc.logger.Errorf("Failed to read root certificate at %s: %s", certPath, err.Error())
+		}
+
+		return fmt.Errorf("failed to read root certificate at %s: %w", certPath, err)
 	}
 
 	transport.TLSClientConfig.RootCAs.AppendCertsFromPEM(pem)
 
-	return mc
+	return nil
 }
 
 // SetToken sets the API token for all requests from this client

--- a/client_test.go
+++ b/client_test.go
@@ -21,12 +21,9 @@ import (
 
 func newTestClient(t *testing.T, hc *http.Client) Client {
 	t.Helper()
-	t.Setenv(APIHostVar, "")
-	t.Setenv(APIVersionVar, "")
 
 	client, err := NewClient(hc)
 	require.NoError(t, err)
-
 	return client
 }
 
@@ -696,6 +693,65 @@ func TestMonitorClient_SetAPIBasics(t *testing.T) {
 
 	if client.hostURL != protocolExpectedHost {
 		t.Fatal(cmp.Diff(client.hostURL, expectedHost))
+	}
+}
+
+func TestMonitorClient_SetRootCertificateWithCustomRoundTripper(t *testing.T) {
+	caFile, err := os.CreateTemp(t.TempDir(), "linodego_test_ca_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp ca file: %s", err)
+	}
+	defer os.Remove(caFile.Name())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tr := &testRoundTripper{Transport: server.Client().Transport}
+	client := NewMonitorClient(&http.Client{Transport: tr})
+
+	err = client.SetRootCertificate(caFile.Name())
+	require.ErrorContains(t, err, "current transport is not an *http.Transport instance")
+}
+
+func TestMonitorClient_SetRootCertificateWithMissingFile(t *testing.T) {
+	client := NewMonitorClient(nil)
+
+	err := client.SetRootCertificate("/does/not/exist.pem")
+	require.ErrorContains(t, err, "failed to read root certificate")
+}
+
+func TestMonitorClient_SetRootCertificateWithoutCustomRoundTripper(t *testing.T) {
+	caFile, err := os.CreateTemp(t.TempDir(), "linodego_test_ca_*")
+	if err != nil {
+		t.Fatalf("Failed to create temp ca file: %s", err)
+	}
+	defer os.Remove(caFile.Name())
+
+	tests := []struct {
+		name       string
+		httpClient *http.Client
+	}{
+		{"default http client", nil},
+		{"timeout http client", &http.Client{Timeout: time.Second}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := NewMonitorClient(test.httpClient)
+
+			err := client.SetRootCertificate(caFile.Name())
+			require.NoError(t, err)
+
+			transport, ok := client.httpClient.Transport.(*http.Transport)
+			if !ok {
+				t.Fatal("expected *http.Transport")
+			}
+			if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs == nil {
+				t.Error("expected root CAs to be set")
+			}
+		})
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +18,17 @@ import (
 	"github.com/linode/linodego/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+func newTestClient(t *testing.T, hc *http.Client) Client {
+	t.Helper()
+	t.Setenv(APIHostVar, "")
+	t.Setenv(APIVersionVar, "")
+
+	client, err := NewClient(hc)
+	require.NoError(t, err)
+
+	return client
+}
 
 func TestClient_SetAPIVersion(t *testing.T) {
 	defaultURL := "https://api.linode.com/v4"
@@ -35,7 +45,7 @@ func TestClient_SetAPIVersion(t *testing.T) {
 	protocolAPIVersion := "v4_http"
 	protocolExpectedHost := fmt.Sprintf("%s/%s", protocolBaseURL, protocolAPIVersion)
 
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 
 	if client.hostURL != defaultURL {
 		t.Fatal(cmp.Diff(client.hostURL, defaultURL))
@@ -152,7 +162,7 @@ func TestClient_UseURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			client := NewClient(nil)
+			client := newTestClient(t, nil)
 
 			_, err := client.UseURL(tt.inputURL)
 
@@ -203,7 +213,7 @@ func TestDebugLogSanitization(t *testing.T) {
 
 	plainTextToken := "NOTANAPIKEY"
 
-	mockClient := testutil.CreateMockClient(t, NewClient)
+	mockClient := testutil.CreateMockClientWithError(t, NewClient)
 	logger := testutil.CreateLogger()
 	mockClient.SetLogger(logger)
 	logger.L.SetOutput(&lgr)
@@ -253,7 +263,7 @@ func TestDoRequest_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
 
-	client := NewClient(server.Client())
+	client := newTestClient(t, server.Client())
 	client.SetBaseURL(server.URL)
 
 	params := requestParams{
@@ -273,7 +283,7 @@ func TestDoRequest_Success(t *testing.T) {
 }
 
 func TestDoRequest_FailedCreateRequest(t *testing.T) {
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 
 	// Create a request with an invalid method to simulate a request creation failure
 	err := client.doRequest(context.Background(), "bad method", "/foo/bar", requestParams{}, nil)
@@ -290,7 +300,7 @@ func TestDoRequest_Non2xxStatusCode(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
 
-	client := NewClient(server.Client())
+	client := newTestClient(t, server.Client())
 	client.SetBaseURL(server.URL)
 
 	err := client.doRequest(context.Background(), http.MethodGet, "/foo/bar", requestParams{}, nil)
@@ -321,7 +331,7 @@ func TestDoRequest_FailedDecodeResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
 
-	client := NewClient(server.Client())
+	client := newTestClient(t, server.Client())
 	client.SetBaseURL(server.URL)
 
 	params := requestParams{
@@ -348,7 +358,7 @@ func TestDoRequest_BeforeRequestSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
 
-	client := NewClient(server.Client())
+	client := newTestClient(t, server.Client())
 	client.SetBaseURL(server.URL)
 
 	mutator := func(req *http.Request) error {
@@ -377,7 +387,7 @@ func TestDoRequest_BeforeRequestError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
 
-	client := NewClient(server.Client())
+	client := newTestClient(t, server.Client())
 	client.SetBaseURL(server.URL)
 
 	mutator := func(req *http.Request) error {
@@ -407,7 +417,7 @@ func TestDoRequest_AfterResponseSuccess(t *testing.T) {
 	tr := &testRoundTripper{
 		Transport: server.Client().Transport,
 	}
-	client := NewClient(&http.Client{Transport: tr})
+	client := newTestClient(t, &http.Client{Transport: tr})
 	client.SetBaseURL(server.URL)
 
 	mutator := func(resp *http.Response) error {
@@ -436,7 +446,7 @@ func TestDoRequest_AfterResponseError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
 	defer server.Close()
 
-	client := NewClient(server.Client())
+	client := newTestClient(t, server.Client())
 	client.SetBaseURL(server.URL)
 
 	mutator := func(resp *http.Response) error {
@@ -457,7 +467,7 @@ func TestDoRequestLogging_Success(t *testing.T) {
 	logger := createLogger()
 	logger.l.SetOutput(&logBuffer) // Redirect log output to buffer
 
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 	client.SetDebug(true)
 	client.SetLogger(logger)
 
@@ -515,7 +525,7 @@ func TestDoRequestLogging_Error(t *testing.T) {
 	logger := createLogger()
 	logger.l.SetOutput(&logBuffer) // Redirect log output to buffer
 
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 	client.SetDebug(true)
 	client.SetLogger(logger)
 
@@ -586,18 +596,15 @@ func TestClient_CustomRootCAWithCustomRoundTripper(t *testing.T) {
 		Transport: server.Client().Transport,
 	}
 
-	buf := new(strings.Builder)
-	log.SetOutput(buf)
+	_, err = NewClient(&http.Client{Transport: tr})
+	require.ErrorContains(t, err, "custom transport is not allowed with a custom root CA")
+}
 
-	NewClient(&http.Client{Transport: tr})
+func TestClient_CustomRootCAWithMissingFile(t *testing.T) {
+	t.Setenv(APIHostCert, "/does/not/exist.pem")
 
-	expectedLog := "Custom transport is not allowed with a custom root CA"
-
-	if !strings.Contains(buf.String(), expectedLog) {
-		t.Fatalf("expected log %q not found in logs", expectedLog)
-	}
-
-	log.SetOutput(os.Stderr)
+	_, err := NewClient(nil)
+	require.ErrorContains(t, err, "failed to read root certificate")
 }
 
 func TestClient_CustomRootCAWithoutCustomRoundTripper(t *testing.T) {
@@ -624,7 +631,7 @@ func TestClient_CustomRootCAWithoutCustomRoundTripper(t *testing.T) {
 				t.Setenv(APIHostCert, caFile.Name())
 			}
 
-			client := NewClient(test.httpClient)
+			client := newTestClient(t, test.httpClient)
 			transport, ok := client.httpClient.Transport.(*http.Transport)
 			if !ok {
 				t.Fatal("expected *http.Transport")
@@ -758,7 +765,7 @@ func TestRedactHeaders(t *testing.T) {
 }
 
 func TestEnableLogSanitization(t *testing.T) {
-	mockClient := testutil.CreateMockClient(t, NewClient)
+	mockClient := testutil.CreateMockClientWithError(t, NewClient)
 	mockClient.SetDebug(true)
 
 	plainTextToken := "supersecrettoken"

--- a/config_test.go
+++ b/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig_LoadWithDefaults(t *testing.T) {
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 
 	file := createTestConfig(t, configLoadWithDefault)
 
@@ -52,7 +52,7 @@ func TestConfig_LoadWithDefaults(t *testing.T) {
 }
 
 func TestConfig_OverrideDefaults(t *testing.T) {
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 
 	file := createTestConfig(t, configOverrideDefaults)
 
@@ -98,7 +98,7 @@ func TestConfig_OverrideDefaults(t *testing.T) {
 }
 
 func TestConfig_NoDefaults(t *testing.T) {
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 
 	file := createTestConfig(t, configNoDefaults)
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -98,7 +98,9 @@ func TestNewError(t *testing.T) {
 	}
 }
 
-func createTestServer(method, route, contentType, body string, statusCode int) (*httptest.Server, *Client) {
+func createTestServer(t *testing.T, method, route, contentType, body string, statusCode int) (*httptest.Server, *Client) {
+	t.Helper()
+
 	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if r.Method == method && r.URL.Path == route {
 			rw.Header().Add("Content-Type", contentType)
@@ -110,7 +112,7 @@ func createTestServer(method, route, contentType, body string, statusCode int) (
 	})
 	ts := httptest.NewServer(h)
 
-	client := NewClient(nil)
+	client := newTestClient(t, nil)
 	client.SetBaseURL(ts.URL)
 	return ts, &client
 }

--- a/internal/testutil/mock.go
+++ b/internal/testutil/mock.go
@@ -98,6 +98,32 @@ func CreateMockClient[T any](t *testing.T, createFunc func(*http.Client) T) *T {
 	return &result
 }
 
+// CreateMockClientWithError is generic because importing the linodego package
+// will result in a cyclic dependency. This pattern isn't ideal but works for now.
+func CreateMockClientWithError[T any](t *testing.T, createFunc func(*http.Client) (T, error)) *T {
+	t.Helper()
+
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: validTestAPIKey})
+
+	client := &http.Client{
+		Transport: &oauth2.Transport{
+			Source: tokenSource,
+		},
+	}
+	httpmock.ActivateNonDefault(client)
+
+	t.Cleanup(func() {
+		httpmock.DeactivateAndReset()
+	})
+
+	result, err := createFunc(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &result
+}
+
 type Logger interface {
 	Errorf(format string, v ...any)
 	Warnf(format string, v ...any)

--- a/request_helpers_test.go
+++ b/request_helpers_test.go
@@ -37,7 +37,7 @@ var testResponse = testResultType{
 }
 
 func TestRequestHelpers_get(t *testing.T) {
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	httpmock.RegisterRegexpResponder("GET", testutil.MockRequestURL("/foo/bar"),
 		httpmock.NewJsonResponderOrPanic(200, &testResponse))
@@ -57,7 +57,7 @@ func TestRequestHelpers_get(t *testing.T) {
 }
 
 func TestRequestHelpers_post(t *testing.T) {
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	httpmock.RegisterRegexpResponder("POST", testutil.MockRequestURL("/foo/bar"),
 		testutil.MockRequestBodyValidate(t, testResponse, testResponse))
@@ -78,7 +78,7 @@ func TestRequestHelpers_post(t *testing.T) {
 }
 
 func TestRequestHelpers_postNoOptions(t *testing.T) {
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	httpmock.RegisterRegexpResponder("POST", testutil.MockRequestURL("/foo/bar"),
 		testutil.MockRequestBodyValidateNoBody(t, testResponse))
@@ -98,7 +98,7 @@ func TestRequestHelpers_postNoOptions(t *testing.T) {
 }
 
 func TestRequestHelpers_put(t *testing.T) {
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	httpmock.RegisterRegexpResponder("PUT", testutil.MockRequestURL("/foo/bar"),
 		testutil.MockRequestBodyValidate(t, testResponse, testResponse))
@@ -119,7 +119,7 @@ func TestRequestHelpers_put(t *testing.T) {
 }
 
 func TestRequestHelpers_putNoOptions(t *testing.T) {
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	httpmock.RegisterRegexpResponder("PUT", testutil.MockRequestURL("/foo/bar"),
 		testutil.MockRequestBodyValidateNoBody(t, testResponse))
@@ -139,7 +139,7 @@ func TestRequestHelpers_putNoOptions(t *testing.T) {
 }
 
 func TestRequestHelpers_delete(t *testing.T) {
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	httpmock.RegisterRegexpResponder("DELETE", testutil.MockRequestURL("/foo/bar/foo%20bar"),
 		httpmock.NewStringResponder(200, "{}"))
@@ -156,7 +156,7 @@ func TestRequestHelpers_delete(t *testing.T) {
 func TestRequestHelpers_paginateAll(t *testing.T) {
 	const totalResults = 4123
 
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	numRequests := 0
 
@@ -186,7 +186,7 @@ func TestRequestHelpers_paginateAll(t *testing.T) {
 }
 
 func TestRequestHelpers_paginateSingle(t *testing.T) {
-	client := testutil.CreateMockClient(t, NewClient)
+	client := testutil.CreateMockClientWithError(t, NewClient)
 
 	numRequests := 0
 

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -163,7 +163,12 @@ func createTestClient(t *testing.T, fixturesYaml string) (*linodego.Client, func
 		},
 	}
 
-	c = linodego.NewClient(oc)
+	client, err := linodego.NewClient(oc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c = client
 	c.SetDebug(debugAPI).
 		SetPollDelay(testingPollDuration).
 		SetRetryMaxWaitTime(testingMaxRetryTime)

--- a/test/unit/base.go
+++ b/test/unit/base.go
@@ -27,7 +27,7 @@ type ClientBaseCase struct {
 // SetUp initializes the Linode client using the mock HTTP client
 func (c *ClientBaseCase) SetUp(t *testing.T) {
 	c.Mock = &mock.Mock{}
-	c.Client = testutil.CreateMockClient(t, linodego.NewClient)
+	c.Client = testutil.CreateMockClientWithError(t, linodego.NewClient)
 
 	baseURL := "https://" + linodego.APIHost
 	if hostOverride, ok := os.LookupEnv(linodego.APIHostVar); ok && hostOverride != "" {

--- a/test/unit/util_test.go
+++ b/test/unit/util_test.go
@@ -20,7 +20,7 @@ func mockRequestURL(t *testing.T, path string) *regexp.Regexp {
 }
 
 func createMockClient(t *testing.T) *linodego.Client {
-	return testutil.CreateMockClient(t, linodego.NewClient)
+	return testutil.CreateMockClientWithError(t, linodego.NewClient)
 }
 
 func formatMockAPIPath(format string, args ...any) string {


### PR DESCRIPTION
## 📝 Description

Intentional breaking changes to various client related functions to return the error if encountered rather than only logging it.

## ✔️ How to Test
```
make test-int
```