### PR TITLE
Removed v2 from k8s module path

### DIFF
--- a/docs/linode_v2_migration_guide.md
+++ b/docs/linode_v2_migration_guide.md
@@ -16,23 +16,10 @@ to:
 import "github.com/linode/linodego/v2"
 ```
 
-If you use the helper Kubernetes package, also change:
-
-```go
-import "github.com/linode/linodego/k8s"
-```
-
-to:
-
-```go
-import "github.com/linode/linodego/v2/k8s"
-```
-
 Also update your module dependencies:
 
 ```shell
 go get github.com/linode/linodego/v2
-go get github.com/linode/linodego/v2/k8s # if you import the Kubernetes helper module
 go mod tidy
 ```
 

--- a/k8s/go.mod
+++ b/k8s/go.mod
@@ -1,4 +1,4 @@
-module github.com/linode/linodego/v2/k8s
+module github.com/linode/linodego/k8s
 
 require (
 	github.com/linode/linodego/v2 v2.0.0

--- a/k8s/pkg/condition/lke.go
+++ b/k8s/pkg/condition/lke.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/linode/linodego/k8s"
 	"github.com/linode/linodego/v2"
-	"github.com/linode/linodego/v2/k8s"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,8 +4,8 @@ require (
 	github.com/dnaeon/go-vcr v1.2.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.4.1
+	github.com/linode/linodego/k8s v0.0.0-00010101000000-000000000000
 	github.com/linode/linodego/v2 v2.0.0
-	github.com/linode/linodego/v2/k8s v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	golang.org/x/net v0.55.0
@@ -61,4 +61,4 @@ go 1.25.0
 
 replace github.com/linode/linodego/v2 => ../
 
-replace github.com/linode/linodego/v2/k8s => ../k8s
+replace github.com/linode/linodego/k8s => ../k8s

--- a/test/integration/lke_clusters_test.go
+++ b/test/integration/lke_clusters_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	k8scondition "github.com/linode/linodego/k8s/pkg/condition"
 	"github.com/linode/linodego/v2"
-	k8scondition "github.com/linode/linodego/v2/k8s/pkg/condition"
 	"github.com/stretchr/testify/require"
 )
 

--- a/test/integration/lke_node_pools_test.go
+++ b/test/integration/lke_node_pools_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	k8scondition "github.com/linode/linodego/k8s/pkg/condition"
 	"github.com/linode/linodego/v2"
-	k8scondition "github.com/linode/linodego/v2/k8s/pkg/condition"
 )
 
 var testLKENodePoolCreateOpts = linodego.LKENodePoolCreateOptions{


### PR DESCRIPTION
## 📝 Description

Updated the k8s submodule path to drop the v2.

## ✔️ How to Test

`make test-unit`
`make test-int`