### PR TITLE
TPT-3388: Separated GET and POST/PUT options structs where needed

### DIFF
--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -76,12 +76,15 @@ type FirewallRuleSet struct {
 	InboundPolicy  string         `json:"inbound_policy"`
 	Outbound       []FirewallRule `json:"outbound"`
 	OutboundPolicy string         `json:"outbound_policy"`
+	Version        int            `json:"version,omitzero"`
+	Fingerprint    string         `json:"fingerprint,omitzero"`
+}
 
-	// TODO: separate request and response types in linodego v2
-	// read-only, can't be used in creating or updating a Firewall
-	Version int `json:"version,omitzero"`
-	// read-only, can't be used in creating or updating a Firewall
-	Fingerprint string `json:"fingerprint,omitzero"`
+type FirewallRuleSetUpdateOptions struct {
+	Inbound        []FirewallRule `json:"inbound"`
+	InboundPolicy  string         `json:"inbound_policy"`
+	Outbound       []FirewallRule `json:"outbound"`
+	OutboundPolicy string         `json:"outbound_policy"`
 }
 
 // GetFirewallRules gets the FirewallRuleSet for the given Firewall.
@@ -97,7 +100,7 @@ func (c *Client) GetFirewallRulesExpansion(ctx context.Context, firewallID int) 
 }
 
 // UpdateFirewallRules updates the FirewallRuleSet for the given Firewall
