### PR TITLE
TPT-4490: Support for firewall rules with numeric and ALL protocols

### DIFF
--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -21,7 +21,7 @@ const (
 	ICMP    NetworkProtocol = "ICMP"
 	IPENCAP NetworkProtocol = "IPENCAP"
 
-	ProtocolALL NetworkProtocol = "ALL"
+	AllNetworkProtocols NetworkProtocol = "ALL"
 )
 
 // NetworkAddresses are arrays of ipv4 and v6 addresses

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -5,7 +5,12 @@ import (
 	"encoding/json"
 )
 
-// NetworkProtocol enum type
+// NetworkProtocol is used for firewall rule protocol fields.
+//
+// This can also represent arbitrary ports, for example `NetworkProtocol("50")`.
+//
+// NOTE: ProtocolALL and numeric protocols may not yet
+// be available to all users.
 type NetworkProtocol string
 
 // NetworkProtocol enum values
@@ -14,6 +19,8 @@ const (
 	UDP     NetworkProtocol = "UDP"
 	ICMP    NetworkProtocol = "ICMP"
 	IPENCAP NetworkProtocol = "IPENCAP"
+
+	ProtocolALL NetworkProtocol = "ALL"
 )
 
 // NetworkAddresses are arrays of ipv4 and v6 addresses

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -7,9 +7,10 @@ import (
 
 // NetworkProtocol is used for firewall rule protocol fields.
 //
-// This can also represent arbitrary ports, for example `NetworkProtocol("50")`.
+// This can also represent arbitrary protocols, for example an IP protocol number
+// like `NetworkProtocol("50")`.
 //
-// NOTE: ProtocolALL and numeric protocols may not yet
+// NOTE: ALL and numeric protocols may not yet
 // be available to all users.
 type NetworkProtocol string
 

--- a/test/integration/firewall_rules_test.go
+++ b/test/integration/firewall_rules_test.go
@@ -2,10 +2,13 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/linode/linodego/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -75,6 +78,76 @@ func TestFirewallRules_Get_smoke(t *testing.T) {
 	if !cmp.Equal(rules.Outbound, testFirewallRuleSet.Outbound, ignoreNetworkAddresses) {
 		t.Errorf("expected outbound rules to match, but got diff: %s", cmp.Diff(rules.Outbound, testFirewallRuleSet.Outbound, ignoreNetworkAddresses))
 	}
+}
+
+func TestFirewallRules_ExtendedProtocols(t *testing.T) {
+	label := fmt.Sprintf("fw-ext-%s", getUniqueText())
+
+	rules := linodego.FirewallRulesCreateOptions{
+		Inbound: []linodego.FirewallRuleInbound{
+			{
+				Label:    "linodego-fwrule-all",
+				Action:   "ACCEPT",
+				Protocol: linodego.ProtocolALL,
+				Addresses: linodego.NetworkAddresses{
+					IPv4: []string{"0.0.0.0/0"},
+				},
+			},
+			{
+				Label:    "linodego-fwrule-numeric",
+				Action:   "ACCEPT",
+				Protocol: linodego.NetworkProtocol("50"),
+				Addresses: linodego.NetworkAddresses{
+					IPv4: []string{"0.0.0.0/0"},
+				},
+			},
+			{
+				Label:    "linodego-fwrule-tcp-numeric",
+				Action:   "ACCEPT",
+				Ports:    "443",
+				Protocol: linodego.NetworkProtocol("6"),
+				Addresses: linodego.NetworkAddresses{
+					IPv4: []string{"0.0.0.0/0"},
+				},
+			},
+		},
+		InboundPolicy:  "DROP",
+		OutboundPolicy: "ACCEPT",
+	}
+
+	client, firewall, teardown, err := setupFirewall(t, []firewallModifier{
+		func(createOpts *linodego.FirewallCreateOptions) {
+			createOpts.Label = label
+			createOpts.Rules = rules
+		},
+	}, "fixtures/TestFirewall_CreateWithExtendedProtocols")
+	t.Cleanup(teardown)
+	require.NoError(t, err)
+
+	require.Len(t, firewall.Rules.Inbound, 3)
+
+	assert.Equal(t, linodego.ProtocolALL, firewall.Rules.Inbound[0].Protocol)
+	assert.Empty(t, firewall.Rules.Inbound[0].Ports)
+
+	assert.Equal(t, linodego.NetworkProtocol("50"), firewall.Rules.Inbound[1].Protocol)
+	assert.Empty(t, firewall.Rules.Inbound[1].Ports)
+
+	assert.Equal(t, linodego.NetworkProtocol("6"), firewall.Rules.Inbound[2].Protocol)
+	assert.Equal(t, "443", firewall.Rules.Inbound[2].Ports)
+
+	result, err := client.GetFirewall(context.Background(), firewall.ID)
+	require.NoErrorf(t, err, "failed to get firewall %d", firewall.ID)
+
+	require.Len(t, result.Rules.Inbound, 3)
+
+	assert.Equal(t, linodego.ProtocolALL, result.Rules.Inbound[0].Protocol)
+	assert.Empty(t, result.Rules.Inbound[0].Ports)
+
+	assert.Equal(t, linodego.NetworkProtocol("50"), result.Rules.Inbound[1].Protocol)
+	assert.Empty(t, result.Rules.Inbound[1].Ports)
+
+	assert.Equal(t, linodego.NetworkProtocol("6"), result.Rules.Inbound[2].Protocol)
+	assert.Equal(t, "443", result.Rules.Inbound[2].Ports)
 }
 
 func TestFirewallRules_Update(t *testing.T) {

--- a/test/integration/firewall_rules_test.go
+++ b/test/integration/firewall_rules_test.go
@@ -120,7 +120,7 @@ func TestFirewallRules_ExtendedProtocols(t *testing.T) {
 			createOpts.Label = label
 			createOpts.Rules = rules
 		},
-	}, "fixtures/TestFirewall_CreateWithExtendedProtocols")
+	}, "fixtures/TestFirewallRules_ExtendedProtocols")
 	t.Cleanup(teardown)
 	require.NoError(t, err)
 

