### PR TITLE
TPT-4464: Update FirewallDeviceEntity Label field to be a pointer

### DIFF
--- a/firewall_devices.go
+++ b/firewall_devices.go
@@ -59,7 +59,7 @@ func (device *FirewallDevice) UnmarshalJSON(b []byte) error {
 type FirewallDeviceEntity struct {
 	ID           int                   `json:"id"`
 	Type         FirewallDeviceType    `json:"type"`
-	Label        *string                `json:"label"`
+	Label        *string               `json:"label"`
 	URL          string                `json:"url"`
 	ParentEntity *FirewallDeviceEntity `json:"parent_entity"`
 }

--- a/firewall_devices.go
+++ b/firewall_devices.go
@@ -59,7 +59,7 @@ func (device *FirewallDevice) UnmarshalJSON(b []byte) error {
 type FirewallDeviceEntity struct {
 	ID           int                   `json:"id"`
 	Type         FirewallDeviceType    `json:"type"`
-	Label        string                `json:"label"`
+	Label        *string                `json:"label"`
 	URL          string                `json:"url"`
 	ParentEntity *FirewallDeviceEntity `json:"parent_entity"`
 }

--- a/test/integration/firewalls_devices_test.go
+++ b/test/integration/firewalls_devices_test.go
@@ -56,7 +56,7 @@ func TestFirewallDevices_List_smoke(t *testing.T) {
 		if firewallDevices[0].Entity.ID != instance.ID {
 			t.Errorf("expected device entity id %d, got %d", instance.ID, firewallDevices[0].Entity.ID)
 		}
-		if firewallDevices[0].Entity.Label == "" {
+		if firewallDevices[0].Entity.Label == nil || *firewallDevices[0].Entity.Label == "" {
 			t.Error("expected non-empty device entity label")
 		}
 		if firewallDevices[0].Entity.ParentEntity != nil {
@@ -91,7 +91,7 @@ func TestFirewallDevice_Get(t *testing.T) {
 	} else if !cmp.Equal(device, firewallDevice) {
 		t.Errorf("expected device to match create result but got diffs: %s", cmp.Diff(device, firewallDevice))
 	} else {
-		if device.Entity.Label == "" {
+		if device.Entity.Label == nil || *device.Entity.Label == "" {
 			t.Error("expected non-empty device entity label")
 		}
 		if device.Entity.ParentEntity != nil {

--- a/test/unit/firewall_devices_test.go
+++ b/test/unit/firewall_devices_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFirewallDevice_List(t *testing.T) {
@@ -37,12 +38,14 @@ func TestFirewallDevice_List(t *testing.T) {
 		switch device.Entity.Type {
 		case "linode":
 			assert.Equal(t, 123, device.Entity.ID)
-			assert.Equal(t, "my-linode", device.Entity.Label)
+			require.NotNil(t, device.Entity.Label)
+			assert.Equal(t, "my-linode", *device.Entity.Label)
 			assert.Equal(t, "/v4/linode/instances/123", device.Entity.URL)
 			assert.Nil(t, device.Entity.ParentEntity)
 		case "nodebalancer":
 			assert.Equal(t, 321, device.Entity.ID)
-			assert.Equal(t, "my-nodebalancer", device.Entity.Label)
+			require.NotNil(t, device.Entity.Label)
+			assert.Equal(t, "my-nodebalancer", *device.Entity.Label)
 			assert.Equal(t, "/v4/nodebalancers/123", device.Entity.URL)
 			assert.Nil(t, device.Entity.ParentEntity)
 		default:
@@ -73,7 +76,8 @@ func TestFirewallDevice_Get(t *testing.T) {
 	assert.NotNil(t, firewallDevice.Entity)
 
 	assert.Equal(t, 123, firewallDevice.Entity.ID)
-	assert.Equal(t, "my-linode", firewallDevice.Entity.Label)
+	require.NotNil(t, firewallDevice.Entity.Label)
+	assert.Equal(t, "my-linode", *firewallDevice.Entity.Label)
 	assert.Equal(t, linodego.FirewallDeviceType("linode"), firewallDevice.Entity.Type)
 	assert.Equal(t, "/v4/linode/instances/123", firewallDevice.Entity.URL)
 	assert.Nil(t, firewallDevice.Entity.ParentEntity)
@@ -106,7 +110,8 @@ func TestFirewallDevice_Create(t *testing.T) {
 	assert.NotNil(t, firewallDevice.Entity)
 
 	assert.Equal(t, 123, firewallDevice.Entity.ID)
-	assert.Equal(t, "my-linode", firewallDevice.Entity.Label)
+	require.NotNil(t, firewallDevice.Entity.Label)
+	assert.Equal(t, "my-linode", *firewallDevice.Entity.Label)
 	assert.Equal(t, linodego.FirewallDeviceType("linode"), firewallDevice.Entity.Type)
 	assert.Equal(t, "/v4/linode/instances/123", firewallDevice.Entity.URL)
 	assert.Nil(t, firewallDevice.Entity.ParentEntity)
@@ -163,12 +168,13 @@ func TestFirewallDevice_Get_WithParentEntity(t *testing.T) {
 	assert.NotNil(t, device)
 
 	assert.Equal(t, linodego.FirewallDeviceLinodeInterface, device.Entity.Type)
-	assert.Equal(t, device.Entity.Label, "")
+	assert.Nil(t, device.Entity.Label, nil)
 
 	if assert.NotNil(t, device.Entity.ParentEntity) {
 		assert.Equal(t, 123, device.Entity.ParentEntity.ID)
 		assert.Equal(t, linodego.FirewallDeviceLinode, device.Entity.ParentEntity.Type)
-		assert.Equal(t, "my-linode", device.Entity.ParentEntity.Label)
+		require.NotNil(t, device.Entity.ParentEntity.Label)
+		assert.Equal(t, "my-linode", *device.Entity.ParentEntity.Label)
 		assert.Equal(t, "/v4/linode/instances/123", device.Entity.ParentEntity.URL)
 	}
 }

--- a/test/unit/firewalls_test.go
+++ b/test/unit/firewalls_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/linode/linodego"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFirewall_List(t *testing.T) {
@@ -149,7 +150,8 @@ func TestFirewall_Create(t *testing.T) {
 	assert.NotNil(t, entity.ParentEntity)
 	assert.Equal(t, 92759172, entity.ParentEntity.ID)
 	assert.Equal(t, linodego.FirewallDeviceLinode, entity.ParentEntity.Type)
-	assert.Equal(t, "test-01", entity.ParentEntity.Label)
+	require.NotNil(t, entity.ParentEntity.Label)
+	assert.Equal(t, "test-01", *entity.ParentEntity.Label)
 	assert.Equal(t, "/v4/linode/instances/92759172", entity.ParentEntity.URL)
 	assert.Nil(t, entity.ParentEntity.ParentEntity)
 }


### PR DESCRIPTION
## 📝 Description

The label of a firewall device entity is now a `nullable` field because some entities, such as a Linode Interface, don't have a label. 

## ✔️ How to Test

```bash
make test-int
```


```bash
make test-unit
```
