### PR TITLE
TPT-4616: Honor cancelled retries and use go work for vet/build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,10 @@ test-smoke:
 	cd test && make test-smoke TEST_TIMEOUT=$(TEST_TIMEOUT)
 
 build: vet lint
-	go build ./...
-	cd k8s && go build ./...
+	go build work
 
 vet:
-	go vet ./...
-	cd k8s && go vet ./...
+	go vet work
 
 lint:
 ifeq ($(SKIP_LINT), 1)

--- a/client.go
+++ b/client.go
@@ -622,8 +622,11 @@ func (c *Client) doRequest(ctx context.Context, method, endpoint string, params 
 			waitTime = c.retryMaxWaitTime
 		}
 
-		// Sleep for the calculated duration before retrying
-		time.Sleep(waitTime)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitTime):
+		}
 	}
 
 	return err

--- a/test/unit/vpc_subnets_test.go
+++ b/test/unit/vpc_subnets_test.go
@@ -23,7 +23,7 @@ func TestVPCSubnet_Create(t *testing.T) {
 		IPv4:  "192.168.1.0/24",
 		IPv6: []linodego.VPCSubnetCreateOptionsIPv6{
 			{
-				linodego.Pointer("auto"),
+				Range: linodego.Pointer("auto"),
 			},
 		},
 	}


### PR DESCRIPTION
## 📝 Description

- Switch `make vet`/`make build` to Go 1.25 `go vet work` / `go build work` so the 3-module workspace is checked in one command. `tidy` stays per-module.
- Honor request cancellation during `doRequest` retry waits, and key the IPv6 create-option field that `go vet work` flagged.

## ✔️ How to Test

```
go vet work
go build work
make TEST_ARGS="-run TestDoRequest" test-unit
```