### PR TITLE
Fixed bug in `doRequest` causing requests to not be sent when RetryCount set to 0

### DIFF
--- a/client.go
+++ b/client.go
@@ -471,7 +471,7 @@ func (c *Client) SetRetryAfter(callback RetryAfter) *Client {
 	return c
 }
 
-// SetRetryCount sets the maximum retry attempts before aborting.
+// SetRetryCount sets the number of retries after the initial request before aborting. .
 func (c *Client) SetRetryCount(count int) *Client {
 	c.retryCount = count
 	return c
@@ -519,7 +519,8 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, params 
 		err  error
 	)
 
-	for range c.retryCount {
+	// retryCount controls the number of retries after the initial attempt
+	for range c.retryCount + 1 {
 		// createRequest seeks params.Body back to the start, so it's safe to retry.
 		req, err = c.createRequest(ctx, method, endpoint, params)
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -471,9 +471,15 @@ func (c *Client) SetRetryAfter(callback RetryAfter) *Client {
 	return c
 }
 
-// SetRetryCount sets the number of retries after the initial request before aborting. .
+// SetRetryCount sets the number of retries after the initial request before aborting.
+// Negative values are treated as 0 (no retries).
 func (c *Client) SetRetryCount(count int) *Client {
+	if count < 0 {
+		count = 0
+	}
+
 	c.retryCount = count
+
 	return c
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -858,3 +858,35 @@ func TestEnableLogSanitization(t *testing.T) {
 		t.Error("expected Authorization header to appear in request log output")
 	}
 }
+
+func TestDoRequest_RetryCountZero_StillExecutes(t *testing.T) {
+	called := false
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":1}`))
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	client := newTestClient(t, nil)
+	client.SetBaseURL(server.URL)
+	client.SetRetryCount(0)
+
+	type result struct {
+		ID int `json:"id"`
+	}
+
+	var got result
+
+	err := client.doRequest(context.Background(), http.MethodGet, "/test", requestParams{
+		Response: &got,
+	}, nil)
+	require.NoError(t, err, "doRequest should not return an error")
+	require.True(t, called, "server handler should have been called even with retryCount=0")
+	require.Equal(t, 1, got.ID, "response should have been decoded")
+}
+

--- a/client_test.go
+++ b/client_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -860,10 +861,10 @@ func TestEnableLogSanitization(t *testing.T) {
 }
 
 func TestDoRequest_RetryCountZero_StillExecutes(t *testing.T) {
-	called := false
+	var called atomic.Bool
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		called = true
+		called.Store(true)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"id":1}`))
@@ -886,7 +887,6 @@ func TestDoRequest_RetryCountZero_StillExecutes(t *testing.T) {
 		Response: &got,
 	}, nil)
 	require.NoError(t, err, "doRequest should not return an error")
-	require.True(t, called, "server handler should have been called even with retryCount=0")
+	require.True(t, called.Load(), "server handler should have been called even with retryCount=0")
 	require.Equal(t, 1, got.ID, "response should have been decoded")
 }
-


### PR DESCRIPTION
## 📝 Description

Fixed a bug that caused `doRequest` to send no requests when the RetryCount is set to 0. New behavior now mimics resty, where at least one request is always sent, with the number of retries (not total requests) dictated by SetRetryCount.

## ✔️ How to Test
`make tet-unit`
`make test-int`
