### PR TITLE
TPT-4533: Check transport type before setting root certificate and log warning for unsupported transports

### DIFF
--- a/client.go
+++ b/client.go
@@ -198,7 +198,8 @@ func NewClient(hc *http.Client) (client Client, err error) {
 	}
 
 	certPath, certPathExists := os.LookupEnv(APIHostCert)
-	if certPathExists {
+
+	if certPathExists { //nolint:nestif
 		if _, ok := client.httpClient.Transport.(*http.Transport); ok {
 			if err := client.SetRootCertificate(certPath); err != nil {
 				return Client{}, err

--- a/client.go
+++ b/client.go
@@ -199,12 +199,16 @@ func NewClient(hc *http.Client) (client Client, err error) {
 
 	certPath, certPathExists := os.LookupEnv(APIHostCert)
 	if certPathExists {
-		if err := client.SetRootCertificate(certPath); err != nil {
-			return Client{}, err
-		}
+		if _, ok := client.httpClient.Transport.(*http.Transport); ok {
+			if err := client.SetRootCertificate(certPath); err != nil {
+				return Client{}, err
+			}
 
-		if envDebug {
-			log.Printf("[DEBUG] Set API root certificate to %s\n", certPath)
+			if envDebug {
+				log.Printf("[DEBUG] Set API root certificate to %s\n", certPath)
+			}
+		} else {
+			log.Println("[WARN] Custom root certificate is not supported with a custom transport")
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -595,9 +595,9 @@ func TestClient_CustomRootCAWithCustomRoundTripper(t *testing.T) {
 	}
 
 	var logBuf bytes.Buffer
+	prevWriter := log.Writer()
 	log.SetOutput(&logBuf)
-	defer log.SetOutput(os.Stderr)
-
+	defer log.SetOutput(prevWriter)
 	_, err = NewClient(&http.Client{Transport: tr})
 	require.NoError(t, err)
 	require.Contains(t, logBuf.String(), "[WARN] Custom root certificate is not supported with a custom transport")

--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -593,8 +594,13 @@ func TestClient_CustomRootCAWithCustomRoundTripper(t *testing.T) {
 		Transport: server.Client().Transport,
 	}
 
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
+
 	_, err = NewClient(&http.Client{Transport: tr})
-	require.ErrorContains(t, err, "custom transport is not allowed with a custom root CA")
+	require.NoError(t, err)
+	require.Contains(t, logBuf.String(), "[WARN] Custom root certificate is not supported with a custom transport")
 }
 
 func TestClient_CustomRootCAWithMissingFile(t *testing.T) {

--- a/test/integration/tags_test.go
+++ b/test/integration/tags_test.go
@@ -105,7 +105,8 @@ func TestTag_CreateTagWithReservedIP(t *testing.T) {
 	tagObjects, err := client.ListTaggedObjects(context.Background(), tag.Label, nil)
 	require.NoErrorf(t, err, "Failed to list tagged objects: %v", err)
 
-	if len(tagObjects) == 0 || tagObjects[0].Type != "reserved_ipv4_address" || !tagObjects[0].Data.(InstanceIP).Reserved || tagObjects[0].Data.(InstanceIP).Tags[0] != tag.Label {
+	if len(tagObjects) == 0 || tagObjects[0].Type != "reserved_ipv4_address" || !tagObjects[0].Data.(InstanceIP).Reserved ||
+		tagObjects[0].Data.(InstanceIP).Tags[0] != tag.Label {
 		t.Fatalf("Should have found Tag in tagged objects list, got %v", tagObjects)
 	}
 


### PR DESCRIPTION
`linodego` v2 returns an error from the `NewClient()` when `SetRootCertificate` failed, and setting the certificate requires the transport to be `http.Transport`, but in many cases we are using `oauth2.Transport`, such as Packer Plugin. This will cause the users with `LINODE_CA` environment variable to always see an error returned from `linodego` because `linodego` always auto detect `LINODE_CA` and attempt to set the certificate in `NewClient()`

This PR makes it check if the transport is qualify for custom certificate before automatically attempt to set it.