### PR TITLE
TPT-4422: Added options structs for POST/PUT endpoints that were missing them

### DIFF
--- a/account_oauth_client.go
+++ b/account_oauth_client.go
@@ -111,5 +111,5 @@ func (c *Client) DeleteOAuthClient(ctx context.Context, clientID string) error {
 // ResetOAuthClientSecret resets the OAuth Client secret for a client with a specified id
 func (c *Client) ResetOAuthClientSecret(ctx context.Context, clientID string) (*OAuthClient, error) {
 	e := formatAPIPath("account/oauth-clients/%s/reset-secret", clientID)
-	return doPOSTRequest[OAuthClient, any](ctx, c, e)
+	return doPOSTRequestNoRequestBody[OAuthClient](ctx, c, e)
 }

--- a/instance_disks.go
+++ b/instance_disks.go
@@ -63,7 +63,15 @@ type InstanceDiskUpdateOptions struct {
 	Label string `json:"label"`
 }
 
-type InstanceDiskCloneOptions struct{}
+// InstanceDiskResizeOptions are InstanceDisk settings that can be used in resizes
+type InstanceDiskResizeOptions struct {
+	Size int `json:"size"`
+}
+
+// InstanceDiskPasswordResetOptions are InstanceDisk settings that can be used in password resets
+type InstanceDiskPasswordResetOptions struct {
+	Password string `json:"password"`
+}
 
 // ListInstanceDisks lists InstanceDisks
 func (c *Client) ListInstanceDisks(ctx context.Context, linodeID int, opts *ListOptions) ([]InstanceDisk, error) {
@@ -117,22 +125,14 @@ func (c *Client) RenameInstanceDisk(ctx context.Context, linodeID int, diskID in
 }
 
 // ResizeInstanceDisk resizes the size of the Instance disk
-func (c *Client) ResizeInstanceDisk(ctx context.Context, linodeID int, diskID int, size int) error {
-	opts := map[string]any{
-		"size": size,
-	}
-
+func (c *Client) ResizeInstanceDisk(ctx context.Context, linodeID int, diskID int, opts InstanceDiskResizeOptions) error {
 	e := formatAPIPath("linode/instances/%d/disks/%d/resize", linodeID, diskID)
 
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 
 // PasswordResetInstanceDisk resets the "root" account password on the Instance disk
-func (c *Client) PasswordResetInstanceDisk(ctx context.Context, linodeID int, diskID int, password string) error {
-	opts := map[string]any{
-		"password": password,
-	}
-
+func (c *Client) PasswordResetInstanceDisk(ctx context.Context, linodeID int, diskID int, opts InstanceDiskPasswordResetOptions) error {
 	e := formatAPIPath("linode/instances/%d/disks/%d/password", linodeID, diskID)
 
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
@@ -145,7 +145,7 @@ func (c *Client) DeleteInstanceDisk(ctx context.Context, linodeID int, diskID in
 }
 
 // CloneInstanceDisk clones the given InstanceDisk for the given Instance
-func (c *Client) CloneInstanceDisk(ctx context.Context, linodeID, diskID int, opts InstanceDiskCloneOptions) (*InstanceDisk, error) {
+func (c *Client) CloneInstanceDisk(ctx context.Context, linodeID, diskID int) (*InstanceDisk, error) {
 	e := formatAPIPath("linode/instances/%d/disks/%d/clone", linodeID, diskID)
-	return doPOSTRequest[InstanceDisk](ctx, c, e, opts)
+	return doPOSTRequestNoRequestBody[InstanceDisk](ctx, c, e)
 }

--- a/instance_ips.go
+++ b/instance_ips.go
@@ -35,6 +35,11 @@ type InstanceIP struct {
 	Reserved    bool               `json:"reserved"`
 }
 
+type InstanceIPAddOptions struct {
+	Type   string `json:"type"`
+	Public bool   `json:"public"`
+}
+
 type InstanceIPAddressUpdateOptions struct {
 	RDNS **string `json:"rdns,omitzero"`
 }
@@ -131,15 +136,11 @@ func (c *Client) GetInstanceIPAddress(ctx context.Context, linodeID int, ipaddre
 }
 
 // AddInstanceIPAddress adds a public or private IP to a Linode instance
-func (c *Client) AddInstanceIPAddress(ctx context.Context, linodeID int, public bool) (*InstanceIP, error) {
-	instanceipRequest := struct {
-		Type   string `json:"type"`
-		Public bool   `json:"public"`
-	}{"ipv4", public}
-
+func (c *Client) AddInstanceIPAddress(ctx context.Context, linodeID int, opts InstanceIPAddOptions) (*InstanceIP, error) {
+	opts.Type = "ipv4"
 	e := formatAPIPath("linode/instances/%d/ips", linodeID)
 
-	return doPOSTRequest[InstanceIP](ctx, c, e, instanceipRequest)
+	return doPOSTRequest[InstanceIP](ctx, c, e, opts)
 }
 
 // UpdateInstanceIPAddress updates the IPAddress with the specified instance id and IP address

--- a/instance_snapshots.go
+++ b/instance_snapshots.go
@@ -20,6 +20,10 @@ type InstanceBackupSnapshotResponse struct {
 	InProgress *InstanceSnapshot `json:"in_progress"`
 }
 
+type InstanceSnapshotCreateOptions struct {
+	Label string `json:"label"`
+}
+
 // RestoreInstanceOptions fields are those accepted by InstanceRestore
 type RestoreInstanceOptions struct {
 	LinodeID  int  `json:"linode_id"`
@@ -93,9 +97,7 @@ func (c *Client) GetInstanceSnapshot(ctx context.Context, linodeID int, snapshot
 }
 
 // CreateInstanceSnapshot Creates or Replaces the snapshot Backup of a Linode. If a previous snapshot exists for this Linode, it will be deleted.
-func (c *Client) CreateInstanceSnapshot(ctx context.Context, linodeID int, label string) (*InstanceSnapshot, error) {
-	opts := map[string]string{"label": label}
-
+func (c *Client) CreateInstanceSnapshot(ctx context.Context, linodeID int, opts InstanceSnapshotCreateOptions) (*InstanceSnapshot, error) {
 	e := formatAPIPath("linode/instances/%d/backups", linodeID)
 
 	return doPOSTRequest[InstanceSnapshot](ctx, c, e, opts)

--- a/instances.go
+++ b/instances.go
@@ -380,6 +380,14 @@ type InstanceResizeOptions struct {
 	AllowAutoDiskResize *bool `json:"allow_auto_disk_resize,omitzero"`
 }
 
+type InstanceBootOptions struct {
+	ConfigID int `json:"config_id"`
+}
+
+type InstanceRebootOptions struct {
+	ConfigID int `json:"config_id"`
+}
+
 // InstanceMigrateOptions is an options struct used when migrating an instance
 type InstanceMigrateOptions struct {
 	Type    InstanceMigrationType `json:"type,omitzero"`
@@ -436,16 +444,18 @@ func (c *Client) DeleteInstance(ctx context.Context, linodeID int) error {
 
 // BootInstance will boot a Linode instance
 // A configID of 0 will cause Linode to choose the last/best config
-func (c *Client) BootInstance(ctx context.Context, linodeID int, configID int) error {
-	opts := make(map[string]int)
+func (c *Client) BootInstance(ctx context.Context, linodeID int, opts InstanceBootOptions) error {
+	var payload InstanceBootOptions
 
-	if configID != 0 {
-		opts = map[string]int{"config_id": configID}
+	if opts.ConfigID != 0 {
+		payload = opts // Use the struct when ConfigID is set
+	} else {
+		payload = InstanceBootOptions{} // Send an empty JSON object when ConfigID is 0
 	}
 
 	e := formatAPIPath("linode/instances/%d/boot", linodeID)
 
-	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
+	return doPOSTRequestNoResponseBody(ctx, c, e, payload)
 }
 
 // CloneInstance clone an existing Instances Disks and Configuration profiles to another Linode Instance
@@ -462,16 +472,18 @@ func (c *Client) ResetInstancePassword(ctx context.Context, linodeID int, opts I
 
 // RebootInstance reboots a Linode instance
 // A configID of 0 will cause Linode to choose the last/best config
-func (c *Client) RebootInstance(ctx context.Context, linodeID int, configID int) error {
-	opts := make(map[string]int)
+func (c *Client) RebootInstance(ctx context.Context, linodeID int, opts InstanceRebootOptions) error {
+	var payload InstanceRebootOptions
 
-	if configID != 0 {
-		opts = map[string]int{"config_id": configID}
+	if opts.ConfigID != 0 {
+		payload = opts // Use the struct when ConfigID is set
+	} else {
+		payload = InstanceRebootOptions{} // Send an empty JSON object when ConfigID is 0
 	}
 
 	e := formatAPIPath("linode/instances/%d/reboot", linodeID)
 
-	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
+	return doPOSTRequestNoResponseBody(ctx, c, e, payload)
 }
 
 // InstanceRebuildOptions is a struct representing the options to send to the rebuild linode endpoint

--- a/instances.go
+++ b/instances.go
@@ -381,11 +381,11 @@ type InstanceResizeOptions struct {
 }
 
 type InstanceBootOptions struct {
-	ConfigID int `json:"config_id"`
+	ConfigID *int `json:"config_id,omitzero"`
 }
 
 type InstanceRebootOptions struct {
-	ConfigID int `json:"config_id"`
+	ConfigID *int `json:"config_id,omitzero"`
 }
 
 // InstanceMigrateOptions is an options struct used when migrating an instance

--- a/instances.go
+++ b/instances.go
@@ -445,17 +445,9 @@ func (c *Client) DeleteInstance(ctx context.Context, linodeID int) error {
 // BootInstance will boot a Linode instance
 // A configID of 0 will cause Linode to choose the last/best config
 func (c *Client) BootInstance(ctx context.Context, linodeID int, opts InstanceBootOptions) error {
-	var payload InstanceBootOptions
-
-	if opts.ConfigID != 0 {
-		payload = opts // Use the struct when ConfigID is set
-	} else {
-		payload = InstanceBootOptions{} // Send an empty JSON object when ConfigID is 0
-	}
-
 	e := formatAPIPath("linode/instances/%d/boot", linodeID)
 
-	return doPOSTRequestNoResponseBody(ctx, c, e, payload)
+	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 
 // CloneInstance clone an existing Instances Disks and Configuration profiles to another Linode Instance
@@ -473,17 +465,9 @@ func (c *Client) ResetInstancePassword(ctx context.Context, linodeID int, opts I
 // RebootInstance reboots a Linode instance
 // A configID of 0 will cause Linode to choose the last/best config
 func (c *Client) RebootInstance(ctx context.Context, linodeID int, opts InstanceRebootOptions) error {
-	var payload InstanceRebootOptions
-
-	if opts.ConfigID != 0 {
-		payload = opts // Use the struct when ConfigID is set
-	} else {
-		payload = InstanceRebootOptions{} // Send an empty JSON object when ConfigID is 0
-	}
-
 	e := formatAPIPath("linode/instances/%d/reboot", linodeID)
 
-	return doPOSTRequestNoResponseBody(ctx, c, e, payload)
+	return doPOSTRequestNoResponseBody(ctx, c, e, opts)
 }
 
 // InstanceRebuildOptions is a struct representing the options to send to the rebuild linode endpoint

--- a/request_helpers.go
+++ b/request_helpers.go
@@ -213,6 +213,16 @@ func doPOSTRequest[T, O any](
 	return &resultType, nil
 }
 
+// doPOSTRequestNoRequestBody runs a POST request using the given client and API endpoint.
+// It does not expect a request body but does expect a response from the endpoint.
+func doPOSTRequestNoRequestBody[T any](
+	ctx context.Context,
+	client *Client,
+	endpoint string,
+) (*T, error) {
+	return doPOSTRequest[T, any](ctx, client, endpoint)
+}
+
 // doPOSTRequestNoResponseBody runs a POST request using the given client, API endpoint,
 // and options/body. It expects only empty response from the endpoint.
 func doPOSTRequestNoResponseBody[T any](

--- a/test/integration/example_nodebalancers_test.go
+++ b/test/integration/example_nodebalancers_test.go
@@ -167,7 +167,10 @@ func ExampleClient_CreateNodeBalancerNode() {
 		log.Fatal(err)
 	}
 
-	ip, err := linodeClient.AddInstanceIPAddress(context.Background(), instance.ID, false)
+	opts := linodego.InstanceIPAddOptions{
+		Public: false,
+	}
+	ip, err := linodeClient.AddInstanceIPAddress(context.Background(), instance.ID, opts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/test/integration/iam_io_ready_test.go
+++ b/test/integration/iam_io_ready_test.go
@@ -201,7 +201,8 @@ func TestIAM_GetIOReadyForClonedVolume(t *testing.T) {
 	requireSingleAttachedInstanceVolume(t, client, instance)
 
 	labelCloned := volume.Label + "-cloned"
-	volumeCloned, err := client.CloneVolume(context.Background(), volume.ID, labelCloned)
+	opts := linodego.VolumeCloneOptions{Label: labelCloned}
+	volumeCloned, err := client.CloneVolume(context.Background(), volume.ID, opts)
 	t.Cleanup(func() {
 		if err = client.DeleteVolume(context.Background(), volumeCloned.ID); err != nil {
 			t.Errorf("Error deleting cloned volume: %v", err)
@@ -234,7 +235,8 @@ func TestIAM_GetIOReadyForResizedVolume(t *testing.T) {
 
 	newSize := volume.Size + 10
 
-	err := client.ResizeVolume(context.Background(), volume.ID, newSize)
+	opts := linodego.VolumeResizeOptions{Size: newSize}
+	err := client.ResizeVolume(context.Background(), volume.ID, opts)
 	require.NoErrorf(t, err, "Error resizing volume: %v", err)
 
 	_, err = client.WaitForVolumeStatus(ctx, volume.ID, linodego.VolumeActive)

--- a/test/integration/instance_snapshots_test.go
+++ b/test/integration/instance_snapshots_test.go
@@ -124,7 +124,9 @@ func setupInstanceBackup(
 		t.Errorf("Error enabling Instance Backups: %v", err)
 	}
 
-	snapshot, err := client.CreateInstanceSnapshot(context.Background(), instance.ID, testSnapshotLabel)
+	opts := linodego.InstanceSnapshotCreateOptions{Label: testSnapshotLabel}
+
+	snapshot, err := client.CreateInstanceSnapshot(context.Background(), instance.ID, opts)
 	if err != nil {
 		t.Errorf("Error creating instance snapshot: %v", err)
 	}

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -425,7 +425,11 @@ func TestInstance_Disk_Resize(t *testing.T) {
 		t.Errorf("Error waiting for disk readiness for resize: %s", err)
 	}
 
-	err = client.ResizeInstanceDisk(context.Background(), instance.ID, disk.ID, 4000)
+	opts := linodego.InstanceDiskResizeOptions{
+		Size: 4000,
+	}
+
+	err = client.ResizeInstanceDisk(context.Background(), instance.ID, disk.ID, opts)
 	if err != nil {
 		t.Errorf("Error resizing instance disk: %s", err)
 	}
@@ -440,7 +444,11 @@ func TestInstance_Disk_ListMultiple(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	err = client.BootInstance(context.Background(), instance1.ID, 0)
+
+	opts := linodego.InstanceBootOptions{
+		ConfigID: 0,
+	}
+	err = client.BootInstance(context.Background(), instance1.ID, opts)
 	if err != nil {
 		t.Error(err)
 	}
@@ -544,9 +552,7 @@ func TestInstance_Disk_Clone(t *testing.T) {
 		t.Errorf("Error waiting for disk readiness for disk clone: %s", err)
 	}
 
-	opts := linodego.InstanceDiskCloneOptions{}
-
-	_, err = client.CloneInstanceDisk(context.Background(), instance.ID, disk.ID, opts)
+	_, err = client.CloneInstanceDisk(context.Background(), instance.ID, disk.ID)
 	if err != nil {
 		t.Errorf("Error cloning instance disk: %s", err)
 	}
@@ -586,7 +592,10 @@ func TestInstance_Disk_ResetPassword(t *testing.T) {
 		t.Errorf("Error waiting for disk readiness for password reset: %s", err)
 	}
 
-	err = client.PasswordResetInstanceDisk(context.Background(), instance.ID, disk.ID, "r34!_b4d_p455")
+	opts := linodego.InstanceDiskPasswordResetOptions{
+		Password: "r34!_b4d_p455",
+	}
+	err = client.PasswordResetInstanceDisk(context.Background(), instance.ID, disk.ID, opts)
 	if err != nil {
 		t.Errorf("Error reseting password on instance disk: %s", err)
 	}

--- a/test/integration/instances_test.go
+++ b/test/integration/instances_test.go
@@ -446,7 +446,7 @@ func TestInstance_Disk_ListMultiple(t *testing.T) {
 	}
 
 	opts := linodego.InstanceBootOptions{
-		ConfigID: 0,
+		ConfigID: linodego.Pointer(0),
 	}
 	err = client.BootInstance(context.Background(), instance1.ID, opts)
 	if err != nil {

--- a/test/integration/network_ips_test.go
+++ b/test/integration/network_ips_test.go
@@ -378,7 +378,10 @@ func TestIPAddress_Instance_Delete(t *testing.T) {
 		t.Error(err)
 	}
 
-	ip, err := client.AddInstanceIPAddress(context.TODO(), instance.ID, true)
+	opts := linodego.InstanceIPAddOptions{
+		Public: true,
+	}
+	ip, err := client.AddInstanceIPAddress(context.TODO(), instance.ID, opts)
 	if err != nil {
 		t.Fatalf("failed to allocate public IPv4 for instance (%d): %s", instance.ID, err)
 	}
@@ -487,7 +490,10 @@ func TestIPAddress_Instance_Share(t *testing.T) {
 		t.Error(err)
 	}
 
-	ip, err := client.AddInstanceIPAddress(context.Background(), newInstance.ID, true)
+	opts := linodego.InstanceIPAddOptions{
+		Public: true,
+	}
+	ip, err := client.AddInstanceIPAddress(context.Background(), newInstance.ID, opts)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/nodebalancer_config_nodes_test.go
+++ b/test/integration/nodebalancer_config_nodes_test.go
@@ -361,7 +361,10 @@ func setupNodeBalancerNode(
 		t.Errorf("failed to create test instance: %s", err)
 	}
 
-	instanceIP, err := client.AddInstanceIPAddress(context.Background(), instance.ID, false)
+	opts := linodego.InstanceIPAddOptions{
+		Public: false,
+	}
+	instanceIP, err := client.AddInstanceIPAddress(context.Background(), instance.ID, opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/volumes_test.go
+++ b/test/integration/volumes_test.go
@@ -81,7 +81,10 @@ func TestVolume_Resize(t *testing.T) {
 		t.Errorf("Error waiting for volume to be active, %s", err)
 	}
 
-	if err := client.ResizeVolume(context.Background(), volume.ID, volume.Size+1); err != nil {
+	opts := linodego.VolumeResizeOptions{
+		Size: volume.Size + 1,
+	}
+	if err := client.ResizeVolume(context.Background(), volume.ID, opts); err != nil {
 		t.Errorf("Error resizing volume, %s", err)
 	}
 }

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -52,7 +52,7 @@ func TestEventPoller_InstancePower(t *testing.T) {
 	}
 
 	opts := linodego.InstanceBootOptions{
-		ConfigID: 0,
+		ConfigID: linodego.Pointer(0),
 	}
 	if err := client.BootInstance(context.Background(), instance.ID, opts); err != nil {
 		t.Fatal(err)

--- a/test/integration/waitfor_test.go
+++ b/test/integration/waitfor_test.go
@@ -51,7 +51,10 @@ func TestEventPoller_InstancePower(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := client.BootInstance(context.Background(), instance.ID, 0); err != nil {
+	opts := linodego.InstanceBootOptions{
+		ConfigID: 0,
+	}
+	if err := client.BootInstance(context.Background(), instance.ID, opts); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/unit/instance_backup_test.go
+++ b/test/unit/instance_backup_test.go
@@ -37,7 +37,9 @@ func TestInstanceSnapshot_Create(t *testing.T) {
 
 	base.MockPost("linode/instances/123/backups", fixtureData)
 
-	snapshot, err := base.Client.CreateInstanceSnapshot(context.Background(), 123, "new-snapshot")
+	opts := linodego.InstanceSnapshotCreateOptions{Label: "new-snapshot"}
+
+	snapshot, err := base.Client.CreateInstanceSnapshot(context.Background(), 123, opts)
 	assert.NoError(t, err)
 	assert.Equal(t, "new-snapshot", snapshot.Label)
 	assert.Equal(t, linodego.SnapshotPending, snapshot.Status)

--- a/test/unit/instance_disks_test.go
+++ b/test/unit/instance_disks_test.go
@@ -19,9 +19,7 @@ func TestInstance_Disks_Clone(t *testing.T) {
 
 	base.MockPost("linode/instances/12345/disks/123/clone", fixtureData)
 
-	opts := linodego.InstanceDiskCloneOptions{}
-
-	disk, err := base.Client.CloneInstanceDisk(context.Background(), 12345, 123, opts)
+	disk, err := base.Client.CloneInstanceDisk(context.Background(), 12345, 123)
 	assert.NoError(t, err)
 
 	assert.Equal(t, linodego.DiskFilesystem("ext4"), disk.Filesystem)
@@ -151,7 +149,9 @@ func TestInstanceDisk_Resize(t *testing.T) {
 
 	base.MockPost("linode/instances/123/disks/1/resize", nil)
 
-	err := base.Client.ResizeInstanceDisk(context.Background(), 123, 1, 40960)
+	opts := linodego.InstanceDiskResizeOptions{Size: 40960}
+
+	err := base.Client.ResizeInstanceDisk(context.Background(), 123, 1, opts)
 	assert.NoError(t, err)
 }
 
@@ -162,6 +162,8 @@ func TestInstanceDisk_PasswordReset(t *testing.T) {
 
 	base.MockPost("linode/instances/123/disks/1/password", nil)
 
-	err := base.Client.PasswordResetInstanceDisk(context.Background(), 123, 1, "new-password")
+	opts := linodego.InstanceDiskPasswordResetOptions{Password: "new-password"}
+
+	err := base.Client.PasswordResetInstanceDisk(context.Background(), 123, 1, opts)
 	assert.NoError(t, err)
 }

--- a/test/unit/instance_ip_test.go
+++ b/test/unit/instance_ip_test.go
@@ -66,7 +66,9 @@ func TestInstanceIPAddress_Add(t *testing.T) {
 
 	base.MockPost("linode/instances/123/ips", fixtureData)
 
-	ip, err := base.Client.AddInstanceIPAddress(context.Background(), 123, true)
+	opts := linodego.InstanceIPAddOptions{Public: true}
+
+	ip, err := base.Client.AddInstanceIPAddress(context.Background(), 123, opts)
 	assert.NoError(t, err)
 	assert.NotNil(t, ip)
 	assert.Equal(t, "198.51.100.1", ip.Address)

--- a/test/unit/instance_test.go
+++ b/test/unit/instance_test.go
@@ -213,7 +213,7 @@ func TestInstance_Boot(t *testing.T) {
 
 	base.MockPost("linode/instances/123/boot", nil)
 
-	opts := linodego.InstanceBootOptions{ConfigID: 0}
+	opts := linodego.InstanceBootOptions{ConfigID: linodego.Pointer(0)}
 
 	err := base.Client.BootInstance(context.Background(), 123, opts)
 	assert.NoError(t, err)
@@ -226,7 +226,7 @@ func TestInstance_Reboot(t *testing.T) {
 
 	base.MockPost("linode/instances/123/reboot", nil)
 
-	opts := linodego.InstanceRebootOptions{ConfigID: 0}
+	opts := linodego.InstanceRebootOptions{ConfigID: linodego.Pointer(0)}
 
 	err := base.Client.RebootInstance(context.Background(), 123, opts)
 	assert.NoError(t, err)

--- a/test/unit/instance_test.go
+++ b/test/unit/instance_test.go
@@ -213,7 +213,9 @@ func TestInstance_Boot(t *testing.T) {
 
 	base.MockPost("linode/instances/123/boot", nil)
 
-	err := base.Client.BootInstance(context.Background(), 123, 0)
+	opts := linodego.InstanceBootOptions{ConfigID: 0}
+
+	err := base.Client.BootInstance(context.Background(), 123, opts)
 	assert.NoError(t, err)
 }
 
@@ -224,7 +226,9 @@ func TestInstance_Reboot(t *testing.T) {
 
 	base.MockPost("linode/instances/123/reboot", nil)
 
-	err := base.Client.RebootInstance(context.Background(), 123, 0)
+	opts := linodego.InstanceRebootOptions{ConfigID: 0}
+
+	err := base.Client.RebootInstance(context.Background(), 123, opts)
 	assert.NoError(t, err)
 }
 

--- a/test/unit/volume_test.go
+++ b/test/unit/volume_test.go
@@ -175,6 +175,8 @@ func TestResizeVolume(t *testing.T) {
 	volumeID := 123
 	base.MockPost(fmt.Sprintf("volumes/%d/resize", volumeID), nil)
 
-	err := base.Client.ResizeVolume(context.Background(), volumeID, 50)
+	opts := linodego.VolumeResizeOptions{Size: 50}
+
+	err := base.Client.ResizeVolume(context.Background(), volumeID, opts)
 	assert.NoError(t, err, "Expected no error when resizing volume")
 }

--- a/volumes.go
+++ b/volumes.go
@@ -63,6 +63,14 @@ type VolumeUpdateOptions struct {
 	Tags  []string `json:"tags,omitzero"`
 }
 
+type VolumeCloneOptions struct {
+	Label string `json:"label"`
+}
+
+type VolumeResizeOptions struct {
+	Size int `json:"size"`
+}
+
 // VolumeAttachOptions fields are those accepted by AttachVolume
 type VolumeAttachOptions struct {
 	LinodeID           int   `json:"linode_id"`
@@ -144,11 +152,7 @@ func (c *Client) UpdateVolume(ctx context.Context, volumeID int, opts VolumeUpda
 }
 
 // CloneVolume clones a Linode volume
-func (c *Client) CloneVolume(ctx context.Context, volumeID int, label string) (*Volume, error) {
-	opts := map[string]any{
-		"label": label,
-	}
-
+func (c *Client) CloneVolume(ctx context.Context, volumeID int, opts VolumeCloneOptions) (*Volume, error) {
 	e := formatAPIPath("volumes/%d/clone", volumeID)
 
 	return doPOSTRequest[Volume](ctx, c, e, opts)
@@ -161,11 +165,7 @@ func (c *Client) DetachVolume(ctx context.Context, volumeID int) error {
 }
 
 // ResizeVolume resizes an instance to new Linode type
-func (c *Client) ResizeVolume(ctx context.Context, volumeID int, size int) error {
-	opts := map[string]int{
-		"size": size,
-	}
-
+func (c *Client) ResizeVolume(ctx context.Context, volumeID int, opts VolumeResizeOptions) error {
 	e := formatAPIPath("volumes/%d/resize", volumeID)
 
 	return doPOSTRequestNoResponseBody(ctx, c, e, opts)


### PR DESCRIPTION
## 📝 Description

Added dedicated options structs where they were missing.

## ✔️ How to Test

`make test-unit`
`make test-int`