-func (c *Client) UpdateFirewallRules(ctx context.Context, firewallID int, rules FirewallRuleSet) (*FirewallRuleSet, error) {
+func (c *Client) UpdateFirewallRules(ctx context.Context, firewallID int, rules FirewallRuleSetUpdateOptions) (*FirewallRuleSet, error) {
 	e := formatAPIPath("networking/firewalls/%d/rules", firewallID)
 	return doPUTRequest[FirewallRuleSet](ctx, c, e, rules)
 }

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -22,17 +22,6 @@ type NetworkAddresses struct {
 	IPv6 []string `json:"ipv6,omitzero"`
 }
 
-// A FirewallRuleSetRule is a whitelist of ports, protocols, and addresses for which traffic should be allowed.
-// The ipv4/ipv6 address lists may contain Prefix List tokens (for example, "pl::..." or "pl:system:...")
-// in addition to literal IP addresses.
-type FirewallRuleSetRule struct {
-	Action    string           `json:"action"`
-	Label     string           `json:"label"`
-	Ports     string           `json:"ports,omitzero"`
-	Protocol  NetworkProtocol  `json:"protocol"`
-	Addresses NetworkAddresses `json:"addresses"`
-}
-
 type FirewallRuleInbound struct {
 	Action      string           `json:"action"`
 	Label       string           `json:"label"`
@@ -132,8 +121,7 @@ type FirewallRules struct {
 	Version        int                    `json:"version,omitzero"`
 	Fingerprint    string                 `json:"fingerprint,omitzero"`
 }
-
-type FirewallRuleSetUpdateOptions struct {
+type FirewallRulesUpdateOptions struct {
 	Inbound        []FirewallRuleInbound  `json:"inbound"`
 	InboundPolicy  string                 `json:"inbound_policy"`
 	Outbound       []FirewallRuleOutbound `json:"outbound"`
@@ -153,7 +141,7 @@ func (c *Client) GetFirewallRulesExpansion(ctx context.Context, firewallID int) 
 }
 
 // UpdateFirewallRules updates the FirewallRules for the given Firewall
-func (c *Client) UpdateFirewallRules(ctx context.Context, firewallID int, rules FirewallRuleSetUpdateOptions) (*FirewallRules, error) {
+func (c *Client) UpdateFirewallRules(ctx context.Context, firewallID int, rules FirewallRulesUpdateOptions) (*FirewallRules, error) {
 	e := formatAPIPath("networking/firewalls/%d/rules", firewallID)
 	return doPUTRequest[FirewallRules](ctx, c, e, rules)
 }

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -22,10 +22,18 @@ type NetworkAddresses struct {
 	IPv6 []string `json:"ipv6,omitzero"`
 }
 
-// A FirewallRule is a whitelist of ports, protocols, and addresses for which traffic should be allowed.
+// A FirewallRuleSetRule is a whitelist of ports, protocols, and addresses for which traffic should be allowed.
 // The ipv4/ipv6 address lists may contain Prefix List tokens (for example, "pl::..." or "pl:system:...")
 // in addition to literal IP addresses.
-type FirewallRule struct {
+type FirewallRuleSetRule struct {
+	Action    string           `json:"action"`
+	Label     string           `json:"label"`
+	Ports     string           `json:"ports,omitzero"`
+	Protocol  NetworkProtocol  `json:"protocol"`
+	Addresses NetworkAddresses `json:"addresses"`
+}
+
+type FirewallRuleInbound struct {
 	Action      string           `json:"action"`
 	Label       string           `json:"label"`
 	Description string           `json:"description,omitzero"`
@@ -33,16 +41,30 @@ type FirewallRule struct {
 	Protocol    NetworkProtocol  `json:"protocol"`
 	Addresses   NetworkAddresses `json:"addresses"`
 
-	// FirewallRule references one `Rule Set` by ID. When provided, this entry
+	// FirewallRuleInbound references one `Rule Set` by ID. When provided, this entry
 	// represents a reference and should be mutually exclusive with ordinary
 	// rule fields according to the API contract.
 	RuleSet int `json:"ruleset,omitzero"`
 }
 
-// MarshalJSON ensures that when a rule references a Rule Set (RuleSet != 0),
+type FirewallRuleOutbound struct {
+	Action      string           `json:"action"`
+	Label       string           `json:"label"`
+	Description string           `json:"description,omitzero"`
+	Ports       string           `json:"ports,omitzero"`
+	Protocol    NetworkProtocol  `json:"protocol"`
+	Addresses   NetworkAddresses `json:"addresses"`
+
+	// FirewallRuleOutbound references one `Rule Set` by ID. When provided, this entry
+	// represents a reference and should be mutually exclusive with ordinary
+	// rule fields according to the API contract.
+	RuleSet int `json:"ruleset,omitzero"`
+}
+
+// MarshalJSON ensures that when a rule references a Rule Set (FirewallRuleSet != 0),
 // only the reference shape { "ruleset": <id> } is emitted. Otherwise, the
 // ordinary rule fields are emitted without the ruleset key.
-func (r FirewallRule) MarshalJSON() ([]byte, error) {
+func (r FirewallRuleInbound) MarshalJSON() ([]byte, error) {
 	if r.RuleSet != 0 {
 		type rulesetOnly struct {
 			RuleSet int `json:"ruleset"`
@@ -70,37 +92,68 @@ func (r FirewallRule) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// FirewallRuleSet is a pair of inbound and outbound rules that specify what network traffic should be allowed.
-type FirewallRuleSet struct {
-	Inbound        []FirewallRule `json:"inbound"`
-	InboundPolicy  string         `json:"inbound_policy"`
-	Outbound       []FirewallRule `json:"outbound"`
-	OutboundPolicy string         `json:"outbound_policy"`
-	Version        int            `json:"version,omitzero"`
-	Fingerprint    string         `json:"fingerprint,omitzero"`
+// MarshalJSON ensures that when a rule references a Rule Set (FirewallRuleSet != 0),
+// only the reference shape { "ruleset": <id> } is emitted. Otherwise, the
+// ordinary rule fields are emitted without the ruleset key.
+func (r FirewallRuleOutbound) MarshalJSON() ([]byte, error) {
+	if r.RuleSet != 0 {
+		type rulesetOnly struct {
+			RuleSet int `json:"ruleset"`
+		}
+
+		return json.Marshal(rulesetOnly{RuleSet: r.RuleSet})
+	}
+
+	type normal struct {
+		Action      string           `json:"action"`
+		Label       string           `json:"label"`
+		Description string           `json:"description,omitzero"`
+		Ports       string           `json:"ports,omitzero"`
+		Protocol    NetworkProtocol  `json:"protocol"`
+		Addresses   NetworkAddresses `json:"addresses"`
+	}
+
+	return json.Marshal(normal{
+		Action:      r.Action,
+		Label:       r.Label,
+		Description: r.Description,
+		Ports:       r.Ports,
+		Protocol:    r.Protocol,
+		Addresses:   r.Addresses,
+	})
+}
+
+// FirewallRules is a pair of inbound and outbound rules that specify what network traffic should be allowed.
+type FirewallRules struct {
+	Inbound        []FirewallRuleInbound  `json:"inbound"`
+	InboundPolicy  string                 `json:"inbound_policy"`
+	Outbound       []FirewallRuleOutbound `json:"outbound"`
+	OutboundPolicy string                 `json:"outbound_policy"`
+	Version        int                    `json:"version,omitzero"`
+	Fingerprint    string                 `json:"fingerprint,omitzero"`
 }
 
 type FirewallRuleSetUpdateOptions struct {
-	Inbound        []FirewallRule `json:"inbound"`
-	InboundPolicy  string         `json:"inbound_policy"`
-	Outbound       []FirewallRule `json:"outbound"`
-	OutboundPolicy string         `json:"outbound_policy"`
+	Inbound        []FirewallRuleInbound  `json:"inbound"`
+	InboundPolicy  string                 `json:"inbound_policy"`
+	Outbound       []FirewallRuleOutbound `json:"outbound"`
+	OutboundPolicy string                 `json:"outbound_policy"`
 }
 
-// GetFirewallRules gets the FirewallRuleSet for the given Firewall.
-func (c *Client) GetFirewallRules(ctx context.Context, firewallID int) (*FirewallRuleSet, error) {
+// GetFirewallRules gets the FirewallRules for the given Firewall.
+func (c *Client) GetFirewallRules(ctx context.Context, firewallID int) (*FirewallRules, error) {
 	e := formatAPIPath("networking/firewalls/%d/rules", firewallID)
-	return doGETRequest[FirewallRuleSet](ctx, c, e)
+	return doGETRequest[FirewallRules](ctx, c, e)
 }
 
-// GetFirewallRulesExpansion gets the expanded FirewallRuleSet for the given Firewall.
-func (c *Client) GetFirewallRulesExpansion(ctx context.Context, firewallID int) (*FirewallRuleSet, error) {
+// GetFirewallRulesExpansion gets the expanded FirewallRules for the given Firewall.
+func (c *Client) GetFirewallRulesExpansion(ctx context.Context, firewallID int) (*FirewallRules, error) {
 	e := formatAPIPath("networking/firewalls/%d/rules/expansion", firewallID)
-	return doGETRequest[FirewallRuleSet](ctx, c, e)
+	return doGETRequest[FirewallRules](ctx, c, e)
 }
 
-// UpdateFirewallRules updates the FirewallRuleSet for the given Firewall
-func (c *Client) UpdateFirewallRules(ctx context.Context, firewallID int, rules FirewallRuleSetUpdateOptions) (*FirewallRuleSet, error) {
+// UpdateFirewallRules updates the FirewallRules for the given Firewall
+func (c *Client) UpdateFirewallRules(ctx context.Context, firewallID int, rules FirewallRuleSetUpdateOptions) (*FirewallRules, error) {
 	e := formatAPIPath("networking/firewalls/%d/rules", firewallID)
-	return doPUTRequest[FirewallRuleSet](ctx, c, e, rules)
+	return doPUTRequest[FirewallRules](ctx, c, e, rules)
 }

--- a/firewall_rulesets.go
+++ b/firewall_rulesets.go
@@ -17,25 +17,25 @@ const (
 	FirewallRuleSetTypeOutbound FirewallRuleSetType = "outbound"
 )
 
-// RuleSet represents the Rule Set resource.
+// FirewallRuleSet represents the Rule Set resource.
 // Note: created/updated/deleted are parsed via UnmarshalJSON into time.Time pointers.
-type RuleSet struct {
-	ID               int                 `json:"id"`
-	Label            string              `json:"label"`
-	Description      string              `json:"description,omitzero"`
-	Type             FirewallRuleSetType `json:"type"`
-	Rules            []FirewallRule      `json:"rules"`
-	IsServiceDefined bool                `json:"is_service_defined"`
-	Version          int                 `json:"version"`
+type FirewallRuleSet struct {
+	ID               int                   `json:"id"`
+	Label            string                `json:"label"`
+	Description      string                `json:"description,omitzero"`
+	Type             FirewallRuleSetType   `json:"type"`
+	Rules            []FirewallRuleSetRule `json:"rules"`
+	IsServiceDefined bool                  `json:"is_service_defined"`
+	Version          int                   `json:"version"`
 
 	Created *time.Time `json:"-"`
 	Updated *time.Time `json:"-"`
 	Deleted *time.Time `json:"-"`
 }
 
-// UnmarshalJSON implements custom timestamp parsing for RuleSet.
-func (r *RuleSet) UnmarshalJSON(b []byte) error {
-	type Mask RuleSet
+// UnmarshalJSON implements custom timestamp parsing for FirewallRuleSet.
+func (r *FirewallRuleSet) UnmarshalJSON(b []byte) error {
+	type Mask FirewallRuleSet
 
 	aux := struct {
 		*Mask
@@ -68,42 +68,42 @@ func (r *RuleSet) UnmarshalJSON(b []byte) error {
 
 // RuleSetCreateOptions fields accepted by CreateRuleSet.
 type RuleSetCreateOptions struct {
-	Label       string              `json:"label"`
-	Description string              `json:"description,omitzero"`
-	Type        FirewallRuleSetType `json:"type"`
-	Rules       []FirewallRule      `json:"rules"`
+	Label       string                `json:"label"`
+	Description string                `json:"description,omitzero"`
+	Type        FirewallRuleSetType   `json:"type"`
+	Rules       []FirewallRuleSetRule `json:"rules"`
 }
 
 // RuleSetUpdateOptions fields accepted by UpdateRuleSet.
 // Omit a top-level field to leave it unchanged. If Rules is provided, it
 // replaces the entire ordered rules array.
 type RuleSetUpdateOptions struct {
-	Label       *string        `json:"label,omitzero"`
-	Description *string        `json:"description,omitzero"`
-	Rules       []FirewallRule `json:"rules,omitzero"`
+	Label       *string               `json:"label,omitzero"`
+	Description *string               `json:"description,omitzero"`
+	Rules       []FirewallRuleSetRule `json:"rules,omitzero"`
 }
 
 // ListFirewallRuleSets returns a paginated list of Rule Sets.
 // Supports filtering (e.g., by label) via ListOptions.Filter.
-func (c *Client) ListFirewallRuleSets(ctx context.Context, opts *ListOptions) ([]RuleSet, error) {
-	return getPaginatedResults[RuleSet](ctx, c, "networking/firewalls/rulesets", opts)
+func (c *Client) ListFirewallRuleSets(ctx context.Context, opts *ListOptions) ([]FirewallRuleSet, error) {
+	return getPaginatedResults[FirewallRuleSet](ctx, c, "networking/firewalls/rulesets", opts)
 }
 
 // CreateFirewallRuleSet creates a new Rule Set.
-func (c *Client) CreateFirewallRuleSet(ctx context.Context, opts RuleSetCreateOptions) (*RuleSet, error) {
-	return doPOSTRequest[RuleSet](ctx, c, "networking/firewalls/rulesets", opts)
+func (c *Client) CreateFirewallRuleSet(ctx context.Context, opts RuleSetCreateOptions) (*FirewallRuleSet, error) {
+	return doPOSTRequest[FirewallRuleSet](ctx, c, "networking/firewalls/rulesets", opts)
 }
 
 // GetFirewallRuleSet fetches a Rule Set by ID.
-func (c *Client) GetFirewallRuleSet(ctx context.Context, rulesetID int) (*RuleSet, error) {
+func (c *Client) GetFirewallRuleSet(ctx context.Context, rulesetID int) (*FirewallRuleSet, error) {
 	e := formatAPIPath("networking/firewalls/rulesets/%d", rulesetID)
-	return doGETRequest[RuleSet](ctx, c, e)
+	return doGETRequest[FirewallRuleSet](ctx, c, e)
 }
 
 // UpdateFirewallRuleSet updates a Rule Set by ID.
-func (c *Client) UpdateFirewallRuleSet(ctx context.Context, rulesetID int, opts RuleSetUpdateOptions) (*RuleSet, error) {
+func (c *Client) UpdateFirewallRuleSet(ctx context.Context, rulesetID int, opts RuleSetUpdateOptions) (*FirewallRuleSet, error) {
 	e := formatAPIPath("networking/firewalls/rulesets/%d", rulesetID)
-	return doPUTRequest[RuleSet](ctx, c, e, opts)
+	return doPUTRequest[FirewallRuleSet](ctx, c, e, opts)
 }
 
 // DeleteFirewallRuleSet deletes a Rule Set by ID.

--- a/firewall_rulesets.go
+++ b/firewall_rulesets.go
@@ -44,6 +44,24 @@ type FirewallRuleSetRule struct {
 	Addresses NetworkAddresses `json:"addresses"`
 }
 
+// FirewallRuleSetRuleCreateOptions fields accepted in Firewall Rule Set create payloads.
+type FirewallRuleSetRuleCreateOptions struct {
+	Action    string           `json:"action"`
+	Label     string           `json:"label"`
+	Ports     string           `json:"ports,omitzero"`
+	Protocol  NetworkProtocol  `json:"protocol"`
+	Addresses NetworkAddresses `json:"addresses"`
+}
+
+// FirewallRuleSetRuleUpdateOptions fields accepted in Firewall Rule Set update payloads.
+type FirewallRuleSetRuleUpdateOptions struct {
+	Action    string           `json:"action"`
+	Label     string           `json:"label"`
+	Ports     string           `json:"ports,omitzero"`
+	Protocol  NetworkProtocol  `json:"protocol"`
+	Addresses NetworkAddresses `json:"addresses"`
+}
+
 // UnmarshalJSON implements custom timestamp parsing for FirewallRuleSet.
 func (r *FirewallRuleSet) UnmarshalJSON(b []byte) error {
 	type Mask FirewallRuleSet
@@ -79,19 +97,19 @@ func (r *FirewallRuleSet) UnmarshalJSON(b []byte) error {
 
 // FirewallRuleSetCreateOptions fields accepted by CreateRuleSet.
 type FirewallRuleSetCreateOptions struct {
-	Label       string                `json:"label"`
-	Description string                `json:"description,omitzero"`
-	Type        FirewallRuleSetType   `json:"type"`
-	Rules       []FirewallRuleSetRule `json:"rules"`
+	Label       string                             `json:"label"`
+	Description string                             `json:"description,omitzero"`
+	Type        FirewallRuleSetType                `json:"type"`
+	Rules       []FirewallRuleSetRuleCreateOptions `json:"rules"`
 }
 
 // FirewallRuleSetUpdateOptions fields accepted by UpdateRuleSet.
 // Omit a top-level field to leave it unchanged. If Rules is provided, it
 // replaces the entire ordered rules array.
 type FirewallRuleSetUpdateOptions struct {
-	Label       *string               `json:"label,omitzero"`
-	Description *string               `json:"description,omitzero"`
-	Rules       []FirewallRuleSetRule `json:"rules,omitzero"`
+	Label       *string                            `json:"label,omitzero"`
+	Description *string                            `json:"description,omitzero"`
+	Rules       []FirewallRuleSetRuleUpdateOptions `json:"rules,omitzero"`
 }
 
 // ListFirewallRuleSets returns a paginated list of Rule Sets.

--- a/firewall_rulesets.go
+++ b/firewall_rulesets.go
@@ -33,6 +33,17 @@ type FirewallRuleSet struct {
 	Deleted *time.Time `json:"-"`
 }
 
+// A FirewallRuleSetRule is a whitelist of ports, protocols, and addresses for which traffic should be allowed.
+// The ipv4/ipv6 address lists may contain Prefix List tokens (for example, "pl::..." or "pl:system:...")
+// in addition to literal IP addresses.
+type FirewallRuleSetRule struct {
+	Action    string           `json:"action"`
+	Label     string           `json:"label"`
+	Ports     string           `json:"ports,omitzero"`
+	Protocol  NetworkProtocol  `json:"protocol"`
+	Addresses NetworkAddresses `json:"addresses"`
+}
+
 // UnmarshalJSON implements custom timestamp parsing for FirewallRuleSet.
 func (r *FirewallRuleSet) UnmarshalJSON(b []byte) error {
 	type Mask FirewallRuleSet
@@ -66,18 +77,18 @@ func (r *FirewallRuleSet) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// RuleSetCreateOptions fields accepted by CreateRuleSet.
-type RuleSetCreateOptions struct {
+// FirewallRuleSetCreateOptions fields accepted by CreateRuleSet.
+type FirewallRuleSetCreateOptions struct {
 	Label       string                `json:"label"`
 	Description string                `json:"description,omitzero"`
 	Type        FirewallRuleSetType   `json:"type"`
 	Rules       []FirewallRuleSetRule `json:"rules"`
 }
 
-// RuleSetUpdateOptions fields accepted by UpdateRuleSet.
+// FirewallRuleSetUpdateOptions fields accepted by UpdateRuleSet.
 // Omit a top-level field to leave it unchanged. If Rules is provided, it
 // replaces the entire ordered rules array.
-type RuleSetUpdateOptions struct {
+type FirewallRuleSetUpdateOptions struct {
 	Label       *string               `json:"label,omitzero"`
 	Description *string               `json:"description,omitzero"`
 	Rules       []FirewallRuleSetRule `json:"rules,omitzero"`
@@ -90,7 +101,7 @@ func (c *Client) ListFirewallRuleSets(ctx context.Context, opts *ListOptions) ([
 }
 
 // CreateFirewallRuleSet creates a new Rule Set.
-func (c *Client) CreateFirewallRuleSet(ctx context.Context, opts RuleSetCreateOptions) (*FirewallRuleSet, error) {
+func (c *Client) CreateFirewallRuleSet(ctx context.Context, opts FirewallRuleSetCreateOptions) (*FirewallRuleSet, error) {
 	return doPOSTRequest[FirewallRuleSet](ctx, c, "networking/firewalls/rulesets", opts)
 }
 
@@ -101,7 +112,7 @@ func (c *Client) GetFirewallRuleSet(ctx context.Context, rulesetID int) (*Firewa
 }
 
 // UpdateFirewallRuleSet updates a Rule Set by ID.
-func (c *Client) UpdateFirewallRuleSet(ctx context.Context, rulesetID int, opts RuleSetUpdateOptions) (*FirewallRuleSet, error) {
+func (c *Client) UpdateFirewallRuleSet(ctx context.Context, rulesetID int, opts FirewallRuleSetUpdateOptions) (*FirewallRuleSet, error) {
 	e := formatAPIPath("networking/firewalls/rulesets/%d", rulesetID)
 	return doPUTRequest[FirewallRuleSet](ctx, c, e, opts)
 }

--- a/firewall_templates.go
+++ b/firewall_templates.go
@@ -5,8 +5,8 @@ import (
 )
 
 type FirewallTemplate struct {
-	Slug  string          `json:"slug"`
-	Rules FirewallRuleSet `json:"rules"`
+	Slug  string        `json:"slug"`
+	Rules FirewallRules `json:"rules"`
 }
 
 // GetFirewallTemplate gets a FirewallTemplate given a slug.

--- a/firewalls.go
+++ b/firewalls.go
@@ -50,8 +50,6 @@ type FirewallRulesCreateOptions struct {
 	InboundPolicy  string                 `json:"inbound_policy"`
 	Outbound       []FirewallRuleOutbound `json:"outbound"`
 	OutboundPolicy string                 `json:"outbound_policy"`
-	Version        int                    `json:"version,omitzero"`
-	Fingerprint    string                 `json:"fingerprint,omitzero"`
 }
 
 // FirewallUpdateOptions is an options struct used when Updating a Firewall

--- a/firewalls.go
+++ b/firewalls.go
@@ -24,7 +24,7 @@ type Firewall struct {
 	Label    string                 `json:"label"`
 	Status   FirewallStatus         `json:"status"`
 	Tags     []string               `json:"tags"`
-	Rules    FirewallRuleSet        `json:"rules"`
+	Rules    FirewallRules          `json:"rules"`
 	Entities []FirewallDeviceEntity `json:"entities"`
 	Created  *time.Time             `json:"-"`
 	Updated  *time.Time             `json:"-"`
@@ -40,7 +40,7 @@ type DevicesCreationOptions struct {
 // FirewallCreateOptions fields are those accepted by CreateFirewall
 type FirewallCreateOptions struct {
 	Label   string                 `json:"label,omitzero"`
-	Rules   FirewallRuleSet        `json:"rules"`
+	Rules   FirewallRules          `json:"rules"`
 	Tags    []string               `json:"tags,omitzero"`
 	Devices DevicesCreationOptions `json:"devices,omitzero"`
 }

--- a/firewalls.go
+++ b/firewalls.go
@@ -39,10 +39,19 @@ type DevicesCreationOptions struct {
 
 // FirewallCreateOptions fields are those accepted by CreateFirewall
 type FirewallCreateOptions struct {
-	Label   string                 `json:"label,omitzero"`
-	Rules   FirewallRules          `json:"rules"`
-	Tags    []string               `json:"tags,omitzero"`
-	Devices DevicesCreationOptions `json:"devices,omitzero"`
+	Label   string                     `json:"label,omitzero"`
+	Rules   FirewallRulesCreateOptions `json:"rules"`
+	Tags    []string                   `json:"tags,omitzero"`
+	Devices DevicesCreationOptions     `json:"devices,omitzero"`
+}
+
+type FirewallRulesCreateOptions struct {
+	Inbound        []FirewallRuleInbound  `json:"inbound"`
+	InboundPolicy  string                 `json:"inbound_policy"`
+	Outbound       []FirewallRuleOutbound `json:"outbound"`
+	OutboundPolicy string                 `json:"outbound_policy"`
+	Version        int                    `json:"version,omitzero"`
+	Fingerprint    string                 `json:"fingerprint,omitzero"`
 }
 
 // FirewallUpdateOptions is an options struct used when Updating a Firewall

--- a/instance_config_interfaces.go
+++ b/instance_config_interfaces.go
@@ -49,13 +49,23 @@ type VPCIPv4 struct {
 	NAT1To1 *string `json:"nat_1_1,omitzero"`
 }
 
+type VPCIPv4CreateOptions struct {
+	VPC     string  `json:"vpc,omitzero"`
+	NAT1To1 *string `json:"nat_1_1,omitzero"`
+}
+
+type VPCIPv4UpdateOptions struct {
+	VPC     string  `json:"vpc,omitzero"`
+	NAT1To1 *string `json:"nat_1_1,omitzero"`
+}
+
 type InstanceConfigInterfaceCreateOptions struct {
 	IPAMAddress string                 `json:"ipam_address,omitzero"`
 	Label       string                 `json:"label,omitzero"`
 	Purpose     ConfigInterfacePurpose `json:"purpose,omitzero"`
 	Primary     bool                   `json:"primary,omitzero"`
 	SubnetID    *int                   `json:"subnet_id,omitzero"`
-	IPv4        *VPCIPv4               `json:"ipv4,omitzero"`
+	IPv4        *VPCIPv4CreateOptions  `json:"ipv4,omitzero"`
 
 	// NOTE: IPv6 interfaces may not currently be available to all users.
 	IPv6 *InstanceConfigInterfaceCreateOptionsIPv6 `json:"ipv6,omitzero"`
@@ -87,8 +97,8 @@ type InstanceConfigInterfaceCreateOptionsIPv6Range struct {
 }
 
 type InstanceConfigInterfaceUpdateOptions struct {
-	Primary bool     `json:"primary,omitzero"`
-	IPv4    *VPCIPv4 `json:"ipv4,omitzero"`
+	Primary bool                  `json:"primary,omitzero"`
+	IPv4    *VPCIPv4UpdateOptions `json:"ipv4,omitzero"`
 
 	// NOTE: IPv6 interfaces may not currently be available to all users.
 	IPv6 *InstanceConfigInterfaceUpdateOptionsIPv6 `json:"ipv6,omitzero"`
@@ -147,7 +157,7 @@ func (i InstanceConfigInterface) GetCreateOptions() InstanceConfigInterfaceCreat
 	}
 
 	if i.IPv4 != nil {
-		opts.IPv4 = &VPCIPv4{
+		opts.IPv4 = &VPCIPv4CreateOptions{
 			VPC:     i.IPv4.VPC,
 			NAT1To1: i.IPv4.NAT1To1,
 		}
@@ -189,7 +199,7 @@ func (i InstanceConfigInterface) GetUpdateOptions() InstanceConfigInterfaceUpdat
 
 	if i.Purpose == InterfacePurposeVPC {
 		if i.IPv4 != nil {
-			opts.IPv4 = &VPCIPv4{
+			opts.IPv4 = &VPCIPv4UpdateOptions{
 				VPC:     i.IPv4.VPC,
 				NAT1To1: i.IPv4.NAT1To1,
 			}

--- a/interfaces.go
+++ b/interfaces.go
@@ -25,6 +25,16 @@ type InterfaceDefaultRoute struct {
 	IPv6 *bool `json:"ipv6,omitzero"`
 }
 
+type InterfaceDefaultRouteCreateOptions struct {
+	IPv4 *bool `json:"ipv4,omitzero"`
+	IPv6 *bool `json:"ipv6,omitzero"`
+}
+
+type InterfaceDefaultRouteUpdateOptions struct {
+	IPv4 *bool `json:"ipv4,omitzero"`
+	IPv6 *bool `json:"ipv6,omitzero"`
+}
+
 type PublicInterface struct {
 	IPv4 *PublicInterfaceIPv4 `json:"ipv4"`
 	IPv6 *PublicInterfaceIPv6 `json:"ipv6"`
@@ -111,18 +121,23 @@ type VLANInterface struct {
 	IPAMAddress *string `json:"ipam_address,omitzero"`
 }
 
+type VLANInterfaceCreateOptions struct {
+	VLANLabel   string  `json:"vlan_label"`
+	IPAMAddress *string `json:"ipam_address,omitzero"`
+}
+
 type LinodeInterfaceCreateOptions struct {
-	FirewallID   *int                          `json:"firewall_id,omitzero"`
-	DefaultRoute *InterfaceDefaultRoute        `json:"default_route,omitzero"`
-	Public       *PublicInterfaceCreateOptions `json:"public,omitzero"`
-	VPC          *VPCInterfaceCreateOptions    `json:"vpc,omitzero"`
-	VLAN         *VLANInterface                `json:"vlan,omitzero"`
+	FirewallID   *int                                `json:"firewall_id,omitzero"`
+	DefaultRoute *InterfaceDefaultRouteCreateOptions `json:"default_route,omitzero"`
+	Public       *PublicInterfaceCreateOptions       `json:"public,omitzero"`
+	VPC          *VPCInterfaceCreateOptions          `json:"vpc,omitzero"`
+	VLAN         *VLANInterfaceCreateOptions         `json:"vlan,omitzero"`
 }
 
 type LinodeInterfaceUpdateOptions struct {
-	DefaultRoute *InterfaceDefaultRoute        `json:"default_route,omitzero"`
-	Public       *PublicInterfaceCreateOptions `json:"public,omitzero"`
-	VPC          *VPCInterfaceUpdateOptions    `json:"vpc,omitzero"`
+	DefaultRoute *InterfaceDefaultRouteUpdateOptions `json:"default_route,omitzero"`
+	Public       *PublicInterfaceCreateOptions       `json:"public,omitzero"`
+	VPC          *VPCInterfaceUpdateOptions          `json:"vpc,omitzero"`
 }
 
 type PublicInterfaceCreateOptions struct {

--- a/object_storage_keys.go
+++ b/object_storage_keys.go
@@ -29,11 +29,18 @@ type ObjectStorageKeyBucketAccess struct {
 	Permissions string `json:"permissions"`
 }
 
+type ObjectStorageKeyBucketAccessCreateOptions struct {
+	Region string `json:"region,omitzero"`
+
+	BucketName  string `json:"bucket_name"`
+	Permissions string `json:"permissions"`
+}
+
 // ObjectStorageKeyCreateOptions fields are those accepted by CreateObjectStorageKey
 type ObjectStorageKeyCreateOptions struct {
-	Label        string                         `json:"label"`
-	BucketAccess []ObjectStorageKeyBucketAccess `json:"bucket_access,omitzero"`
-	Regions      []string                       `json:"regions,omitzero"`
+	Label        string                                      `json:"label"`
+	BucketAccess []ObjectStorageKeyBucketAccessCreateOptions `json:"bucket_access,omitzero"`
+	Regions      []string                                    `json:"regions,omitzero"`
 }
 
 // ObjectStorageKeyUpdateOptions fields are those accepted by UpdateObjectStorageKey

--- a/test/integration/firewall_rules_test.go
+++ b/test/integration/firewall_rules_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	testFirewallRule = linodego.FirewallRule{
+	testFirewallRule = linodego.FirewallRuleSetRule{
 		Label:    "go-fwrule-test",
 		Action:   "ACCEPT",
 		Ports:    "22",
@@ -20,10 +20,10 @@ var (
 		},
 	}
 
-	testFirewallRuleSet = linodego.FirewallRuleSet{
-		Inbound:        []linodego.FirewallRule{testFirewallRule},
+	testFirewallRuleSet = linodego.FirewallRules{
+		Inbound:        []linodego.FirewallRuleSetRule{testFirewallRule},
 		InboundPolicy:  "ACCEPT",
-		Outbound:       []linodego.FirewallRule{testFirewallRule},
+		Outbound:       []linodego.FirewallRuleSetRule{testFirewallRule},
 		OutboundPolicy: "ACCEPT",
 	}
 )
@@ -75,7 +75,7 @@ func TestFirewallRules_Update(t *testing.T) {
 	defer teardown()
 
 	newRules := linodego.FirewallRuleSetUpdateOptions{
-		Inbound: []linodego.FirewallRule{
+		Inbound: []linodego.FirewallRuleSetRule{
 			{
 				Label:    testFirewallRule.Label + "_r",
 				Action:   "DROP",

--- a/test/integration/firewall_rules_test.go
+++ b/test/integration/firewall_rules_test.go
@@ -74,7 +74,7 @@ func TestFirewallRules_Update(t *testing.T) {
 	}
 	defer teardown()
 
-	newRules := linodego.FirewallRuleSet{
+	newRules := linodego.FirewallRuleSetUpdateOptions{
 		Inbound: []linodego.FirewallRule{
 			{
 				Label:    testFirewallRule.Label + "_r",

--- a/test/integration/firewall_rules_test.go
+++ b/test/integration/firewall_rules_test.go
@@ -9,7 +9,17 @@ import (
 )
 
 var (
-	testFirewallRule = linodego.FirewallRuleSetRule{
+	testFirewallRuleInbound = linodego.FirewallRuleInbound{
+		Label:    "go-fwrule-test",
+		Action:   "ACCEPT",
+		Ports:    "22",
+		Protocol: "TCP",
+		Addresses: linodego.NetworkAddresses{
+			IPv4: []string{"0.0.0.0/0"},
+			IPv6: []string{"::0/0"},
+		},
+	}
+	testFirewallRuleOutbound = linodego.FirewallRuleOutbound{
 		Label:    "go-fwrule-test",
 		Action:   "ACCEPT",
 		Ports:    "22",
@@ -21,9 +31,9 @@ var (
 	}
 
 	testFirewallRuleSet = linodego.FirewallRules{
-		Inbound:        []linodego.FirewallRuleSetRule{testFirewallRule},
+		Inbound:        []linodego.FirewallRuleInbound{testFirewallRuleInbound},
 		InboundPolicy:  "ACCEPT",
-		Outbound:       []linodego.FirewallRuleSetRule{testFirewallRule},
+		Outbound:       []linodego.FirewallRuleOutbound{testFirewallRuleOutbound},
 		OutboundPolicy: "ACCEPT",
 	}
 )
@@ -75,9 +85,9 @@ func TestFirewallRules_Update(t *testing.T) {
 	defer teardown()
 
 	newRules := linodego.FirewallRuleSetUpdateOptions{
-		Inbound: []linodego.FirewallRuleSetRule{
+		Inbound: []linodego.FirewallRuleInbound{
 			{
-				Label:    testFirewallRule.Label + "_r",
+				Label:    testFirewallRuleInbound.Label + "_r",
 				Action:   "DROP",
 				Ports:    "22",
 				Protocol: "TCP",

--- a/test/integration/firewall_rules_test.go
+++ b/test/integration/firewall_rules_test.go
@@ -30,7 +30,7 @@ var (
 		},
 	}
 
-	testFirewallRuleSet = linodego.FirewallRules{
+	testFirewallRuleSet = linodego.FirewallRulesCreateOptions{
 		Inbound:        []linodego.FirewallRuleInbound{testFirewallRuleInbound},
 		InboundPolicy:  "ACCEPT",
 		Outbound:       []linodego.FirewallRuleOutbound{testFirewallRuleOutbound},
@@ -84,7 +84,7 @@ func TestFirewallRules_Update(t *testing.T) {
 	}
 	defer teardown()
 
-	newRules := linodego.FirewallRuleSetUpdateOptions{
+	newRules := linodego.FirewallRulesUpdateOptions{
 		Inbound: []linodego.FirewallRuleInbound{
 			{
 				Label:    testFirewallRuleInbound.Label + "_r",

--- a/test/integration/firewall_rulesets_test.go
+++ b/test/integration/firewall_rulesets_test.go
@@ -18,7 +18,7 @@ func TestFirewallRuleSets_CRUD(t *testing.T) {
 		Label:       label,
 		Description: "Allow inbound HTTP",
 		Type:        linodego.FirewallRuleSetTypeInbound,
-		Rules: []linodego.FirewallRuleSetRule{
+		Rules: []linodego.FirewallRuleSetRuleCreateOptions{
 			{
 				Label:    "allow-http",
 				Action:   "ACCEPT",
@@ -64,7 +64,7 @@ func TestFirewallRuleSets_CRUD(t *testing.T) {
 
 	updatedLabel := label + "-updated"
 	updatedDescription := "Updated description"
-	updatedRules := []linodego.FirewallRuleSetRule{
+	updatedRules := []linodego.FirewallRuleSetRuleUpdateOptions{
 		{
 			Label:    "allow-https",
 			Action:   "ACCEPT",

--- a/test/integration/firewall_rulesets_test.go
+++ b/test/integration/firewall_rulesets_test.go
@@ -18,7 +18,7 @@ func TestFirewallRuleSets_CRUD(t *testing.T) {
 		Label:       label,
 		Description: "Allow inbound HTTP",
 		Type:        linodego.FirewallRuleSetTypeInbound,
-		Rules: []linodego.FirewallRule{
+		Rules: []linodego.FirewallRuleSetRule{
 			{
 				Label:    "allow-http",
 				Action:   "ACCEPT",
@@ -64,7 +64,7 @@ func TestFirewallRuleSets_CRUD(t *testing.T) {
 
 	updatedLabel := label + "-updated"
 	updatedDescription := "Updated description"
-	updatedRules := []linodego.FirewallRule{
+	updatedRules := []linodego.FirewallRuleSetRule{
 		{
 			Label:    "allow-https",
 			Action:   "ACCEPT",

--- a/test/integration/firewall_rulesets_test.go
+++ b/test/integration/firewall_rulesets_test.go
@@ -14,7 +14,7 @@ func TestFirewallRuleSets_CRUD(t *testing.T) {
 	ctx := context.Background()
 
 	label := "rs-51452000"
-	createOpts := linodego.RuleSetCreateOptions{
+	createOpts := linodego.FirewallRuleSetCreateOptions{
 		Label:       label,
 		Description: "Allow inbound HTTP",
 		Type:        linodego.FirewallRuleSetTypeInbound,
@@ -76,7 +76,7 @@ func TestFirewallRuleSets_CRUD(t *testing.T) {
 		},
 	}
 
-	updateOpts := linodego.RuleSetUpdateOptions{
+	updateOpts := linodego.FirewallRuleSetUpdateOptions{
 		Label:       &updatedLabel,
 		Description: &updatedDescription,
 		Rules:       updatedRules,

--- a/test/integration/firewalls_test.go
+++ b/test/integration/firewalls_test.go
@@ -49,7 +49,7 @@ func TestFirewalls_List_smoke(t *testing.T) {
 }
 
 func TestFirewall_Get(t *testing.T) {
-	rules := linodego.FirewallRules{
+	rules := linodego.FirewallRulesCreateOptions{
 		Inbound: []linodego.FirewallRuleInbound{
 			{
 				Label:    "linodego-fwrule-test",
@@ -90,7 +90,7 @@ func TestFirewall_Get(t *testing.T) {
 }
 
 func TestFirewall_Update(t *testing.T) {
-	rules := linodego.FirewallRules{
+	rules := linodego.FirewallRulesCreateOptions{
 		InboundPolicy: "ACCEPT",
 		Inbound: []linodego.FirewallRuleInbound{
 			{

--- a/test/integration/firewalls_test.go
+++ b/test/integration/firewalls_test.go
@@ -18,7 +18,7 @@ var testFirewallCreateOpts = linodego.FirewallCreateOptions{
 
 // ignoreNetworkAddresses negates comparing IP addresses. Because of fixture sanitization,
 // these addresses will be changed to bogus values when running tests.
-var ignoreNetworkAddresses = cmpopts.IgnoreFields(linodego.FirewallRule{}, "Addresses")
+var ignoreNetworkAddresses = cmpopts.IgnoreFields(linodego.FirewallRuleSetRule{}, "Addresses")
 
 // ignoreFirewallTimestamps negates comparing created and updated timestamps. Because of
 // fixture sanitization, these addresses will be changed to bogus values when running tests.
@@ -46,8 +46,8 @@ func TestFirewalls_List_smoke(t *testing.T) {
 }
 
 func TestFirewall_Get(t *testing.T) {
-	rules := linodego.FirewallRuleSet{
-		Inbound: []linodego.FirewallRule{
+	rules := linodego.FirewallRules{
+		Inbound: []linodego.FirewallRuleSetRule{
 			{
 				Label:    "linodego-fwrule-test",
 				Action:   "DROP",
@@ -87,9 +87,9 @@ func TestFirewall_Get(t *testing.T) {
 }
 
 func TestFirewall_Update(t *testing.T) {
-	rules := linodego.FirewallRuleSet{
+	rules := linodego.FirewallRules{
 		InboundPolicy: "ACCEPT",
-		Inbound: []linodego.FirewallRule{
+		Inbound: []linodego.FirewallRuleSetRule{
 			{
 				Label:    "linodego-fwrule-test",
 				Action:   "DROP",

--- a/test/integration/firewalls_test.go
+++ b/test/integration/firewalls_test.go
@@ -18,7 +18,10 @@ var testFirewallCreateOpts = linodego.FirewallCreateOptions{
 
 // ignoreNetworkAddresses negates comparing IP addresses. Because of fixture sanitization,
 // these addresses will be changed to bogus values when running tests.
-var ignoreNetworkAddresses = cmpopts.IgnoreFields(linodego.FirewallRuleSetRule{}, "Addresses")
+var ignoreNetworkAddresses = cmp.Options{
+	cmpopts.IgnoreFields(linodego.FirewallRuleInbound{}, "Addresses"),
+	cmpopts.IgnoreFields(linodego.FirewallRuleOutbound{}, "Addresses"),
+}
 
 // ignoreFirewallTimestamps negates comparing created and updated timestamps. Because of
 // fixture sanitization, these addresses will be changed to bogus values when running tests.
@@ -47,7 +50,7 @@ func TestFirewalls_List_smoke(t *testing.T) {
 
 func TestFirewall_Get(t *testing.T) {
 	rules := linodego.FirewallRules{
-		Inbound: []linodego.FirewallRuleSetRule{
+		Inbound: []linodego.FirewallRuleInbound{
 			{
 				Label:    "linodego-fwrule-test",
 				Action:   "DROP",
@@ -89,7 +92,7 @@ func TestFirewall_Get(t *testing.T) {
 func TestFirewall_Update(t *testing.T) {
 	rules := linodego.FirewallRules{
 		InboundPolicy: "ACCEPT",
-		Inbound: []linodego.FirewallRuleSetRule{
+		Inbound: []linodego.FirewallRuleInbound{
 			{
 				Label:    "linodego-fwrule-test",
 				Action:   "DROP",

--- a/test/integration/fixtures/TestFirewallRuleSets_CRUD.yaml
+++ b/test/integration/fixtures/TestFirewallRuleSets_CRUD.yaml
@@ -14,7 +14,7 @@ interactions:
     url: https://api.linode.com/v4beta/networking/firewalls/rulesets
     method: POST
   response:
-    body: '{"id": 66319, "version": 1, "label": "rs-51452000", "description": "Allow
+    body: '{"id": 76228, "version": 1, "label": "rs-51452000", "description": "Allow
       inbound HTTP", "type": "inbound", "is_service_defined": false, "rules": [{"action":
       "ACCEPT", "label": "allow-http", "ports": "80", "protocol": "TCP", "addresses":
       {"ipv4": ["0.0.0.0/0"]}}], "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
@@ -43,7 +43,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 23:45:09 GMT
+      - Tue, 19 May 2026 19:46:09 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -76,10 +76,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/rulesets/66319
+    url: https://api.linode.com/v4beta/networking/firewalls/rulesets/76228
     method: GET
   response:
-    body: '{"id": 66319, "version": 1, "label": "rs-51452000", "description": "Allow
+    body: '{"id": 76228, "version": 1, "label": "rs-51452000", "description": "Allow
       inbound HTTP", "type": "inbound", "is_service_defined": false, "rules": [{"label":
       "allow-http", "ports": "80", "action": "ACCEPT", "protocol": "TCP", "addresses":
       {"ipv4": ["0.0.0.0/0"]}}], "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05",
@@ -108,7 +108,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 23:45:09 GMT
+      - Tue, 19 May 2026 19:46:09 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -142,10 +142,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/rulesets/66319
+    url: https://api.linode.com/v4beta/networking/firewalls/rulesets/76228
     method: PUT
   response:
-    body: '{"id": 66319, "version": 2, "label": "rs-51452000-updated", "description":
+    body: '{"id": 76228, "version": 2, "label": "rs-51452000-updated", "description":
       "Updated description", "type": "inbound", "is_service_defined": false, "rules":
       [{"label": "allow-https", "ports": "443", "action": "ACCEPT", "protocol": "TCP",
       "addresses": {"ipv6": ["1234::5678/0"]}}], "created": "2018-01-02T03:04:05", "updated":
@@ -174,7 +174,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 23:45:09 GMT
+      - Tue, 19 May 2026 19:46:10 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -219,7 +219,12 @@ interactions:
       "inbound", "is_service_defined": false, "rules": [{"label": "allow-https", "ports":
       "443", "action": "ACCEPT", "protocol": "TCP", "addresses": {"ipv6": ["1234::5678/0"]}}],
       "created": "2018-01-02T03:04:05", "updated": "2018-01-02T03:04:05", "deleted":
-      null}], "page": 1, "pages": 1, "results": 2}'
+      "2018-01-02T03:04:05"}, {"id": 76228, "version": 2, "label": "rs-51452000-updated",
+      "description": "Updated description", "type": "inbound", "is_service_defined":
+      false, "rules": [{"label": "allow-https", "ports": "443", "action": "ACCEPT",
+      "protocol": "TCP", "addresses": {"ipv6": ["1234::5678/0"]}}], "created": "2018-01-02T03:04:05",
+      "updated": "2018-01-02T03:04:05", "deleted": null}], "page": 1, "pages": 1,
+      "results": 3}'
     headers:
       Access-Control-Allow-Credentials:
       - "true"
@@ -237,14 +242,12 @@ interactions:
       - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
-      Content-Length:
-      - "778"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 23:45:10 GMT
+      - Tue, 19 May 2026 19:46:10 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:
@@ -252,6 +255,7 @@ interactions:
       Vary:
       - Authorization, X-Filter
       - Authorization, X-Filter
+      - Accept-Encoding
       X-Accepted-Oauth-Scopes:
       - firewall:read_only
       X-Content-Type-Options:
@@ -278,7 +282,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/rulesets/66319
+    url: https://api.linode.com/v4beta/networking/firewalls/rulesets/76228
     method: DELETE
   response:
     body: '{}'
@@ -306,7 +310,7 @@ interactions:
       Content-Type:
       - application/json
       Expires:
-      - Tue, 05 May 2026 23:45:11 GMT
+      - Tue, 19 May 2026 19:46:10 GMT
       Pragma:
       - no-cache
       Strict-Transport-Security:

--- a/test/integration/instance_config_test.go
+++ b/test/integration/instance_config_test.go
@@ -89,7 +89,7 @@ func setupInstanceWithVPCAndNATOneToOne(t *testing.T, fixturesYaml string) (
 		{
 			Purpose:  InterfacePurposeVPC,
 			SubnetID: &vpcSubnet.ID,
-			IPv4: &VPCIPv4{
+			IPv4: &VPCIPv4CreateOptions{
 				NAT1To1: &NAT1To1Any,
 			},
 		},
@@ -183,7 +183,7 @@ func setupInstanceWithDualStackVPCAndNAT11(t *testing.T, fixturesYaml string) (
 		{
 			Purpose:  InterfacePurposeVPC,
 			SubnetID: &vpcSubnet.ID,
-			IPv4: &VPCIPv4{
+			IPv4: &VPCIPv4CreateOptions{
 				NAT1To1: &NAT1To1Any,
 			},
 			IPv6: &InstanceConfigInterfaceCreateOptionsIPv6{
@@ -244,7 +244,7 @@ func setupInstanceWith3Interfaces(t *testing.T, fixturesYaml string) (
 		{
 			Purpose:  InterfacePurposeVPC,
 			SubnetID: &vpcSubnet.ID,
-			IPv4: &VPCIPv4{
+			IPv4: &VPCIPv4CreateOptions{
 				NAT1To1: &NAT1To1Any,
 			},
 		},
@@ -490,7 +490,7 @@ func TestInstance_ConfigInterfaces_Update(t *testing.T) {
 		{
 			Purpose:  InterfacePurposeVPC,
 			SubnetID: &vpcSubnet.ID,
-			IPv4: &VPCIPv4{
+			IPv4: &VPCIPv4CreateOptions{
 				VPC: "192.168.0.87",
 			},
 		},
@@ -590,7 +590,7 @@ func TestInstance_ConfigInterface_Update(t *testing.T) {
 	}
 
 	NAT1To1Any := "any"
-	updateOpts.IPv4 = &VPCIPv4{
+	updateOpts.IPv4 = &VPCIPv4UpdateOptions{
 		VPC:     "192.168.0.10",
 		NAT1To1: &NAT1To1Any,
 	}

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -77,7 +77,7 @@ func deleteCloudFirewall() {
 }
 
 func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRules {
-	cloudFirewallRule := linodego.FirewallRuleSetRule{
+	cloudFirewallRuleInbound := linodego.FirewallRuleInbound{
 		Label:     "ssh-inbound-accept-local",
 		Action:    "ACCEPT",
 		Ports:     "22",
@@ -86,9 +86,9 @@ func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRules {
 	}
 
 	return linodego.FirewallRules{
-		Inbound:        []linodego.FirewallRuleSetRule{cloudFirewallRule},
+		Inbound:        []linodego.FirewallRuleInbound{cloudFirewallRuleInbound},
 		InboundPolicy:  "DROP",
-		Outbound:       []linodego.FirewallRuleSetRule{},
+		Outbound:       []linodego.FirewallRuleOutbound{},
 		OutboundPolicy: "ACCEPT",
 	}
 }

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -76,7 +76,7 @@ func deleteCloudFirewall() {
 	}
 }
 
-func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRules {
+func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRulesCreateOptions {
 	cloudFirewallRuleInbound := linodego.FirewallRuleInbound{
 		Label:     "ssh-inbound-accept-local",
 		Action:    "ACCEPT",
@@ -85,7 +85,7 @@ func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRules {
 		Addresses: linodego.NetworkAddresses{IPv4: []string{publicIPv4}},
 	}
 
-	return linodego.FirewallRules{
+	return linodego.FirewallRulesCreateOptions{
 		Inbound:        []linodego.FirewallRuleInbound{cloudFirewallRuleInbound},
 		InboundPolicy:  "DROP",
 		Outbound:       []linodego.FirewallRuleOutbound{},

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -76,8 +76,8 @@ func deleteCloudFirewall() {
 	}
 }
 
-func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRuleSet {
-	cloudFirewallRule := linodego.FirewallRule{
+func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRules {
+	cloudFirewallRule := linodego.FirewallRuleSetRule{
 		Label:     "ssh-inbound-accept-local",
 		Action:    "ACCEPT",
 		Ports:     "22",
@@ -85,10 +85,10 @@ func getDefaultFirewallRuleSet(publicIPv4 string) linodego.FirewallRuleSet {
 		Addresses: linodego.NetworkAddresses{IPv4: []string{publicIPv4}},
 	}
 
-	return linodego.FirewallRuleSet{
-		Inbound:        []linodego.FirewallRule{cloudFirewallRule},
+	return linodego.FirewallRules{
+		Inbound:        []linodego.FirewallRuleSetRule{cloudFirewallRule},
 		InboundPolicy:  "DROP",
-		Outbound:       []linodego.FirewallRule{},
+		Outbound:       []linodego.FirewallRuleSetRule{},
 		OutboundPolicy: "ACCEPT",
 	}
 }

--- a/test/integration/nodebalancer_configs_test.go
+++ b/test/integration/nodebalancer_configs_test.go
@@ -284,7 +284,7 @@ func setupNodeBalancerWithVPCAndInstance(
 				{
 					Purpose:  "vpc",
 					SubnetID: &subnet.ID,
-					IPv4: &linodego.VPCIPv4{
+					IPv4: &linodego.VPCIPv4CreateOptions{
 						NAT1To1: &NAT1To1Any,
 					},
 				},

--- a/test/integration/object_storage_keys_test.go
+++ b/test/integration/object_storage_keys_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+    
 	"github.com/linode/linodego"
 	. "github.com/linode/linodego"
 )
@@ -113,8 +113,12 @@ func TestObjectStorageKeys_Limited(t *testing.T) {
 	)
 	defer teardown()
 
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	createOpts := testBasicObjectStorageKeyCreateOpts
-	createOpts.BucketAccess = []ObjectStorageKeyBucketAccess{
+	createOpts.BucketAccess = []ObjectStorageKeyBucketAccessCreateOptions{
 		{
 			Region:      "us-east",
 			BucketName:  bucket.Label,
@@ -132,12 +136,24 @@ func TestObjectStorageKeys_Limited(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if !objectStorageKey.Limited || !cmp.Equal(*objectStorageKey.BucketAccess, createOpts.BucketAccess) {
-		t.Errorf(
-			"objectStorageKey returned (%v) does not match objectStorageKey creation request (%v)",
-			*objectStorageKey.BucketAccess,
-			createOpts.BucketAccess,
-		)
+	if !objectStorageKey.Limited {
+		t.Errorf("expected key to be limited")
+	}
+
+	if objectStorageKey.BucketAccess == nil {
+		t.Fatalf("expected BucketAccess to be set on returned key")
+	}
+
+	// Compare values field-by-field to avoid relying on concrete types.
+	got := *objectStorageKey.BucketAccess
+	if len(got) != len(createOpts.BucketAccess) {
+		t.Fatalf("bucket access length mismatch: got %d, want %d", len(got), len(createOpts.BucketAccess))
+	}
+	for i := range got {
+		want := createOpts.BucketAccess[i]
+		if got[i].Region != want.Region || got[i].BucketName != want.BucketName || got[i].Permissions != want.Permissions {
+			t.Errorf("bucket access mismatch at index %d: got %+v, want %+v", i, got[i], want)
+		}
 	}
 }
 
@@ -145,7 +161,7 @@ func TestObjectStorageKeys_Limited_NoAccess(t *testing.T) {
 	t.Skip("skipping test due to unexpected API behavior with limited object storage keys")
 
 	createOpts := testBasicObjectStorageKeyCreateOpts
-	createOpts.BucketAccess = []ObjectStorageKeyBucketAccess{}
+	createOpts.BucketAccess = []ObjectStorageKeyBucketAccessCreateOptions{}
 
 	_, objectStorageKey, teardown, err := setupObjectStorageKey(t, createOpts, "fixtures/TestObjectStorageKeys_Limited_NoAccess", nil, nil)
 	defer teardown()
@@ -178,7 +194,7 @@ func TestObjectStorageKeys_Regional_Limited(t *testing.T) {
 	}
 
 	createOpts := testBasicObjectStorageKeyCreateOpts
-	createOpts.BucketAccess = []ObjectStorageKeyBucketAccess{
+	createOpts.BucketAccess = []ObjectStorageKeyBucketAccessCreateOptions{
 		{
 			Region:      region,
 			BucketName:  bucket.Label,

--- a/test/integration/object_storage_keys_test.go
+++ b/test/integration/object_storage_keys_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-    
 	"github.com/linode/linodego"
 	. "github.com/linode/linodego"
 )

--- a/test/unit/firewall_rules_test.go
+++ b/test/unit/firewall_rules_test.go
@@ -81,7 +81,7 @@ func TestFirewallRule_Update(t *testing.T) {
 	firewallID := 123
 	base.MockPut(formatMockAPIPath("networking/firewalls/%d/rules", firewallID), fixtureData)
 
-	requestData := linodego.FirewallRuleSetUpdateOptions{
+	requestData := linodego.FirewallRulesUpdateOptions{
 		Inbound: []linodego.FirewallRuleInbound{
 			{
 				Action:      "ACCEPT",

--- a/test/unit/firewall_rules_test.go
+++ b/test/unit/firewall_rules_test.go
@@ -86,7 +86,7 @@ func TestFirewallRule_Update(t *testing.T) {
 	firewallID := 123
 	base.MockPut(formatMockAPIPath("networking/firewalls/%d/rules", firewallID), fixtureData)
 
-	requestData := linodego.FirewallRuleSet{
+	requestData := linodego.FirewallRuleSetUpdateOptions{
 		Inbound: []linodego.FirewallRule{
 			{
 				Action:      "ACCEPT",

--- a/test/unit/firewall_rules_test.go
+++ b/test/unit/firewall_rules_test.go
@@ -50,7 +50,7 @@ func TestFirewallRule_Get(t *testing.T) {
 
 func TestFirewallRule_MarshalJSON(t *testing.T) {
 	ipv4 := []string{"pl::vpcs:123"}
-	ruleWithoutRuleset := linodego.FirewallRuleSetRule{
+	ruleWithoutRuleset := linodego.FirewallRuleSetRuleCreateOptions{
 		Action:   "ACCEPT",
 		Label:    "allow-vpc",
 		Ports:    "443",

--- a/test/unit/firewall_rules_test.go
+++ b/test/unit/firewall_rules_test.go
@@ -49,13 +49,8 @@ func TestFirewallRule_Get(t *testing.T) {
 }
 
 func TestFirewallRule_MarshalJSON(t *testing.T) {
-	ruleWithRuleset := linodego.FirewallRule{RuleSet: 51}
-	data, err := json.Marshal(ruleWithRuleset)
-	assert.NoError(t, err)
-	assert.JSONEq(t, `{"ruleset":51}`, string(data))
-
 	ipv4 := []string{"pl::vpcs:123"}
-	ruleWithoutRuleset := linodego.FirewallRule{
+	ruleWithoutRuleset := linodego.FirewallRuleSetRule{
 		Action:   "ACCEPT",
 		Label:    "allow-vpc",
 		Ports:    "443",
@@ -64,7 +59,7 @@ func TestFirewallRule_MarshalJSON(t *testing.T) {
 			IPv4: ipv4,
 		},
 	}
-	data, err = json.Marshal(ruleWithoutRuleset)
+	data, err := json.Marshal(ruleWithoutRuleset)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{
         "action":"ACCEPT",
@@ -87,7 +82,7 @@ func TestFirewallRule_Update(t *testing.T) {
 	base.MockPut(formatMockAPIPath("networking/firewalls/%d/rules", firewallID), fixtureData)
 
 	requestData := linodego.FirewallRuleSetUpdateOptions{
-		Inbound: []linodego.FirewallRule{
+		Inbound: []linodego.FirewallRuleInbound{
 			{
 				Action:      "ACCEPT",
 				Label:       "firewallrule123",
@@ -101,7 +96,7 @@ func TestFirewallRule_Update(t *testing.T) {
 			},
 		},
 		InboundPolicy: "DROP",
-		Outbound: []linodego.FirewallRule{
+		Outbound: []linodego.FirewallRuleOutbound{
 			{
 				Action:      "ACCEPT",
 				Label:       "firewallrule123",
@@ -151,8 +146,8 @@ func TestFirewallRule_GetExpansion(t *testing.T) {
 	outboundIPv4 := []string{"pl::vpcs:1234"}
 	outboundIPv6 := []string{"pl::vpcs:<current>"}
 
-	mockResponse := linodego.FirewallRuleSet{
-		Inbound: []linodego.FirewallRule{
+	mockResponse := linodego.FirewallRules{
+		Inbound: []linodego.FirewallRuleInbound{
 			{
 				Action:      "ACCEPT",
 				Label:       "accept-inbound-ssh",
@@ -166,7 +161,7 @@ func TestFirewallRule_GetExpansion(t *testing.T) {
 			},
 		},
 		InboundPolicy: "DROP",
-		Outbound: []linodego.FirewallRule{
+		Outbound: []linodego.FirewallRuleOutbound{
 			{
 				Action:      "ACCEPT",
 				Label:       "accept-outbound-ssh",

--- a/test/unit/firewall_rulesets_test.go
+++ b/test/unit/firewall_rulesets_test.go
@@ -121,7 +121,7 @@ func TestFirewallRuleSets_Get(t *testing.T) {
 func TestFirewallRuleSets_Create(t *testing.T) {
 	client := createMockClient(t)
 
-	req := linodego.RuleSetCreateOptions{
+	req := linodego.FirewallRuleSetCreateOptions{
 		Label:       "allow-vpc",
 		Description: "Allow VPC ingress",
 		Type:        linodego.FirewallRuleSetTypeInbound,
@@ -186,7 +186,7 @@ func TestFirewallRuleSets_Update(t *testing.T) {
 		},
 	}
 
-	req := linodego.RuleSetUpdateOptions{
+	req := linodego.FirewallRuleSetUpdateOptions{
 		Label:       &label,
 		Description: &description,
 		Rules:       rules,

--- a/test/unit/firewall_rulesets_test.go
+++ b/test/unit/firewall_rulesets_test.go
@@ -31,10 +31,9 @@ func TestFirewallRuleSets_List(t *testing.T) {
 							"ipv4": []string{"pl::vpcs:primary"},
 							"ipv6": []string{"pl::vpcs:primary"},
 						},
-						"label":       "ssh",
-						"ports":       "22",
-						"protocol":    "TCP",
-						"description": "Allow inbound SSH",
+						"label":    "ssh",
+						"ports":    "22",
+						"protocol": "TCP",
 					},
 				},
 				"version":            3,
@@ -93,7 +92,13 @@ func TestFirewallRuleSets_Get(t *testing.T) {
 		"type":        "outbound",
 		"rules": []map[string]any{
 			{
-				"ruleset": 77,
+				"action": "ACCEPT",
+				"addresses": map[string]any{
+					"ipv4": []string{"0.0.0.0/0"},
+				},
+				"label":    "egress",
+				"ports":    "443",
+				"protocol": "TCP",
 			},
 		},
 		"version":            4,
@@ -110,6 +115,7 @@ func TestFirewallRuleSets_Get(t *testing.T) {
 	assert.Equal(t, ruleSetID, rs.ID)
 	assert.Equal(t, linodego.FirewallRuleSetTypeOutbound, rs.Type)
 	assert.True(t, rs.IsServiceDefined)
+	assert.Len(t, rs.Rules, 1)
 	if assert.NotNil(t, rs.Created) {
 		assert.Equal(t, time.Date(2024, time.February, 1, 1, 1, 1, 0, time.UTC), rs.Created.UTC())
 	}
@@ -125,7 +131,7 @@ func TestFirewallRuleSets_Create(t *testing.T) {
 		Label:       "allow-vpc",
 		Description: "Allow VPC ingress",
 		Type:        linodego.FirewallRuleSetTypeInbound,
-		Rules: []linodego.FirewallRuleSetRule{
+		Rules: []linodego.FirewallRuleSetRuleCreateOptions{
 			{
 				Action: "ACCEPT",
 				Addresses: linodego.NetworkAddresses{
@@ -174,7 +180,7 @@ func TestFirewallRuleSets_Update(t *testing.T) {
 	ruleSetID := 404
 	label := "updated-egress"
 	description := "Updated description"
-	rules := []linodego.FirewallRuleSetRule{
+	rules := []linodego.FirewallRuleSetRuleUpdateOptions{
 		{
 			Action: "ACCEPT",
 			Addresses: linodego.NetworkAddresses{
@@ -241,7 +247,13 @@ func TestRuleSet_UnmarshalJSON(t *testing.T) {
 		"type": "inbound",
 		"description": "Combined rule set",
 		"rules": [
-			{"ruleset": 12}
+			{
+				"action": "ACCEPT",
+				"label": "combined-rule",
+				"ports": "443",
+				"protocol": "TCP",
+				"addresses": {"ipv4": ["0.0.0.0/0"]}
+			}
 		],
 		"version": 2,
 		"is_service_defined": false,
@@ -261,6 +273,7 @@ func TestRuleSet_UnmarshalJSON(t *testing.T) {
 	if assert.NotNil(t, rs.Deleted) {
 		assert.Equal(t, time.Date(2023, time.May, 5, 5, 5, 5, 0, time.UTC), rs.Deleted.UTC())
 	}
+	assert.Len(t, rs.Rules, 1)
 }
 
 func TestRuleSet_UnmarshalJSONServiceDefined(t *testing.T) {

--- a/test/unit/firewall_rulesets_test.go
+++ b/test/unit/firewall_rulesets_test.go
@@ -110,9 +110,6 @@ func TestFirewallRuleSets_Get(t *testing.T) {
 	assert.Equal(t, ruleSetID, rs.ID)
 	assert.Equal(t, linodego.FirewallRuleSetTypeOutbound, rs.Type)
 	assert.True(t, rs.IsServiceDefined)
-	if assert.Len(t, rs.Rules, 1) {
-		assert.Equal(t, 77, rs.Rules[0].RuleSet)
-	}
 	if assert.NotNil(t, rs.Created) {
 		assert.Equal(t, time.Date(2024, time.February, 1, 1, 1, 1, 0, time.UTC), rs.Created.UTC())
 	}
@@ -128,7 +125,7 @@ func TestFirewallRuleSets_Create(t *testing.T) {
 		Label:       "allow-vpc",
 		Description: "Allow VPC ingress",
 		Type:        linodego.FirewallRuleSetTypeInbound,
-		Rules: []linodego.FirewallRule{
+		Rules: []linodego.FirewallRuleSetRule{
 			{
 				Action: "ACCEPT",
 				Addresses: linodego.NetworkAddresses{
@@ -177,7 +174,7 @@ func TestFirewallRuleSets_Update(t *testing.T) {
 	ruleSetID := 404
 	label := "updated-egress"
 	description := "Updated description"
-	rules := []linodego.FirewallRule{
+	rules := []linodego.FirewallRuleSetRule{
 		{
 			Action: "ACCEPT",
 			Addresses: linodego.NetworkAddresses{
@@ -236,7 +233,7 @@ func TestFirewallRuleSets_Delete(t *testing.T) {
 }
 
 func TestRuleSet_UnmarshalJSON(t *testing.T) {
-	var rs linodego.RuleSet
+	var rs linodego.FirewallRuleSet
 
 	raw := []byte(`{
 		"id": 42,
@@ -264,13 +261,10 @@ func TestRuleSet_UnmarshalJSON(t *testing.T) {
 	if assert.NotNil(t, rs.Deleted) {
 		assert.Equal(t, time.Date(2023, time.May, 5, 5, 5, 5, 0, time.UTC), rs.Deleted.UTC())
 	}
-	if assert.Len(t, rs.Rules, 1) {
-		assert.Equal(t, 12, rs.Rules[0].RuleSet)
-	}
 }
 
 func TestRuleSet_UnmarshalJSONServiceDefined(t *testing.T) {
-	var rs linodego.RuleSet
+	var rs linodego.FirewallRuleSet
 
 	raw := []byte(`{
 		"id": 99,

--- a/test/unit/firewalls_test.go
+++ b/test/unit/firewalls_test.go
@@ -67,7 +67,7 @@ func TestFirewall_Create(t *testing.T) {
 
 	requestData := linodego.FirewallCreateOptions{
 		Label: "firewall123",
-		Rules: linodego.FirewallRules{
+		Rules: linodego.FirewallRulesCreateOptions{
 			InboundPolicy:  "DROP",
 			OutboundPolicy: "DROP",
 			Inbound: []linodego.FirewallRuleInbound{

--- a/test/unit/firewalls_test.go
+++ b/test/unit/firewalls_test.go
@@ -67,10 +67,10 @@ func TestFirewall_Create(t *testing.T) {
 
 	requestData := linodego.FirewallCreateOptions{
 		Label: "firewall123",
-		Rules: linodego.FirewallRuleSet{
+		Rules: linodego.FirewallRules{
 			InboundPolicy:  "DROP",
 			OutboundPolicy: "DROP",
-			Inbound: []linodego.FirewallRule{
+			Inbound: []linodego.FirewallRuleInbound{
 				{
 					Action: "ACCEPT",
 					Addresses: linodego.NetworkAddresses{
@@ -83,7 +83,7 @@ func TestFirewall_Create(t *testing.T) {
 					Protocol:    "TCP",
 				},
 			},
-			Outbound: []linodego.FirewallRule{
+			Outbound: []linodego.FirewallRuleOutbound{
 				{
 					Action: "ACCEPT",
 					Addresses: linodego.NetworkAddresses{

--- a/test/unit/instance_config_interfaces_test.go
+++ b/test/unit/instance_config_interfaces_test.go
@@ -75,7 +75,7 @@ func TestInstanceConfigInterface_Create(t *testing.T) {
 		Purpose:  linodego.InterfacePurposeVPC,
 		Primary:  true,
 		SubnetID: &subnetID,
-		IPv4: &linodego.VPCIPv4{
+		IPv4: &linodego.VPCIPv4CreateOptions{
 			NAT1To1: &nat1to1,
 		},
 		IPRanges: []string{"192.168.1.0/24"},
@@ -111,7 +111,7 @@ func TestInstanceConfigInterface_Update(t *testing.T) {
 
 	updateOptions := linodego.InstanceConfigInterfaceUpdateOptions{
 		Primary: true,
-		IPv4: &linodego.VPCIPv4{
+		IPv4: &linodego.VPCIPv4UpdateOptions{
 			NAT1To1: &nat1to1,
 		},
 		IPRanges: ipRanges,

--- a/test/unit/interface_test.go
+++ b/test/unit/interface_test.go
@@ -191,7 +191,7 @@ func TestInterface_UpdateVLAN(t *testing.T) {
 	base.MockPut("linode/instances/123/interfaces/123", fixtureData)
 
 	opts := linodego.LinodeInterfaceUpdateOptions{
-		DefaultRoute: &linodego.InterfaceDefaultRoute{
+		DefaultRoute: &linodego.InterfaceDefaultRouteUpdateOptions{
 			IPv6: linodego.Pointer(true),
 		},
 	}
@@ -221,7 +221,7 @@ func TestInterface_UpdateVPC(t *testing.T) {
 	base.MockPut("linode/instances/123/interfaces/456", fixtureData)
 
 	opts := linodego.LinodeInterfaceUpdateOptions{
-		DefaultRoute: &linodego.InterfaceDefaultRoute{
+		DefaultRoute: &linodego.InterfaceDefaultRouteUpdateOptions{
 			IPv4: linodego.Pointer(true),
 			IPv6: linodego.Pointer(true),
 		},


### PR DESCRIPTION
## 📝 Description

Created separate structs where they were previously being reused for both GET and POST/PUT endpoint methods.

Note: I was only able to find one instance of this across the repo but its possible I missed something.

## ✔️ How to Test

`make test-unit`
`make test-int`