### PR TITLE
add label for deprecations

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -26,6 +26,9 @@
 - name: breaking-change
   description: for breaking changes in the changelog.
   color: ff0000
+- name: deprecation
+  description: for deprecations in the changelog.
+  color: ff8a00
 - name: community-contribution
   description: contributions from the community.
   color: 22ee47

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,9 +6,12 @@ changelog:
     - title: 📋 New Project
       labels:
         - project
-    - title: ⚠️ Breaking Change
+    - title: 🚨 Breaking Change
       labels:
         - breaking-change
+    - title: ⚠️ Deprecation
+      labels:
+        - deprecation
     - title: 🐛 Bug Fixes
       labels:
         - bugfix


### PR DESCRIPTION
## 📝 Description

Adds a deprecation label and category to generated release notes so developers can be aware before breaking changes / removals. Updates the emoji as well to distinguish between deprecations and breaking changes.
Deprecations can throw staticcheck errors for repos using linodego as a dependency so these are good to raise in release notes.