### PR TITLE
TPT-3031: Export PaginatedResponse type in request_helpers

### DIFF
--- a/request_helpers.go
+++ b/request_helpers.go
@@ -10,9 +10,9 @@ import (
 	"reflect"
 )
 
-// paginatedResponse represents a single response from a paginated
+// PaginatedResponse represents a single response from a paginated
 // endpoint.
-type paginatedResponse[T any] struct {
+type PaginatedResponse[T any] struct {
 	Page    int `json:"page"`
 	Pages   int `json:"pages"`
 	Results int `json:"results"`
@@ -60,7 +60,7 @@ func handlePaginatedResults[T any, O any](
 
 	// Makes a request to a particular page and appends the response to the result
 	handlePage := func(page int) error {
-		var resultType paginatedResponse[T]
+		var resultType PaginatedResponse[T]
 
 		// Override the page to be applied in createListOptionsToRequestMutator(...)
 		opts.Page = page

--- a/request_helpers_test.go
+++ b/request_helpers_test.go
@@ -268,7 +268,7 @@ func mockPaginatedResponse(
 
 		return httpmock.NewJsonResponse(
 			200,
-			paginatedResponse[testResultType]{
+			PaginatedResponse[testResultType]{
 				Page:    page,
 				Pages:   int(math.Ceil(float64(len(entries)) / float64(pageSize))),
 				Results: pageSize,

--- a/test/unit/nodebalancer_types_test.go
+++ b/test/unit/nodebalancer_types_test.go
@@ -16,7 +16,7 @@ func TestNodeBalancerTypes_List(t *testing.T) {
 	base.SetUp(t)
 	defer base.TearDown(t)
 
-	// Mock the GET request for the node balancer types endpoint (mock as an array instead of paginatedResponse)
+	// Mock the GET request for the node balancer types endpoint (mock as an array instead of PaginatedResponse)
 	base.MockGet("nodebalancers/types", fixtureData)
 
 	// Call the ListNodeBalancerTypes method


### PR DESCRIPTION
## 📝 Description

Export `PaginatedResponse` because the legacy `ResourcePagedResponse` structs has been removed.

## ✔️ How to Test
```
make test-int
```