### PR TITLE
TPT-4582: clarify requirements for json:",omitzero" fields in options structs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
 
 ## Conventions And Gotchas
 - Optional fields in create or update options structs must use `json:",omitzero"`.
-- Optional fields in create or update options structs must be pointer types so explicit zero values can be serialized when needed.
+- Every field with a `json:",omitzero"` tag MUST be a nil-able type (pointers, slices, maps, interfaces, etc.) so omitted vs explicit zero values can be distinguished and serialized correctly when needed. Non-nil-able types (plain `string`, `int`, `bool`, structs, etc.) must not use `omitzero`.
 - List APIs mutate the supplied `*ListOptions` with `Page`, `Pages`, and `Results`; do not reuse one `ListOptions` across list calls.
 - Use `formatAPIPath` for endpoint paths with user-provided string path segments so path escaping matches the client helpers.
 - CI enforces PR titles like `TPT-1234: Description` unless labels exempt the PR (`dependencies`, `hotfix`, `community-contribution`, `ignore-for-release`).


### PR DESCRIPTION
## 📝 Description

Update AGENTS.md to clarify requiring of nil-able type for fields with `omitzero` tag.