### PR TITLE
TPT-4657: Add support for Backend Connectivity and more types in NodeBalancers

### DIFF
--- a/nodebalancer.go
+++ b/nodebalancer.go
@@ -34,6 +34,9 @@ type NodeBalancer struct {
 	// This NodeBalancer's plan Type
 	Type NodeBalancerPlanType `json:"type"`
 
+	// NOTE: BackendConnectivity may not currently be available to all users and can only be used with v4beta.
+	BackendConnectivity *NodeBalancerBackendConnectivity `json:"backend_connectivity"`
+
 	// An array of tags applied to this object. Tags are for organizational purposes only.
 	Tags []string `json:"tags"`
 
@@ -81,6 +84,9 @@ type NodeBalancerCreateOptions struct {
 	Type       NodeBalancerPlanType              `json:"type,omitzero"`
 	VPCs       []NodeBalancerVPCOptions          `json:"vpcs,omitzero"`
 	IPv4       *string                           `json:"ipv4,omitzero"`
+
+	// NOTE: BackendConnectivity may not currently be available to all users and can only be used with v4beta.
+	BackendConnectivity *NodeBalancerBackendConnectivity `json:"backend_connectivity,omitzero"`
 }
 
 // NodeBalancerUpdateOptions are the options permitted for UpdateNodeBalancer
@@ -110,9 +116,42 @@ type NodeBalancerPlanType string
 
 // NodeBalancerPlanType constants reflect the plan type used by a NodeBalancer Config
 const (
-	NBTypePremium     NodeBalancerPlanType = "premium"
+	// NBTypePremium supports higher connection and backend limits with guaranteed 10Gbps.
+	NBTypePremium NodeBalancerPlanType = "premium"
+
+	// NBTypeBasic is the default plan. Clients do not have to specify this value.
+	NBTypeBasic NodeBalancerPlanType = "basic"
+
+	// NBTypeEnterprise supports up to 40Gbps bandwidth.
+	NBTypeEnterprise NodeBalancerPlanType = "enterprise"
+
+	// NBTypeCommon is the default plan. Clients do not have to specify this value.
+	//
+	// Deprecated: NBTypeCommon will be replaced by NBTypeBasic.
+	NBTypeCommon NodeBalancerPlanType = "common"
+
+	// NBTypePremium40GB is the Enterprise offering with up to 40Gbps bandwidth.
+	//
+	// Deprecated: NBTypePremium40GB will be replaced by NBTypeEnterprise.
 	NBTypePremium40GB NodeBalancerPlanType = "premium_40gb"
-	NBTypeCommon      NodeBalancerPlanType = "common"
+)
+
+// NodeBalancerBackendConnectivity is the backend communication mode for a NodeBalancer.
+// NOTE: BackendConnectivity may not currently be available to all users and can only be used with v4beta.
+type NodeBalancerBackendConnectivity string
+
+const (
+	// NBBackendConnectivityLegacy communicates with backends over private IPv4.
+	NBBackendConnectivityLegacy NodeBalancerBackendConnectivity = "legacy"
+	// NBBackendConnectivityIPv6AndVPC is an unpublished value that will be deprecated.
+	NBBackendConnectivityIPv6AndVPC NodeBalancerBackendConnectivity = "ipv6_and_vpc"
+	// NBBackendConnectivityIPv6 communicates with backends using the NodeBalancer frontend IPv6.
+	NBBackendConnectivityIPv6 NodeBalancerBackendConnectivity = "ipv6"
+	// NBBackendConnectivityVPC communicates with backends using a VPC.
+	NBBackendConnectivityVPC NodeBalancerBackendConnectivity = "vpc"
+	// NBBackendConnectivityUndefined is assigned by the API when backend_connectivity, nodes, and vpcs are omitted.
+	// It cannot be specified in the Create NodeBalancer API.
+	NBBackendConnectivityUndefined NodeBalancerBackendConnectivity = "undefined"
 )
 
 // UnmarshalJSON implements the json.Unmarshaler interface
@@ -140,7 +179,7 @@ func (i *NodeBalancer) UnmarshalJSON(b []byte) error {
 
 // GetCreateOptions converts a NodeBalancer to NodeBalancerCreateOptions for use in CreateNodeBalancer
 func (i NodeBalancer) GetCreateOptions() NodeBalancerCreateOptions {
-	return NodeBalancerCreateOptions{
+	opts := NodeBalancerCreateOptions{
 		Label:                 i.Label,
 		Region:                i.Region,
 		ClientConnThrottle:    &i.ClientConnThrottle,
@@ -148,6 +187,12 @@ func (i NodeBalancer) GetCreateOptions() NodeBalancerCreateOptions {
 		Type:                  i.Type,
 		Tags:                  i.Tags,
 	}
+
+	if i.BackendConnectivity != nil && *i.BackendConnectivity != NBBackendConnectivityUndefined {
+		opts.BackendConnectivity = i.BackendConnectivity
+	}
+
+	return opts
 }
 
 // GetUpdateOptions converts a NodeBalancer to NodeBalancerUpdateOptions for use in UpdateNodeBalancer

--- a/test/integration/fixtures/TestNodeBalancer_Create_BackendConnectivity_Premium.yaml
+++ b/test/integration/fixtures/TestNodeBalancer_Create_BackendConnectivity_Premium.yaml
@@ -1,0 +1,656 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/(devel) https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/regions?page=1
+    method: GET
+  response:
+    body: '{"data": [{"id": "de-fra-2", "label": "Frankfurt 2, DE", "country": "de",
+      "capabilities": ["Linodes", "Block Storage Encryption", "LA Disk Encryption",
+      "Disk Encryption", "Backups", "Premium NodeBalancers", "NodeBalancers", "Block
+      Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Kubernetes Enterprise",
+      "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack", "Managed Databases", "Metadata",
+      "Premium Plans", "Placement Group", "StackScripts", "NETINT Quadra T1U", "Maintenance
+      Policy", "Linode Interfaces", "ACLP Logs Datacenter LKE-E"], "monitors": {"alerts":
+      ["Managed Databases", "NodeBalancers", "Object Storage"], "metrics": ["Managed
+      Databases", "NodeBalancers", "Object Storage"]}, "status": "ok", "resolvers":
+      {"ipv4": "172.236.203.9,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "nz-akl-1",
+      "label": "Auckland, NZ", "country": "nz", "capabilities": ["Linodes", "Disk
+      Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans", "Maintenance
+      Policy"], "monitors": {"alerts": [], "metrics": []}, "status": "ok", "resolvers":
+      {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "us-den-1", "label": "Denver, CO", "country": "us", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans",
+      "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "de-ham-1", "label": "Hamburg, DE", "country": "de", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans",
+      "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "za-jnb-1", "label": "Johannesburg, ZA", "country": "za", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans",
+      "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "my-kul-1", "label": "Kuala Lumpur, MY", "country": "my", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans",
+      "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "mx-qro-1", "label": "Quer\u00e9taro, MX", "country": "mx", "capabilities":
+      ["Linodes", "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed
+      Plans", "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "us-hou-1", "label": "Houston, TX", "country": "us", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans",
+      "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "cl-scl-1", "label": "Santiago, CL", "country": "cl", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans",
+      "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "gb-lon", "label": "London 2, UK", "country": "gb", "capabilities": ["Linodes",
+      "Block Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups",
+      "Premium NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage",
+      "GPU Linodes", "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans",
+      "VPCs", "VPC Dual Stack", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "NETINT Quadra T1U", "Maintenance Policy",
+      "Linode Interfaces", "ACLP Logs Datacenter LKE-E"], "monitors": {"alerts": ["Managed
+      Databases", "NodeBalancers", "Object Storage"], "metrics": ["Managed Databases",
+      "NodeBalancers", "Object Storage"]}, "status": "ok", "resolvers": {"ipv4": "172.236.0.46,172.236.0.50,172.236.0.47,172.236.0.53,172.236.0.52,172.236.0.45,172.236.0.49,172.236.0.51,172.236.0.54,172.236.0.48",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "au-mel",
+      "label": "Melbourne, AU", "country": "au", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "Kubernetes", "Cloud Firewall", "Vlans",
+      "VPCs", "VPC Dual Stack", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Maintenance Policy", "Linode Interfaces"],
+      "monitors": {"alerts": ["Managed Databases", "NodeBalancers", "Object Storage"],
+      "metrics": ["Managed Databases", "NodeBalancers", "Object Storage"]}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "in-bom-2",
+      "label": "Mumbai 2, IN", "country": "in", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes",
+      "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack",
+      "Managed Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
+      "Maintenance Policy", "Linode Interfaces", "ACLP Logs Datacenter LKE-E"], "monitors":
+      {"alerts": ["Managed Databases", "NodeBalancers", "Object Storage"], "metrics":
+      ["Managed Databases", "NodeBalancers", "Object Storage"]}, "status": "ok", "resolvers":
+      {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-lax",
+      "label": "Los Angeles, CA", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "NETINT Quadra T1U", "Maintenance Policy", "Linode Interfaces",
+      "ACLP Logs Datacenter LKE-E"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers", "Object Storage"], "metrics": ["Managed Databases", "NodeBalancers",
+      "Object Storage"]}, "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "sg-sin-2",
+      "label": "Singapore 2, SG", "country": "sg", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces", "ACLP Logs Datacenter
+      LKE-E"], "monitors": {"alerts": ["Managed Databases", "NodeBalancers", "Object
+      Storage"], "metrics": ["Managed Databases", "NodeBalancers", "Object Storage"]},
+      "status": "ok", "resolvers": {"ipv4": "172.236.129.8,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "jp-tyo-3",
+      "label": "Tokyo 3, JP", "country": "jp", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces", "ACLP Logs Datacenter
+      LKE-E"], "monitors": {"alerts": ["Managed Databases", "NodeBalancers", "Object
+      Storage"], "metrics": ["Managed Databases", "NodeBalancers", "Object Storage"]},
+      "status": "ok", "resolvers": {"ipv4": "172.237.4.15,172.237.4.19,172.237.4.17,172.237.4.21,172.237.4.16,172.237.4.18,172.237.4.23,172.237.4.24,172.237.4.20,172.237.4.14",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "de-ber-1",
+      "label": "Berlin, DE", "country": "de", "capabilities": ["Linodes", "Disk Encryption",
+      "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans", "Maintenance Policy"],
+      "monitors": {"alerts": [], "metrics": []}, "status": "ok", "resolvers": {"ipv4":
+      "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "no-osl-1", "label": "Oslo, NO", "country": "no", "capabilities": ["Linodes",
+      "Block Storage Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "Custom VPC IPv4 Ranges", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces", "ACLP Logs Datacenter
+      LKE-E"], "monitors": {"alerts": ["Managed Databases", "NodeBalancers", "Object
+      Storage"], "metrics": ["Managed Databases", "NodeBalancers", "Object Storage"]},
+      "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-iad-2",
+      "label": "Washington 2, DC", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack", "Managed Databases",
+      "Metadata", "Premium Plans", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers", "Object Storage"], "metrics": ["Managed Databases", "NodeBalancers",
+      "Object Storage"]}, "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "fr-par-2",
+      "label": "Paris 2, FR", "country": "fr", "capabilities": ["Linodes", "Block
+      Storage Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "GPU Linodes", "Kubernetes", "Kubernetes Enterprise",
+      "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack", "Managed Databases", "Metadata",
+      "Premium Plans", "Placement Group", "StackScripts", "Maintenance Policy", "Linode
+      Interfaces", "ACLP Logs Datacenter LKE-E"], "monitors": {"alerts": ["Managed
+      Databases", "NodeBalancers", "Object Storage"], "metrics": ["Managed Databases",
+      "NodeBalancers", "Object Storage"]}, "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "au-syd-2",
+      "label": "Sydney 2, AU", "country": "au", "capabilities": ["Linodes", "Disk
+      Encryption", "Backups", "Premium NodeBalancers", "NodeBalancers", "Cloud Firewall",
+      "Vlans", "VPCs", "VPC Dual Stack", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts":
+      ["NodeBalancers"], "metrics": ["NodeBalancers"]}, "status": "ok", "resolvers":
+      {"ipv4": "", "ipv6": ""}, "placement_group_limits": {"maximum_pgs_per_customer":
+      null, "maximum_linodes_per_pg": 5, "maximum_linodes_per_flexible_pg": 250},
+      "site_type": "core"}, {"id": "us-rno-1", "label": "Reno, NV", "country": "us",
+      "capabilities": ["Linodes", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Kubernetes", "Cloud Firewall", "Vlans", "VPCs", "Custom VPC
+      IPv4 Ranges", "VPC Dual Stack", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts":
+      ["NodeBalancers"], "metrics": ["NodeBalancers"]}, "status": "ok", "resolvers":
+      {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "co-bog-2",
+      "label": "Bogot\u00e1 2, CO", "country": "co", "capabilities": ["Linodes", "Disk
+      Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans", "Maintenance
+      Policy"], "monitors": {"alerts": [], "metrics": []}, "status": "ok", "resolvers":
+      {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "fr-mrs-2", "label": "Marseille 2, FR", "country": "fr", "capabilities": ["Linodes",
+      "Disk Encryption", "Cloud Firewall", "Vlans", "Metadata", "Distributed Plans",
+      "Maintenance Policy"], "monitors": {"alerts": [], "metrics": []}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "mx-qro-2", "label": "Quer\u00e9taro, MX", "country": "mx", "capabilities":
+      ["Linodes", "Disk Encryption", "Metadata", "Distributed Plans", "Maintenance
+      Policy"], "monitors": {"alerts": [], "metrics": []}, "status": "ok", "resolvers":
+      {"ipv4": "192.0.2.0,192.0.2.0", "ipv6": "1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": 0, "maximum_linodes_per_pg":
+      0, "maximum_linodes_per_flexible_pg": 0}, "site_type": "distributed"}, {"id":
+      "id-cgk", "label": "Jakarta, ID", "country": "id", "capabilities": ["Linodes",
+      "Block Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups",
+      "Premium NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage",
+      "GPU Linodes", "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans",
+      "VPCs", "VPC Dual Stack", "Managed Databases", "Metadata", "Premium Plans",
+      "Placement Group", "StackScripts", "Maintenance Policy", "Linode Interfaces"],
+      "monitors": {"alerts": ["Managed Databases", "NodeBalancers"], "metrics": ["Managed
+      Databases", "NodeBalancers"]}, "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "ap-west",
+      "label": "Mumbai, IN", "country": "in", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases", "Metadata", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]}, "status":
+      "ok", "resolvers": {"ipv4": "172.105.34.5,172.105.35.5,172.105.36.5,172.105.37.5,172.105.38.5,172.105.39.5,172.105.40.5,172.105.41.5,172.105.42.5,172.105.43.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "ca-central",
+      "label": "Toronto, CA", "country": "ca", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall", "Vlans", "Block
+      Storage Migrations", "Managed Databases", "Metadata", "Placement Group", "StackScripts",
+      "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed
+      Databases", "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]},
+      "status": "ok", "resolvers": {"ipv4": "172.105.0.5,172.105.3.5,172.105.4.5,172.105.5.5,172.105.6.5,172.105.7.5,172.105.8.5,172.105.9.5,172.105.10.5,172.105.11.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "ap-southeast",
+      "label": "Sydney, AU", "country": "au", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases", "Metadata", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]}, "status":
+      "ok", "resolvers": {"ipv4": "172.105.166.5,172.105.169.5,172.105.168.5,172.105.172.5,172.105.162.5,172.105.170.5,172.105.167.5,172.105.171.5,172.105.181.5,172.105.161.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-iad",
+      "label": "Washington, DC", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack",
+      "Managed Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
+      "Maintenance Policy", "Linode Interfaces", "ACLP Logs Datacenter LKE-E"], "monitors":
+      {"alerts": ["Managed Databases", "NodeBalancers", "Object Storage"], "metrics":
+      ["Managed Databases", "NodeBalancers", "Object Storage"]}, "status": "ok", "resolvers":
+      {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-ord",
+      "label": "Chicago, IL", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces", "ACLP Logs Datacenter
+      LKE-E"], "monitors": {"alerts": ["Linodes", "Managed Databases", "NodeBalancers",
+      "Object Storage"], "metrics": ["Linodes", "Managed Databases", "NodeBalancers",
+      "Object Storage"]}, "status": "ok", "resolvers": {"ipv4": "172.232.0.17,172.232.0.16,172.232.0.21,172.232.0.13,172.232.0.22,172.232.0.9,172.232.0.19,172.232.0.20,172.232.0.15,172.232.0.18",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "fr-par",
+      "label": "Paris, FR", "country": "fr", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
+      "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack",
+      "Managed Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
+      "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed
+      Databases", "NodeBalancers", "Object Storage"], "metrics": ["Managed Databases",
+      "NodeBalancers", "Object Storage"]}, "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-sea",
+      "label": "Seattle, WA", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces", "ACLP Logs Datacenter
+      LKE-E"], "monitors": {"alerts": ["Managed Databases", "NodeBalancers", "Object
+      Storage"], "metrics": ["Managed Databases", "NodeBalancers", "Object Storage"]},
+      "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,172.232.160.8,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "br-gru",
+      "label": "Sao Paulo, BR", "country": "br", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes",
+      "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack",
+      "Managed Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
+      "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed
+      Databases", "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]},
+      "status": "ok", "resolvers": {"ipv4": "172.233.0.4,172.233.0.9,172.233.0.7,172.233.0.12,172.233.0.5,172.233.0.13,172.233.0.10,172.233.0.6,172.233.0.8,172.233.0.11",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "nl-ams",
+      "label": "Amsterdam, NL", "country": "nl", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts":
+      ["Managed Databases", "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]},
+      "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "se-sto",
+      "label": "Stockholm, SE", "country": "se", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts":
+      ["Managed Databases", "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]},
+      "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "es-mad",
+      "label": "Madrid, ES", "country": "es", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack", "Managed Databases",
+      "Metadata", "Premium Plans", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]}, "status":
+      "ok", "resolvers": {"ipv4": "172.233.111.6,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,172.233.111.9",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "in-maa",
+      "label": "Chennai, IN", "country": "in", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium
+      NodeBalancers", "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes",
+      "Kubernetes", "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC
+      Dual Stack", "Managed Databases", "Metadata", "Premium Plans", "Placement Group",
+      "StackScripts", "NETINT Quadra T1U", "Maintenance Policy", "Linode Interfaces"],
+      "monitors": {"alerts": ["Managed Databases", "NodeBalancers"], "metrics": ["Managed
+      Databases", "NodeBalancers"]}, "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "jp-osa",
+      "label": "Osaka, JP", "country": "jp", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
+      "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack",
+      "Managed Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
+      "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed
+      Databases", "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]},
+      "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "it-mil",
+      "label": "Milan, IT", "country": "it", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "Object Storage", "Kubernetes", "Kubernetes
+      Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack", "Managed Databases",
+      "Metadata", "Premium Plans", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]}, "status":
+      "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-mia",
+      "label": "Miami, FL", "country": "us", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "Premium NodeBalancers",
+      "NodeBalancers", "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes",
+      "Kubernetes Enterprise", "Cloud Firewall", "Vlans", "VPCs", "VPC Dual Stack",
+      "Managed Databases", "Metadata", "Premium Plans", "Placement Group", "StackScripts",
+      "NETINT Quadra T1U", "Maintenance Policy", "Linode Interfaces"], "monitors":
+      {"alerts": ["Managed Databases", "NodeBalancers"], "metrics": ["Managed Databases",
+      "NodeBalancers"]}, "status": "ok", "resolvers": {"ipv4": "192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0,192.0.2.0",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-central",
+      "label": "Dallas, TX", "country": "us", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases", "Metadata", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]}, "status":
+      "ok", "resolvers": {"ipv4": "72.14.179.5,72.14.188.5,173.255.199.5,66.228.53.5,96.126.122.5,96.126.124.5,96.126.127.5,198.58.107.5,198.58.111.5,23.239.24.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "ap-northeast",
+      "label": "Tokyo 2, JP", "country": "jp", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases", "Metadata", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]}, "status":
+      "ok", "resolvers": {"ipv4": "139.162.66.5,139.162.67.5,139.162.68.5,139.162.69.5,139.162.70.5,139.162.71.5,139.162.72.5,139.162.73.5,139.162.74.5,139.162.75.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "eu-central",
+      "label": "Frankfurt, DE", "country": "de", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases", "Metadata", "Placement
+      Group", "StackScripts", "Maintenance Policy", "Linode Interfaces"], "monitors":
+      {"alerts": ["Managed Databases", "NodeBalancers"], "metrics": ["Managed Databases",
+      "NodeBalancers"]}, "status": "ok", "resolvers": {"ipv4": "139.162.130.5,139.162.131.5,139.162.132.5,139.162.133.5,139.162.134.5,139.162.135.5,139.162.136.5,139.162.137.5,139.162.138.5,139.162.139.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "ap-south",
+      "label": "Singapore, SG", "country": "sg", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Metadata", "Placement Group", "StackScripts",
+      "Maintenance Policy", "Linode Interfaces"], "monitors": {"alerts": ["NodeBalancers"],
+      "metrics": ["NodeBalancers"]}, "status": "ok", "resolvers": {"ipv4": "139.162.11.5,139.162.13.5,139.162.14.5,139.162.15.5,139.162.16.5,139.162.21.5,139.162.27.5,103.3.60.18,103.3.60.19,103.3.60.20",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "eu-west",
+      "label": "London, UK", "country": "gb", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Metadata", "Placement Group", "StackScripts", "Maintenance Policy", "Linode
+      Interfaces"], "monitors": {"alerts": ["NodeBalancers"], "metrics": ["NodeBalancers"]},
+      "status": "ok", "resolvers": {"ipv4": "178.79.182.5, 176.58.107.5, 176.58.116.5,
+      176.58.121.5, 151.236.220.5, 212.71.252.5, 212.71.253.5, 192.0.2.0, 192.0.2.0,
+      192.0.2.0", "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-east",
+      "label": "Newark, NJ", "country": "us", "capabilities": ["Linodes", "Block Storage
+      Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases", "Metadata", "Placement
+      Group", "StackScripts", "Maintenance Policy", "Linode Interfaces"], "monitors":
+      {"alerts": ["Managed Databases", "NodeBalancers"], "metrics": ["Managed Databases",
+      "NodeBalancers"]}, "status": "ok", "resolvers": {"ipv4": "66.228.42.5,96.126.106.5,50.116.53.5,50.116.58.5,50.116.61.5,50.116.62.5,66.175.211.5,97.107.133.4,173.255.225.5,66.228.35.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-southeast",
+      "label": "Atlanta, GA", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Object Storage", "GPU Linodes", "Kubernetes", "Cloud Firewall",
+      "Vlans", "Block Storage Migrations", "Managed Databases", "Metadata", "Placement
+      Group", "StackScripts", "Maintenance Policy", "Linode Interfaces"], "monitors":
+      {"alerts": ["Managed Databases", "NodeBalancers"], "metrics": ["Managed Databases",
+      "NodeBalancers"]}, "status": "ok", "resolvers": {"ipv4": "74.207.231.5,173.230.128.5,173.230.129.5,173.230.136.5,173.230.140.5,66.228.59.5,66.228.62.5,50.116.35.5,50.116.41.5,23.239.18.5",
+      "ipv6": "1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678,1234::5678"},
+      "placement_group_limits": {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg":
+      5, "maximum_linodes_per_flexible_pg": 250}, "site_type": "core"}, {"id": "us-west",
+      "label": "Fremont, CA", "country": "us", "capabilities": ["Linodes", "Block
+      Storage Encryption", "LA Disk Encryption", "Disk Encryption", "Backups", "NodeBalancers",
+      "Block Storage", "Kubernetes", "Cloud Firewall", "Vlans", "Block Storage Migrations",
+      "Managed Databases", "Metadata", "Placement Group", "StackScripts", "Maintenance
+      Policy", "Linode Interfaces"], "monitors": {"alerts": ["Managed Databases",
+      "NodeBalancers"], "metrics": ["Managed Databases", "NodeBalancers"]}, "status":
+      "ok", "resolvers": {"ipv4": "173.230.145.5, 173.230.147.5, 173.230.155.5, 173.255.212.5,
+      173.255.219.5, 173.255.241.5, 173.255.243.5, 173.255.244.5, 74.207.241.5, 74.207.242.5",
+      "ipv6": "1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678,
+      1234::5678, 1234::5678, 1234::5678, 1234::5678, 1234::5678"}, "placement_group_limits":
+      {"maximum_pgs_per_customer": null, "maximum_linodes_per_pg": 5, "maximum_linodes_per_flexible_pg":
+      250}, "site_type": "core"}], "page": 1, "pages": 1, "results": 48}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Fri, 28 Aug 2026 19:07:55 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      - Authorization, X-Filter
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - '*'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "1840"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"label":"go-test-def","region":"de-fra-2","client_conn_throttle":20,"tags":null,"firewall_id":145330218,"type":"premium","backend_connectivity":"ipv6"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/(devel) https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/nodebalancers
+    method: POST
+  response:
+    body: '{"id": 2442626, "label": "go-test-def", "region": "de-fra-2", "type": "premium",
+      "backend_connectivity": "ipv6", "hostname":"thisIsYourHostName",
+      "ipv4": "192.0.2.0", "ipv6": "1234::5678", "frontend_address_type":
+      "public", "frontend_vpc_subnet_id": null, "created": "2018-01-02T03:04:05",
+      "updated": "2018-01-02T03:04:05", "client_conn_throttle": 20, "client_udp_sess_throttle":
+      0, "lke_cluster": null, "tags": [], "locks": [], "transfer": {"in": null, "out":
+      null, "total": null}}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "521"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Fri, 28 Aug 2026 19:07:56 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - nodebalancers:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "1840"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/(devel) https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/nodebalancers/2442626
+    method: DELETE
+  response:
+    body: '{}'
+    headers:
+      Access-Control-Allow-Credentials:
+      - "true"
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "2"
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json
+      Expires:
+      - Fri, 28 Aug 2026 19:07:56 GMT
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - nodebalancers:read_write
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+      X-Ratelimit-Limit:
+      - "1840"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/test/integration/nodebalancers_test.go
+++ b/test/integration/nodebalancers_test.go
@@ -58,6 +58,22 @@ func TestNodeBalancer_Create_Type(t *testing.T) {
 	assertDateSet(t, nodebalancer.Updated)
 }
 
+func TestNodeBalancer_Create_BackendConnectivity_Premium(t *testing.T) {
+	_, nodebalancer, teardown, err := setupNodeBalancer(
+		t,
+		"fixtures/TestNodeBalancer_Create_BackendConnectivity_Premium",
+		[]nbModifier{func(createOpts *linodego.NodeBalancerCreateOptions) {
+			createOpts.BackendConnectivity = linodego.Pointer(linodego.NBBackendConnectivityIPv6)
+			createOpts.Type = linodego.NBTypePremium
+		}},
+	)
+	t.Cleanup(teardown)
+
+	require.NoError(t, err)
+	require.NotNil(t, nodebalancer.BackendConnectivity)
+	require.Equal(t, linodego.NBBackendConnectivityIPv6, *nodebalancer.BackendConnectivity)
+}
+
 func TestNodeBalancer_Create_with_ReservedIP(t *testing.T) {
 	_, reserveIP, nodebalancer, teardown, err := setupNodeBalancerWithReservedIP(t, "fixtures/TestNodeBalancer_With_ReservedIP_Create")
 	defer teardown()

--- a/test/unit/fixtures/nodebalancer_create.json
+++ b/test/unit/fixtures/nodebalancer_create.json
@@ -11,6 +11,8 @@
       "in": 500.3,
       "out": 500.2
     },
+    "type": "common",
+    "backend_connectivity": "undefined",
     "tags": ["test", "example"],
     "locks": [],
     "created": "2025-02-01T10:00:00",

--- a/test/unit/fixtures/nodebalancer_create_with_backend_connectivity.json
+++ b/test/unit/fixtures/nodebalancer_create_with_backend_connectivity.json
@@ -1,0 +1,20 @@
+{
+    "id": 125,
+    "label": "Test Premium NodeBalancer",
+    "region": "us-east",
+    "hostname": "test-premium.nodebalancer.linode.com",
+    "ipv4": "192.0.2.3",
+    "ipv6": "2600:3c03::f03c:91ff:fe24:9dd0",
+    "client_conn_throttle": 10,
+    "transfer": {
+      "total": 0,
+      "in": 0,
+      "out": 0
+    },
+    "type": "premium",
+    "backend_connectivity": "ipv6",
+    "tags": ["test", "example"],
+    "locks": [],
+    "created": "2025-02-01T10:00:00",
+    "updated": "2025-02-06T10:00:00"
+}

--- a/test/unit/fixtures/nodebalancer_create_with_ipv4.json
+++ b/test/unit/fixtures/nodebalancer_create_with_ipv4.json
@@ -11,6 +11,8 @@
         "out": 0,
         "in": 0
     },
+    "type": "common",
+    "backend_connectivity": "undefined",
     "tags": ["test", "example"],
     "locks": [],
     "created": "2023-01-01T00:00:00",

--- a/test/unit/fixtures/nodebalancer_get.json
+++ b/test/unit/fixtures/nodebalancer_get.json
@@ -11,6 +11,8 @@
       "in": 1000.0,
       "out": 1000.0
     },
+    "type": "common",
+    "backend_connectivity": "undefined",
     "lke_cluster": null,
     "tags": ["production"],
     "locks": ["cannot_delete_with_subresources"],

--- a/test/unit/fixtures/nodebalancer_get_with_lke_cluster.json
+++ b/test/unit/fixtures/nodebalancer_get_with_lke_cluster.json
@@ -12,6 +12,7 @@
       "out": 1000.0
     },
     "type": "common",
+    "backend_connectivity": "undefined",
     "lke_cluster": {
         "id": 1234,
         "type": "lkecluster",

--- a/test/unit/fixtures/nodebalancer_node_create_ipv6.json
+++ b/test/unit/fixtures/nodebalancer_node_create_ipv6.json
@@ -1,0 +1,10 @@
+{
+    "id": 790,
+    "address": "[2001:db8:abcd:12::1]:80",
+    "label": "IPv6 Node",
+    "status": "UP",
+    "weight": 50,
+    "mode": "accept",
+    "config_id": 456,
+    "nodebalancer_id": 123
+}

--- a/test/unit/fixtures/nodebalancer_update.json
+++ b/test/unit/fixtures/nodebalancer_update.json
@@ -11,6 +11,8 @@
       "in": 750.0,
       "out": 750.0
     },
+    "type": "common",
+    "backend_connectivity": "legacy",
     "tags": ["updated", "production"],
     "locks": ["cannot_delete_with_subresources"],
     "created": "2025-01-15T08:00:00",

--- a/test/unit/fixtures/nodebalancers_list.json
+++ b/test/unit/fixtures/nodebalancers_list.json
@@ -4,6 +4,8 @@
             "id": 123,
             "label": "NodeBalancer A",
             "region": "us-east",
+            "type": "common",
+            "backend_connectivity": "undefined",
             "tags": ["tag1", "tag2"],
             "locks": ["cannot_delete"],
             "lke_cluster": null
@@ -12,6 +14,8 @@
             "id": 456,
             "label": "NodeBalancer B",
             "region": "us-west",
+            "type": "premium",
+            "backend_connectivity": "ipv6",
             "tags": ["tag3"],
             "locks": [],
             "lke_cluster": {

--- a/test/unit/nodebalancer_node_test.go
+++ b/test/unit/nodebalancer_node_test.go
@@ -35,6 +35,32 @@ func TestNodeBalancerNode_Create(t *testing.T) {
 	assert.Equal(t, linodego.ModeAccept, node.Mode)
 }
 
+func TestNodeBalancerNode_Create_IPv6(t *testing.T) {
+	fixtureData, err := fixtures.GetFixture("nodebalancer_node_create_ipv6")
+	assert.NoError(t, err)
+
+	var base ClientBaseCase
+	base.SetUp(t)
+	defer base.TearDown(t)
+
+	base.MockPost("nodebalancers/123/configs/456/nodes", fixtureData)
+
+	createOpts := linodego.NodeBalancerNodeCreateOptions{
+		Address: "[2001:db8:abcd:12::1]:80",
+		Label:   "IPv6 Node",
+		Weight:  50,
+		Mode:    linodego.ModeAccept,
+	}
+	node, err := base.Client.CreateNodeBalancerNode(context.Background(), 123, 456, createOpts)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 790, node.ID)
+	assert.Equal(t, "[2001:db8:abcd:12::1]:80", node.Address)
+	assert.Equal(t, "IPv6 Node", node.Label)
+	assert.Equal(t, 50, node.Weight)
+	assert.Equal(t, linodego.ModeAccept, node.Mode)
+}
+
 func TestNodeBalancerNode_Update(t *testing.T) {
 	fixtureData, err := fixtures.GetFixture("nodebalancer_node_update")
 	assert.NoError(t, err)

--- a/test/unit/nodebalancer_test.go
+++ b/test/unit/nodebalancer_test.go
@@ -38,6 +38,18 @@ func TestNodeBalancer_Create(t *testing.T) {
 			fixture:    "nodebalancer_create_with_ipv4",
 			expectIPv4: "192.0.2.2",
 		},
+		{
+			name: "creation with backend connectivity",
+			createOpts: linodego.NodeBalancerCreateOptions{
+				Label:               String("Test Premium NodeBalancer"),
+				Region:              "us-east",
+				Tags:                []string{"test", "example"},
+				Type:                linodego.NBTypePremium,
+				BackendConnectivity: linodego.Pointer(linodego.NBBackendConnectivityIPv6),
+			},
+			fixture:    "nodebalancer_create_with_backend_connectivity",
+			expectIPv4: "192.0.2.3",
+		},
 	}
 
 	for _, tt := range tests {
@@ -58,6 +70,14 @@ func TestNodeBalancer_Create(t *testing.T) {
 			assert.Equal(t, tt.createOpts.Region, nodebalancer.Region)
 			assert.Equal(t, tt.createOpts.Tags, nodebalancer.Tags)
 			assert.Equal(t, tt.expectIPv4, *nodebalancer.IPv4)
+			if tt.createOpts.Type != "" {
+				assert.Equal(t, tt.createOpts.Type, nodebalancer.Type)
+			}
+			if tt.createOpts.BackendConnectivity != nil {
+				assert.Equal(t, *tt.createOpts.BackendConnectivity, *nodebalancer.BackendConnectivity)
+			} else {
+				assert.Equal(t, linodego.NBBackendConnectivityUndefined, *nodebalancer.BackendConnectivity)
+			}
 		})
 	}
 }
@@ -113,6 +133,8 @@ func TestNodeBalancer_Get(t *testing.T) {
 			assert.Equal(t, "us-west", nodebalancer.Region, "Expected NodeBalancer region to match")
 			assert.Equal(t, []linodego.LockType{linodego.LockTypeCannotDeleteWithSubresources}, nodebalancer.Locks, "Expected NodeBalancer locks to match")
 			assert.Equal(t, tt.expectedLKECluster, nodebalancer.LKECluster, "Expected NodeBalancer LKECluster to match")
+			assert.Equal(t, linodego.NBTypeCommon, nodebalancer.Type)
+			assert.Equal(t, linodego.NBBackendConnectivityUndefined, *nodebalancer.BackendConnectivity)
 		})
 	}
 }
@@ -140,6 +162,8 @@ func TestNodeBalancer_List(t *testing.T) {
 	assert.Equal(t, []string{"tag1", "tag2"}, nodebalancers[0].Tags, "Expected first NodeBalancer tags to match")
 	assert.Equal(t, []linodego.LockType{linodego.LockTypeCannotDelete}, nodebalancers[0].Locks, "Expected first NodeBalancer locks to match")
 	assert.Nil(t, nodebalancers[0].LKECluster, "Expected first NodeBalancer LKECluster to match")
+	assert.Equal(t, linodego.NBTypeCommon, nodebalancers[0].Type)
+	assert.Equal(t, linodego.NBBackendConnectivityUndefined, *nodebalancers[0].BackendConnectivity)
 
 	// Verify details of the second NodeBalancer
 	assert.Equal(t, 456, nodebalancers[1].ID, "Expected second NodeBalancer ID to match")
@@ -147,6 +171,8 @@ func TestNodeBalancer_List(t *testing.T) {
 	assert.Equal(t, "us-west", nodebalancers[1].Region, "Expected second NodeBalancer region to match")
 	assert.Equal(t, []string{"tag3"}, nodebalancers[1].Tags, "Expected second NodeBalancer tags to match")
 	assert.Empty(t, nodebalancers[1].Locks, "Expected second NodeBalancer to have no locks")
+	assert.Equal(t, linodego.NBTypePremium, nodebalancers[1].Type)
+	assert.Equal(t, linodego.NBBackendConnectivityIPv6, *nodebalancers[1].BackendConnectivity)
 	assert.Equal(t, &linodego.NodeBalancerLKECluster{
 		ID:    1234,
 		Type:  "lkecluster",
@@ -178,6 +204,8 @@ func TestNodeBalancer_Update(t *testing.T) {
 	assert.Equal(t, "Updated NodeBalancer", *nodebalancer.Label)
 	assert.Equal(t, []string{"updated", "production"}, nodebalancer.Tags)
 	assert.Equal(t, []linodego.LockType{linodego.LockTypeCannotDeleteWithSubresources}, nodebalancer.Locks, "Expected NodeBalancer locks to match")
+	assert.Equal(t, linodego.NBTypeCommon, nodebalancer.Type)
+	assert.Equal(t, linodego.NBBackendConnectivityLegacy, *nodebalancer.BackendConnectivity)
 }
 
 func TestNodeBalancer_Delete(t *testing.T) {
@@ -207,4 +235,44 @@ func TestNodeBalancer_Create_IPv4RequestBody(t *testing.T) {
 	if _, err := client.CreateNodeBalancer(context.Background(), opts); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestNodeBalancer_Create_BackendConnectivityRequestBody(t *testing.T) {
+	client := createMockClient(t)
+
+	opts := linodego.NodeBalancerCreateOptions{
+		Label:               String("Test Premium NodeBalancer"),
+		Region:              "us-east",
+		Type:                linodego.NBTypePremium,
+		BackendConnectivity: linodego.Pointer(linodego.NBBackendConnectivityIPv6),
+	}
+
+	httpmock.RegisterRegexpResponder("POST", mockRequestURL(t, "/nodebalancers"),
+		mockRequestBodyValidate(t, opts, nil))
+
+	if _, err := client.CreateNodeBalancer(context.Background(), opts); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNodeBalancer_GetCreateOptions_OmitsUndefinedBackendConnectivity(t *testing.T) {
+	nb := linodego.NodeBalancer{
+		Label:               String("Existing NodeBalancer"),
+		Region:              "us-west",
+		BackendConnectivity: linodego.Pointer(linodego.NBBackendConnectivityUndefined),
+	}
+
+	opts := nb.GetCreateOptions()
+	assert.Nil(t, opts.BackendConnectivity)
+}
+
+func TestNodeBalancer_GetCreateOptions_CopiesExplicitBackendConnectivity(t *testing.T) {
+	nb := linodego.NodeBalancer{
+		Label:               String("Existing NodeBalancer"),
+		Region:              "us-west",
+		BackendConnectivity: linodego.Pointer(linodego.NBBackendConnectivityIPv6),
+	}
+
+	opts := nb.GetCreateOptions()
+	assert.Equal(t, linodego.NBBackendConnectivityIPv6, *opts.BackendConnectivity)
 }


### PR DESCRIPTION
## 📝 Description

Add support for Backend Connectivity and more types in NodeBalancers, IPv6 support not included.

## ✔️ How to Test
```bash
make TEST_ARGS="-run TestNodeBalancer_Create_BackendConnectivity_Premium" test-int
```