--- a/test/integration/firewall_rules_test.go
+++ b/test/integration/firewall_rules_test.go
@@ -88,7 +88,7 @@ func TestFirewallRules_ExtendedProtocols(t *testing.T) {
 			{
 				Label:    "linodego-fwrule-all",
 				Action:   "ACCEPT",
-				Protocol: linodego.ProtocolALL,
+				Protocol: linodego.AllNetworkProtocols,
 				Addresses: linodego.NetworkAddresses{
 					IPv4: []string{"0.0.0.0/0"},
 				},
@@ -126,7 +126,7 @@ func TestFirewallRules_ExtendedProtocols(t *testing.T) {
 
 	require.Len(t, firewall.Rules.Inbound, 3)
 
-	assert.Equal(t, linodego.ProtocolALL, firewall.Rules.Inbound[0].Protocol)
+	assert.Equal(t, linodego.AllNetworkProtocols, firewall.Rules.Inbound[0].Protocol)
 	assert.Empty(t, firewall.Rules.Inbound[0].Ports)
 
 	assert.Equal(t, linodego.NetworkProtocol("50"), firewall.Rules.Inbound[1].Protocol)
@@ -140,7 +140,7 @@ func TestFirewallRules_ExtendedProtocols(t *testing.T) {
 
 	require.Len(t, result.Rules.Inbound, 3)
 
-	assert.Equal(t, linodego.ProtocolALL, result.Rules.Inbound[0].Protocol)
+	assert.Equal(t, linodego.AllNetworkProtocols, result.Rules.Inbound[0].Protocol)
 	assert.Empty(t, result.Rules.Inbound[0].Ports)
 
 	assert.Equal(t, linodego.NetworkProtocol("50"), result.Rules.Inbound[1].Protocol)

--- a/test/integration/fixtures/TestFirewallRules_ExtendedProtocols.yaml
+++ b/test/integration/fixtures/TestFirewallRules_ExtendedProtocols.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"label":"fw-ext-1782930907178636000","rules":{"inbound":[{"action":"ACCEPT","label":"linodego-fwrule-all","protocol":"ALL","addresses":{"ipv4":["0.0.0.0/0"]}},{"action":"ACCEPT","label":"linodego-fwrule-numeric","protocol":"50","addresses":{"ipv4":["0.0.0.0/0"]}},{"action":"ACCEPT","label":"linodego-fwrule-tcp-numeric","ports":"443","protocol":"6","addresses":{"ipv4":["0.0.0.0/0"]}}],"inbound_policy":"DROP","outbound":null,"outbound_policy":"ACCEPT"},"tags":["testing"]}'
+    body: '{"label":"fw-ext-1782999745568178000","rules":{"inbound":[{"action":"ACCEPT","label":"linodego-fwrule-all","protocol":"ALL","addresses":{"ipv4":["0.0.0.0/0"]}},{"action":"ACCEPT","label":"linodego-fwrule-numeric","protocol":"50","addresses":{"ipv4":["0.0.0.0/0"]}},{"action":"ACCEPT","label":"linodego-fwrule-tcp-numeric","ports":"443","protocol":"6","addresses":{"ipv4":["0.0.0.0/0"]}}],"inbound_policy":"DROP","outbound":null,"outbound_policy":"ACCEPT"},"tags":["testing"]}'
     form: {}
     headers:
       Accept:
@@ -14,7 +14,7 @@ interactions:
     url: https://api.linode.com/v4beta/networking/firewalls
     method: POST
   response:
-    body: '{"id": 1639903, "label": "fw-ext-1782930907178636000", "created": "2018-01-02T03:04:05",
+    body: '{"id": 1645933, "label": "fw-ext-1782999745568178000", "created": "2018-01-02T03:04:05",
       "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
       [{"protocol": "ALL", "addresses": {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT",
       "label": "linodego-fwrule-all"}, {"protocol": "50", "addresses": {"ipv4": ["0.0.0.0/0"]},
@@ -78,10 +78,10 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/1639903
+    url: https://api.linode.com/v4beta/networking/firewalls/1645933
     method: GET
   response:
-    body: '{"id": 1639903, "label": "fw-ext-1782930907178636000", "created": "2018-01-02T03:04:05",
+    body: '{"id": 1645933, "label": "fw-ext-1782999745568178000", "created": "2018-01-02T03:04:05",
       "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
       [{"protocol": "ALL", "addresses": {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT",
       "label": "linodego-fwrule-all"}, {"protocol": "50", "addresses": {"ipv4": ["0.0.0.0/0"]},
@@ -147,7 +147,7 @@ interactions:
       - application/json
       User-Agent:
       - linodego/dev https://github.com/linode/linodego
-    url: https://api.linode.com/v4beta/networking/firewalls/1639903
+    url: https://api.linode.com/v4beta/networking/firewalls/1645933
     method: DELETE
   response:
     body: '{}'

--- a/test/integration/fixtures/TestFirewall_CreateWithExtendedProtocols.yaml
+++ b/test/integration/fixtures/TestFirewall_CreateWithExtendedProtocols.yaml
@@ -1,0 +1,198 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"label":"fw-ext-1782930907178636000","rules":{"inbound":[{"action":"ACCEPT","label":"linodego-fwrule-all","protocol":"ALL","addresses":{"ipv4":["0.0.0.0/0"]}},{"action":"ACCEPT","label":"linodego-fwrule-numeric","protocol":"50","addresses":{"ipv4":["0.0.0.0/0"]}},{"action":"ACCEPT","label":"linodego-fwrule-tcp-numeric","ports":"443","protocol":"6","addresses":{"ipv4":["0.0.0.0/0"]}}],"inbound_policy":"DROP","outbound":null,"outbound_policy":"ACCEPT"},"tags":["testing"]}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls
+    method: POST
+  response:
+    body: '{"id": 1639903, "label": "fw-ext-1782930907178636000", "created": "2018-01-02T03:04:05",
+      "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
+      [{"protocol": "ALL", "addresses": {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT",
+      "label": "linodego-fwrule-all"}, {"protocol": "50", "addresses": {"ipv4": ["0.0.0.0/0"]},
+      "action": "ACCEPT", "label": "linodego-fwrule-numeric"}, {"protocol": "6", "addresses":
+      {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT", "label": "linodego-fwrule-tcp-numeric",
+      "ports": "443"}], "inbound_policy": "DROP", "outbound": null, "outbound_policy":
+      "ACCEPT", "version": 1, "fingerprint": "1e4bedfd"}, "tags": ["testing"], "entities":
+      []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "676"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - firewall:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/1639903
+    method: GET
+  response:
+    body: '{"id": 1639903, "label": "fw-ext-1782930907178636000", "created": "2018-01-02T03:04:05",
+      "updated": "2018-01-02T03:04:05", "status": "enabled", "rules": {"inbound":
+      [{"protocol": "ALL", "addresses": {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT",
+      "label": "linodego-fwrule-all"}, {"protocol": "50", "addresses": {"ipv4": ["0.0.0.0/0"]},
+      "action": "ACCEPT", "label": "linodego-fwrule-numeric"}, {"protocol": "6", "addresses":
+      {"ipv4": ["0.0.0.0/0"]}, "action": "ACCEPT", "label": "linodego-fwrule-tcp-numeric",
+      "ports": "443"}], "inbound_policy": "DROP", "outbound": null, "outbound_policy":
+      "ACCEPT", "version": 1, "fingerprint": "1e4bedfd"}, "tags": ["testing"], "entities":
+      []}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "676"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - firewall:read_only
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/firewalls/1639903
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - firewall:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "400"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/unit/firewall_rules_test.go
+++ b/test/unit/firewall_rules_test.go
@@ -85,7 +85,7 @@ func TestFirewallRule_MarshalExtendedProtocols(t *testing.T) {
 			rule: linodego.FirewallRuleInbound{
 				Action:   "ACCEPT",
 				Label:    "allow-all",
-				Protocol: linodego.ProtocolALL,
+				Protocol: linodego.AllNetworkProtocols,
 				Addresses: linodego.NetworkAddresses{
 					IPv4: []string{"0.0.0.0/0"},
 				},

--- a/test/unit/firewall_rules_test.go
+++ b/test/unit/firewall_rules_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/linode/linodego/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFirewallRule_Get(t *testing.T) {
@@ -68,6 +69,81 @@ func TestFirewallRule_MarshalJSON(t *testing.T) {
         "protocol":"TCP",
         "addresses":{"ipv4":["pl::vpcs:123"]}
     }`, string(data))
+}
+
+func TestFirewallRule_MarshalExtendedProtocols(t *testing.T) {
+	tests := []struct {
+		name        string
+		rule        any
+		label       string
+		protocol    string
+		ports       string
+		expectPorts bool
+	}{
+		{
+			name: "all without ports",
+			rule: linodego.FirewallRuleInbound{
+				Action:   "ACCEPT",
+				Label:    "allow-all",
+				Protocol: linodego.ProtocolALL,
+				Addresses: linodego.NetworkAddresses{
+					IPv4: []string{"0.0.0.0/0"},
+				},
+			},
+			label:    "allow-all",
+			protocol: "ALL",
+		},
+		{
+			name: "numeric without ports",
+			rule: linodego.FirewallRuleOutbound{
+				Action:   "ACCEPT",
+				Label:    "allow-esp",
+				Protocol: linodego.NetworkProtocol("50"),
+				Addresses: linodego.NetworkAddresses{
+					IPv4: []string{"0.0.0.0/0"},
+				},
+			},
+			label:    "allow-esp",
+			protocol: "50",
+		},
+		{
+			name: "numeric tcp with ports",
+			rule: linodego.FirewallRuleSetRuleCreateOptions{
+				Action:   "ACCEPT",
+				Label:    "allow-https",
+				Ports:    "443",
+				Protocol: linodego.NetworkProtocol("6"),
+				Addresses: linodego.NetworkAddresses{
+					IPv4: []string{"0.0.0.0/0"},
+				},
+			},
+			label:       "allow-https",
+			protocol:    "6",
+			ports:       "443",
+			expectPorts: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.rule)
+			require.NoError(t, err)
+
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(data, &payload))
+
+			assert.Equal(t, "ACCEPT", payload["action"])
+			assert.Equal(t, tt.label, payload["label"])
+			assert.Equal(t, tt.protocol, payload["protocol"])
+			assert.Equal(t, map[string]any{"ipv4": []any{"0.0.0.0/0"}}, payload["addresses"])
+
+			if tt.expectPorts {
+				assert.Equal(t, tt.ports, payload["ports"])
+			} else {
+				assert.NotContains(t, payload, "ports")
+			}
+		})
+	}
 }
 
 func TestFirewallRule_Update(t *testing.T) {


### PR DESCRIPTION
## 📝 Description

This pull request adds support for managing firewall rules with numeric and `ALL` protocols. 

## ✔️ How to Test

**NOTE: This feature is not yet generally available. See TPT-4469 for required test environment information.**

### Unit Testing

```
make test-unit
```

### Integration Testing

```
make fixtures TEST_ARGS="-run TestFirewallRules_ExtendedProtocols"
```